### PR TITLE
compiler: fix string/numbers equality/inequality gen again

### DIFF
--- a/pkg/vm/compiler/codegen.go
+++ b/pkg/vm/compiler/codegen.go
@@ -392,10 +392,18 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 				}
 			case n.Op == token.EQL:
 				// VM has separate opcodes for number and string equality
-				if isStringType(tinfo.Type) {
+				if isStringType(c.typeInfo.Types[n.X].Type) {
 					emitOpcode(c.prog, vm.EQUAL)
 				} else {
 					emitOpcode(c.prog, vm.NUMEQUAL)
+				}
+			case n.Op == token.NEQ:
+				// VM has separate opcodes for number and string equality
+				if isStringType(c.typeInfo.Types[n.X].Type) {
+					emitOpcode(c.prog, vm.EQUAL)
+					emitOpcode(c.prog, vm.NOT)
+				} else {
+					emitOpcode(c.prog, vm.NUMNOTEQUAL)
 				}
 			default:
 				c.convertToken(n.Op)


### PR DESCRIPTION
Unfortunately d58fbe0c88b7848ce4d8ef300d594b7cc39f94cc didn't really fix the
problem because tinfo.Type (the expression resulting type) actually is a bool
and we need to check its parameters. Also, there is need to fix the NEQ
operation.