### PR TITLE
connmgr: correctly pass binding error to the server

### DIFF
--- a/pkg/connmgr/connmgr.go
+++ b/pkg/connmgr/connmgr.go
@@ -27,7 +27,13 @@ type Connmgr struct {
 }
 
 //New creates a new connection manager
-func New(cfg Config) *Connmgr {
+func New(cfg Config) (*Connmgr, error) {
+	listener, err := net.Listen("tcp", cfg.AddressPort)
+
+	if err != nil {
+		return nil, err
+	}
+
 	cnnmgr := &Connmgr{
 		cfg,
 		make(map[string]*Request),
@@ -36,13 +42,6 @@ func New(cfg Config) *Connmgr {
 	}
 
 	go func() {
-
-		listener, err := net.Listen("tcp", cfg.AddressPort)
-
-		if err != nil {
-			fmt.Println("Error connecting to outbound ", err)
-		}
-
 		defer func() {
 			listener.Close()
 		}()
@@ -59,7 +58,7 @@ func New(cfg Config) *Connmgr {
 
 	}()
 
-	return cnnmgr
+	return cnnmgr, nil
 }
 
 // NewRequest will make a new connection gets the address from address func in config

--- a/pkg/server/connmgr.go
+++ b/pkg/server/connmgr.go
@@ -11,7 +11,7 @@ import (
 	iputils "github.com/CityOfZion/neo-go/pkg/wire/util/ip"
 )
 
-func setupConnManager(s *Server, port uint16) *connmgr.Connmgr {
+func setupConnManager(s *Server, port uint16) (*connmgr.Connmgr, error) {
 	cfg := connmgr.Config{
 		GetAddress:   s.getAddress,
 		OnAccept:     s.onAccept,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -63,7 +63,10 @@ func New(net protocol.Magic, port uint16) (*Server, error) {
 	s.smg = syncmgr
 
 	// Setup connection manager
-	connmgr := setupConnManager(s, port)
+	connmgr, err := setupConnManager(s, port)
+	if err != nil {
+		return nil, err
+	}
 	s.cmg = connmgr
 
 	// Setup peer config


### PR DESCRIPTION
And make the node fail gracefully if it's unable to bind. Before this commit:
```
Server is starting up
Connection manager started
Error connecting to outbound  listen tcp 127.0.0.1:20332: bind: address already in use
We have connected successfully to:  127.0.0.1:20334
panic: runtime error: invalid memory address or nil pointer dereference
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x6bbfa2]

goroutine 12 [running]:
github.com/CityOfZion/neo-go/pkg/connmgr.New.func1.1(0x0, 0x0)
        /home/rik/dev/neo-go/pkg/connmgr/connmgr.go:47 +0x22
panic(0x718980, 0xa22f70)
        /usr/lib64/go/1.12/src/runtime/panic.go:522 +0x1b5
github.com/CityOfZion/neo-go/pkg/connmgr.New.func1(0xc000013430, 0xc000013450, 0xc000013440, 0xc0005265f0, 0xf, 0x0)
        /home/rik/dev/neo-go/pkg/connmgr/connmgr.go:52 +0x15e
created by github.com/CityOfZion/neo-go/pkg/connmgr.New
        /home/rik/dev/neo-go/pkg/connmgr/connmgr.go:38 +0xfe
exit status 2
```

After this commit:
```
listen tcp 127.0.0.1:20332: bind: address already in use
```