### PR TITLE
Use our RFC6979 fork

### DIFF
--- a/_pkg.dev/crypto/privatekey/privatekey.go
+++ b/_pkg.dev/crypto/privatekey/privatekey.go
@@ -15,7 +15,7 @@ import (
 	"github.com/CityOfZion/neo-go/pkg/crypto/base58"
 	"github.com/CityOfZion/neo-go/pkg/crypto/elliptic"
 	"github.com/CityOfZion/neo-go/pkg/crypto/hash"
-	"github.com/anthdm/rfc6979"
+	"github.com/nspcc-dev/rfc6979"
 )
 
 // PrivateKey represents a NEO private key.

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module github.com/CityOfZion/neo-go
 
 require (
-	github.com/anthdm/rfc6979 v0.0.0-20141003034818-6a90f24967eb
-	github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb // indirect
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/go-redis/redis v6.10.2+incompatible
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049 // indirect
+	github.com/nspcc-dev/rfc6979 v0.1.0
 	github.com/onsi/gomega v1.4.2 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/anthdm/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:UTxADjhpvBfb7LpAB+uu4uzlTJ3ZJyWA5En+KsYHed8=
-github.com/anthdm/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:EjSkpESoXW3cDxVZzHil2eVMoGkYxb8Q7qgfV5JOTPs=
-github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
-github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -16,6 +12,8 @@ github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0a
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/nspcc-dev/rfc6979 v0.1.0 h1:Lwg7esRRoyK1Up/IN1vAef1EmvrBeMHeeEkek2fAJ6c=
+github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.2 h1:3mYCb7aPxS/RU7TI1y4rkEn1oKmPRjNJLNEXgw7MH2I=

--- a/pkg/wallet/private_key.go
+++ b/pkg/wallet/private_key.go
@@ -14,7 +14,7 @@ import (
 	"math/big"
 
 	"github.com/CityOfZion/neo-go/pkg/crypto"
-	"github.com/anthdm/rfc6979"
+	"github.com/nspcc-dev/rfc6979"
 )
 
 // PrivateKey represents a NEO private key.


### PR DESCRIPTION
- prepare fork
- update go-modules
- update dependencies

---

Note: `anthdm/rfc6979` adds two dependencies