### PR TITLE
Make & config fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,9 @@ ARG VERSION=dev
 # https://github.com/golang/go/wiki/Modules#how-do-i-use-vendoring-with-modules-is-vendoring-going-away
 # go build -mod=vendor
 RUN set -x \
-    && export BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
     && export GOGC=off \
     && export CGO_ENABLED=0 \
-    && export LDFLAGS="-X ${REPO}/config.Version=${VERSION} -X ${REPO}/config.BuildTime=${BUILD_TIME}" \
+    && export LDFLAGS="-X ${REPO}/config.Version=${VERSION}" \
     && go build -v -mod=vendor -ldflags "${LDFLAGS}" -o /go/bin/node ./cli/main.go
 
 # Executable image

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BRANCH = "master"
 BUILD_TIME = "$(shell date -u +\"%Y-%m-%dT%H:%M:%SZ\")"
 REPONAME = "neo-go"
 NETMODE ?= "privnet"
+BINARY = "./bin/neo-go"
 
 REPO ?= "$(shell go list -m)"
 VERSION ?= "$(shell git describe --tags 2>/dev/null | sed 's/^v//')"
@@ -13,7 +14,7 @@ build: deps
 		&& export GOGC=off \
 		&& export CGO_ENABLED=0 \
 		&& echo $(VERSION)-$(BUILD_TIME) \
-		&& go build -v -mod=vendor -ldflags $(BUILD_FLAGS) -o ./bin/node ./cli/main.go
+		&& go build -v -mod=vendor -ldflags $(BUILD_FLAGS) -o ${BINARY} ./cli/main.go
 
 image: deps
 	@echo "=> Building image"
@@ -46,7 +47,7 @@ push-to-registry:
 	@docker push CityOfZion/${REPONAME}
 
 run: build
-	./bin/neo-go node -config-path ./config -${NETMODE}
+	${BINARY} node -config-path ./config -${NETMODE}
 
 run-cluster: build-linux
 	@echo "=> Starting docker-compose cluster"

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,17 @@
 BRANCH = "master"
-BUILD_TIME = "$(shell date -u +\"%Y-%m-%dT%H:%M:%SZ\")"
 REPONAME = "neo-go"
 NETMODE ?= "privnet"
 BINARY = "./bin/neo-go"
 
 REPO ?= "$(shell go list -m)"
 VERSION ?= "$(shell git describe --tags 2>/dev/null | sed 's/^v//')"
-BUILD_FLAGS = "-X $(REPO)/config.Version=$(VERSION) -X $(REPO)/config.BuildTime=$(BUILD_TIME)"
+BUILD_FLAGS = "-X $(REPO)/config.Version=$(VERSION)"
 
 build: deps
 	@echo "=> Building binary"
 	@set -x \
 		&& export GOGC=off \
 		&& export CGO_ENABLED=0 \
-		&& echo $(VERSION)-$(BUILD_TIME) \
 		&& go build -v -mod=vendor -ldflags $(BUILD_FLAGS) -o ${BINARY} ./cli/main.go
 
 image: deps

--- a/config/config.go
+++ b/config/config.go
@@ -25,10 +25,6 @@ const (
 var (
 	// Version the version of the node, set at build time.
 	Version string
-
-	// BuildTime the time and date the current version of the node built,
-	// set at build time.
-	BuildTime string
 )
 
 type (


### PR DESCRIPTION
Makes `make run` work again and gives us reproducible builds.