### PR TITLE
circleci: fix workflow version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
 
 
 workflows:
-  version: 2.1
+  version: 2
   workflow:
     jobs:
       - vet:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
             curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz
             tar -xz -C /tmp -f /tmp/docker-$VER.tgz
             mv /tmp/docker/* /usr/bin
-      - run: make build-image
+      - run: make image
 
 
 workflows:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ARG VERSION=dev
 # go build -mod=vendor
 RUN set -x \
     && export GOGC=off \
+    && export GO111MODULE=on \
     && export CGO_ENABLED=0 \
     && export LDFLAGS="-X ${REPO}/config.Version=${VERSION}" \
     && go build -v -mod=vendor -ldflags "${LDFLAGS}" -o /go/bin/neo-go ./cli/main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN set -x \
     && export GO111MODULE=on \
     && export CGO_ENABLED=0 \
     && export LDFLAGS="-X ${REPO}/config.Version=${VERSION}" \
+    && go mod tidy -v \
+    && go mod vendor \
     && go build -v -mod=vendor -ldflags "${LDFLAGS}" -o /go/bin/neo-go ./cli/main.go
 
 # Executable image

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && export GOGC=off \
     && export CGO_ENABLED=0 \
     && export LDFLAGS="-X ${REPO}/config.Version=${VERSION}" \
-    && go build -v -mod=vendor -ldflags "${LDFLAGS}" -o /go/bin/node ./cli/main.go
+    && go build -v -mod=vendor -ldflags "${LDFLAGS}" -o /go/bin/neo-go ./cli/main.go
 
 # Executable image
 FROM alpine:3.10
@@ -31,9 +31,9 @@ WORKDIR /
 
 ENV NETMODE=testnet
 COPY --from=builder /neo-go/config   /config
-COPY --from=builder /go/bin/node     /usr/bin/node
+COPY --from=builder /go/bin/neo-go     /usr/bin/neo-go
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-ENTRYPOINT ["/usr/bin/node"]
+ENTRYPOINT ["/usr/bin/neo-go"]
 
-CMD ["node", "--config-path", "./config", "--testnet"]
+CMD ["neo-go", "--config-path", "./config", "--testnet"]

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build: deps
 		&& export CGO_ENABLED=0 \
 		&& go build -v -mod=vendor -ldflags $(BUILD_FLAGS) -o ${BINARY} ./cli/main.go
 
-image: deps
+image:
 	@echo "=> Building image"
 	@docker build -t cityofzion/neo-go:latest --build-arg REPO=$(REPO) --build-arg VERSION=$(VERSION) .
 	@docker build -t cityofzion/neo-go:$(VERSION) --build-arg REPO=$(REPO) --build-arg VERSION=$(VERSION) .


### PR DESCRIPTION
Only version 2 is supported at the moment as per
https://circleci.com/docs/2.0/configuration-reference/#version-1

Not to confuse with top-level version which really can be 2.1.
