### PR TITLE
Minor VM fixes for #96

### DIFF
--- a/pkg/vm/cli/cli.go
+++ b/pkg/vm/cli/cli.go
@@ -127,16 +127,13 @@ func (c *VMCLI) handleCommand(cmd string, args ...string) {
 		fmt.Printf("READY: loaded %d instructions\n", c.vm.Context().LenInstr())
 
 	case "run":
-		var (
-			method []byte
-			params []vm.StackItem
-			err    error
-			start  int
-		)
-
-		if len(args) == 0 {
-			c.vm.Run()
-		} else {
+		if len(args) != 0 {
+			var (
+				method []byte
+				params []vm.StackItem
+				err    error
+				start  int
+			)
 			if isMethodArg(args[0]) {
 				method = []byte(args[0])
 				start = 1
@@ -146,8 +143,8 @@ func (c *VMCLI) handleCommand(cmd string, args ...string) {
 				fmt.Println(err)
 				return
 			}
+			c.vm.LoadArgs(method, params)
 		}
-		c.vm.LoadArgs(method, params)
 		c.vm.Run()
 
 	case "cont":

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -342,7 +342,11 @@ func (v *VM) execute(ctx *Context, op Instruction) {
 			panic("negative stack item returned")
 		}
 		if n > 0 {
-			v.estack.Push(v.estack.RemoveAt(n))
+			e := v.estack.RemoveAt(n)
+			if e == nil {
+				panic("bad index")
+			}
+			v.estack.Push(e)
 		}
 
 	case DROP:


### PR DESCRIPTION
This fixes two minor things observed in #96:
* running VM twice, which leads to instruction execution attempt for VM in FAULT state
* panicing with nil dereference (it's better to show some error message)

Before this patchset:
```
NEO-GO-VM > run
NEO-GO-VM > error encountered at instruction 6 (ROLL)
NEO-GO-VM > runtime error: invalid memory address or nil pointer dereference
FAULT
NEO-GO-VM > error encountered at instruction 7 (SETITEM)
NEO-GO-VM > interface conversion: interface {} is []vm.StackItem, not []uint8
```

After this patchset:
```
NEO-GO-VM > run
NEO-GO-VM > error encountered at instruction 6 (ROLL)
NEO-GO-VM > bad index
FAULT
```