### PR TITLE
vm: do not fault on LEFT with big index

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -315,6 +315,9 @@ func (v *VM) execute(ctx *Context, op Instruction) {
 	case LEFT:
 		l := int(v.estack.Pop().BigInt().Int64())
 		s := v.estack.Pop().Bytes()
+		if t := len(s); l > t {
+			l = t
+		}
 		v.estack.PushVal(s[:l])
 	case RIGHT:
 		l := int(v.estack.Pop().BigInt().Int64())

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -685,13 +685,15 @@ func TestLEFTGood(t *testing.T) {
 	assert.Equal(t, []byte("ab"), vm.estack.Peek(0).Bytes())
 }
 
-func TestLEFTBadLen(t *testing.T) {
+func TestLEFTGoodLen(t *testing.T) {
 	prog := makeProgram(LEFT)
 	vm := load(prog)
 	vm.estack.PushVal([]byte("abcdef"))
 	vm.estack.PushVal(8)
 	vm.Run()
-	assert.Equal(t, true, vm.state.HasFlag(faultState))
+	assert.Equal(t, false, vm.state.HasFlag(faultState))
+	assert.Equal(t, 1, vm.estack.Len())
+	assert.Equal(t, []byte("abcdef"), vm.estack.Peek(0).Bytes())
 }
 
 func TestRIGHTBadNoArgs(t *testing.T) {


### PR DESCRIPTION
Fixes #378.

### Problem

LEFT applied to index which is greater than the string lengths, causes panic.

### Solution

Check slice bounds before pushing a value.
