### PR TITLE
VM: fix codegen for APPEND

### DIFF
--- a/pkg/vm/compiler/analysis.go
+++ b/pkg/vm/compiler/analysis.go
@@ -203,6 +203,10 @@ func isSyscall(fun *funcScope) bool {
 	return ok
 }
 
+func isByteArrayType(t types.Type) bool {
+	return t.String() == "[]byte"
+}
+
 func isStringType(t types.Type) bool {
 	return t.String() == "string"
 }

--- a/pkg/vm/compiler/codegen.go
+++ b/pkg/vm/compiler/codegen.go
@@ -614,7 +614,17 @@ func (c *codegen) convertBuiltin(expr *ast.CallExpr) {
 			emitOpcode(c.prog, vm.ARRAYSIZE)
 		}
 	case "append":
-		emitOpcode(c.prog, vm.APPEND)
+		arg := expr.Args[0]
+		typ := c.typeInfo.Types[arg].Type
+		if isByteArrayType(typ) {
+			emitOpcode(c.prog, vm.CAT)
+		} else {
+			emitOpcode(c.prog, vm.SWAP)
+			emitOpcode(c.prog, vm.DUP)
+			emitOpcode(c.prog, vm.PUSH2)
+			emitOpcode(c.prog, vm.XSWAP)
+			emitOpcode(c.prog, vm.APPEND)
+		}
 	case "SHA256":
 		emitOpcode(c.prog, vm.SHA256)
 	case "SHA1":


### PR DESCRIPTION
After changes in #391 some tests started to fail. This PR fixes codegen for `APPEND`.