### PR TITLE
VM: compare Array by reference

### DIFF
--- a/pkg/vm/stack_item.go
+++ b/pkg/vm/stack_item.go
@@ -75,6 +75,21 @@ func (i *StructItem) String() string {
 	return "Struct"
 }
 
+// Clone returns a Struct with all Struct fields copied by value.
+// Array fields are still copied by reference.
+func (i *StructItem) Clone() *StructItem {
+	ret := &StructItem{make([]StackItem, len(i.value))}
+	for j := range i.value {
+		switch t := i.value[j].(type) {
+		case *StructItem:
+			ret.value[j] = t.Clone()
+		default:
+			ret.value[j] = t
+		}
+	}
+	return ret
+}
+
 // BigIntegerItem represents a big integer on the stack.
 type BigIntegerItem struct {
 	value *big.Int

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -454,6 +454,12 @@ func (v *VM) execute(ctx *Context, op Instruction) {
 		if a == nil {
 			panic("no second-to-the-top element found")
 		}
+		if ta, ok := a.value.(*ArrayItem); ok {
+			if tb, ok := b.value.(*ArrayItem); ok {
+				v.estack.PushVal(ta == tb)
+				break
+			}
+		}
 		v.estack.PushVal(reflect.DeepEqual(a, b))
 
 	// Bit operations.

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -642,14 +642,19 @@ func (v *VM) execute(ctx *Context, op Instruction) {
 		itemElem := v.estack.Pop()
 		arrElem := v.estack.Pop()
 
+		val := itemElem.value
+		if t, ok := itemElem.value.(*StructItem); ok {
+			val = t.Clone()
+		}
+
 		switch t := arrElem.value.(type) {
 		case *ArrayItem:
 			arr := t.Value().([]StackItem)
-			arr = append(arr, itemElem.value)
+			arr = append(arr, val)
 			t.value = arr
 		case *StructItem:
 			arr := t.Value().([]StackItem)
-			arr = append(arr, itemElem.value)
+			arr = append(arr, val)
 			t.value = arr
 		default:
 			panic("APPEND: not of underlying type Array")

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -405,6 +405,27 @@ func TestEQUALGoodInteger(t *testing.T) {
 	assert.Equal(t, &BoolItem{true}, vm.estack.Pop().value)
 }
 
+func TestEQUALArrayTrue(t *testing.T) {
+	prog := makeProgram(DUP, EQUAL)
+	vm := load(prog)
+	vm.estack.PushVal([]StackItem{})
+	vm.Run()
+	assert.Equal(t, false, vm.state.HasFlag(faultState))
+	assert.Equal(t, 1, vm.estack.Len())
+	assert.Equal(t, &BoolItem{true}, vm.estack.Pop().value)
+}
+
+func TestEQUALArrayFalse(t *testing.T) {
+	prog := makeProgram(EQUAL)
+	vm := load(prog)
+	vm.estack.PushVal([]StackItem{})
+	vm.estack.PushVal([]StackItem{})
+	vm.Run()
+	assert.Equal(t, false, vm.state.HasFlag(faultState))
+	assert.Equal(t, 1, vm.estack.Len())
+	assert.Equal(t, &BoolItem{false}, vm.estack.Pop().value)
+}
+
 func TestNumEqual(t *testing.T) {
 	prog := makeProgram(NUMEQUAL)
 	vm := load(prog)

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -538,6 +538,18 @@ func TestAPPENDStruct(t *testing.T) {
 	assert.Equal(t, &StructItem{[]StackItem{makeStackItem(5)}}, vm.estack.Pop().value)
 }
 
+func TestAPPENDCloneStruct(t *testing.T) {
+	prog := makeProgram(DUP, PUSH0, NEWSTRUCT, TOALTSTACK, DUPFROMALTSTACK, APPEND, FROMALTSTACK, PUSH1, APPEND)
+	vm := load(prog)
+	vm.estack.Push(&Element{value: &ArrayItem{}})
+	vm.Run()
+	assert.Equal(t, false, vm.state.HasFlag(faultState))
+	assert.Equal(t, 1, vm.estack.Len())
+	assert.Equal(t, &ArrayItem{[]StackItem{
+		&StructItem{[]StackItem{}},
+	}}, vm.estack.Pop().value)
+}
+
 func TestAPPENDBadNoArguments(t *testing.T) {
 	prog := makeProgram(APPEND)
 	vm := load(prog)


### PR DESCRIPTION
1. Arrays are reference types in NeoVM
https://github.com/neo-project/neo-vm/issues/201
https://github.com/neo-project/neo-vm/blob/master/tests/neo-vm.Tests/Tests/OpCodes/BitwiseLogic/EQUAL.json#L477
We need to compare pointer values in `EQUAL`.

2. Structs are cloned when `APPEND`ed
https://github.com/neo-project/neo-vm/blob/master/src/neo-vm/ExecutionEngine.cs#L966