### PR TITLE
VM: do not pop too many items from stack

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -408,15 +408,10 @@ func (v *VM) execute(ctx *Context, op Instruction) {
 		}
 
 	case OVER:
-		b := v.estack.Pop()
-		if b == nil {
-			panic("no top-level element found")
-		}
-		a := v.estack.Peek(0)
+		a := v.estack.Peek(1)
 		if a == nil {
 			panic("no second element found")
 		}
-		v.estack.Push(b)
 		v.estack.Push(a)
 
 	case PICK:

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -318,18 +318,22 @@ func (v *VM) execute(ctx *Context, op Instruction) {
 		v.estack.PushVal(ab)
 	case SUBSTR:
 		l := int(v.estack.Pop().BigInt().Int64())
-		o := int(v.estack.Pop().BigInt().Int64())
-		s := v.estack.Pop().Bytes()
 		if l < 0 {
 			panic("negative length")
 		}
+		o := int(v.estack.Pop().BigInt().Int64())
 		if o < 0 {
 			panic("negative index")
 		}
-		if l+o > len(s) {
-			panic("out of bounds access")
+		s := v.estack.Pop().Bytes()
+		if o > len(s) {
+			panic("invalid offset")
 		}
-		v.estack.PushVal(s[o : o+l])
+		last := l + o
+		if last > len(s) {
+			last = len(s)
+		}
+		v.estack.PushVal(s[o:last])
 	case LEFT:
 		l := int(v.estack.Pop().BigInt().Int64())
 		if l < 0 {

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -920,6 +920,8 @@ func TestOVERbadNoitem(t *testing.T) {
 	vm.estack.PushVal(1)
 	vm.Run()
 	assert.Equal(t, true, vm.state.HasFlag(faultState))
+	assert.Equal(t, 1, vm.estack.Len())
+	assert.Equal(t, makeStackItem(1), vm.estack.Pop().value)
 }
 
 func TestOVERbadNoitems(t *testing.T) {

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1138,20 +1138,22 @@ func TestSUBSTRBadOffset(t *testing.T) {
 	prog := makeProgram(SUBSTR)
 	vm := load(prog)
 	vm.estack.PushVal([]byte("abcdef"))
-	vm.estack.PushVal(6)
+	vm.estack.PushVal(7)
 	vm.estack.PushVal(1)
 	vm.Run()
 	assert.Equal(t, true, vm.state.HasFlag(faultState))
 }
 
-func TestSUBSTRBadLen(t *testing.T) {
+func TestSUBSTRBigLen(t *testing.T) {
 	prog := makeProgram(SUBSTR)
 	vm := load(prog)
 	vm.estack.PushVal([]byte("abcdef"))
 	vm.estack.PushVal(1)
 	vm.estack.PushVal(6)
 	vm.Run()
-	assert.Equal(t, true, vm.state.HasFlag(faultState))
+	assert.Equal(t, false, vm.state.HasFlag(faultState))
+	assert.Equal(t, 1, vm.estack.Len())
+	assert.Equal(t, []byte("bcdef"), vm.estack.Pop().Bytes())
 }
 
 func TestSUBSTRBad387(t *testing.T) {
@@ -1163,7 +1165,9 @@ func TestSUBSTRBad387(t *testing.T) {
 	vm.estack.PushVal(1)
 	vm.estack.PushVal(6)
 	vm.Run()
-	assert.Equal(t, true, vm.state.HasFlag(faultState))
+	assert.Equal(t, false, vm.state.HasFlag(faultState))
+	assert.Equal(t, 1, vm.estack.Len())
+	assert.Equal(t, []byte("bcdef"), vm.estack.Pop().Bytes())
 }
 
 func TestSUBSTRBadNegativeOffset(t *testing.T) {

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -305,6 +305,15 @@ func TestSHRZero(t *testing.T) {
 	assert.Equal(t, makeStackItem([]byte{0, 1}), vm.estack.Pop().value)
 }
 
+func TestSHRSmallValue(t *testing.T) {
+	prog := makeProgram(SHR)
+	vm := load(prog)
+	vm.estack.PushVal(5)
+	vm.estack.PushVal(-257)
+	vm.Run()
+	assert.Equal(t, true, vm.state.HasFlag(faultState))
+}
+
 func TestSHLGood(t *testing.T) {
 	prog := makeProgram(SHL)
 	vm := load(prog)
@@ -325,6 +334,15 @@ func TestSHLZero(t *testing.T) {
 	assert.Equal(t, false, vm.state.HasFlag(faultState))
 	assert.Equal(t, 1, vm.estack.Len())
 	assert.Equal(t, makeStackItem([]byte{0, 1}), vm.estack.Pop().value)
+}
+
+func TestSHLBigValue(t *testing.T) {
+	prog := makeProgram(SHL)
+	vm := load(prog)
+	vm.estack.PushVal(5)
+	vm.estack.PushVal(257)
+	vm.Run()
+	assert.Equal(t, true, vm.state.HasFlag(faultState))
 }
 
 func TestLT(t *testing.T) {


### PR DESCRIPTION
JSON tests in neo-vm check stack state even in case of failure.
There are 2 corrections need to be done:
1. Pop items in `EQUAL` one-by-one.
2. Do not pop anything from stack in `OVER`.

I have also implemented operand restriction for `SHL`/`SHR`.