### PR TITLE
Various transaction verification fixes (testnet up to 4586)

### DIFF
--- a/pkg/core/block.go
+++ b/pkg/core/block.go
@@ -46,6 +46,10 @@ func (b *Block) rebuildMerkleRoot() error {
 
 // Verify the integrity of the block.
 func (b *Block) Verify(full bool) bool {
+	// There has to be some transaction inside.
+	if len(b.Transactions) == 0 {
+		return false
+	}
 	// The first TX has to be a miner transaction.
 	if b.Transactions[0].Type != transaction.MinerType {
 		return false

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -899,7 +899,7 @@ func (bc *Blockchain) GetScriptHashesForVerifying(t *transaction.Transaction) ([
 		if as == nil {
 			return nil, errors.New("Invalid operation")
 		}
-		if as.AssetType == transaction.DutyFlag {
+		if as.AssetType&transaction.DutyFlag != 0 {
 			for _, o := range outputs {
 				h := o.ScriptHash
 				if _, ok := hashes[h]; !ok {

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -207,8 +207,16 @@ func (bc *Blockchain) AddBlock(block *Block) error {
 	if expectedHeight != block.Index {
 		return fmt.Errorf("expected block %d, but passed block %d", expectedHeight, block.Index)
 	}
-	if bc.verifyBlocks && !block.Verify(false) {
-		return fmt.Errorf("block %s is invalid", block.Hash())
+	if bc.verifyBlocks {
+		if !block.Verify(false) {
+			return fmt.Errorf("block %s is invalid", block.Hash())
+		}
+		for _, tx := range block.Transactions {
+			err := bc.Verify(tx)
+			if err != nil {
+				return fmt.Errorf("transaction %s failed to verify: %s", tx.Hash().ReverseString(), err)
+			}
+		}
 	}
 	headerLen := bc.headerListLen()
 	if int(block.Index) == headerLen {

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -22,6 +22,13 @@ import (
 const (
 	headerBatchCount = 2000
 	version          = "0.0.1"
+
+	// This one comes from C# code and it's different from the constant used
+	// when creating an asset with Neo.Asset.Create interop call. It looks
+	// like 2000000 is coming from the decrementInterval, but C# code doesn't
+	// contain any relationship between the two, so we should follow this
+	// behavior.
+	registeredAssetLifetime = 2 * 2000000
 )
 
 var (
@@ -358,13 +365,14 @@ func (bc *Blockchain) storeBlock(block *Block) error {
 		switch t := tx.Data.(type) {
 		case *transaction.RegisterTX:
 			assets[tx.Hash()] = &AssetState{
-				ID:        tx.Hash(),
-				AssetType: t.AssetType,
-				Name:      t.Name,
-				Amount:    t.Amount,
-				Precision: t.Precision,
-				Owner:     t.Owner,
-				Admin:     t.Admin,
+				ID:         tx.Hash(),
+				AssetType:  t.AssetType,
+				Name:       t.Name,
+				Amount:     t.Amount,
+				Precision:  t.Precision,
+				Owner:      t.Owner,
+				Admin:      t.Admin,
+				Expiration: bc.BlockHeight() + registeredAssetLifetime,
 			}
 		case *transaction.IssueTX:
 		case *transaction.ClaimTX:

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/CityOfZion/neo-go/config"
 	"github.com/CityOfZion/neo-go/pkg/core/storage"
+	"github.com/CityOfZion/neo-go/pkg/core/transaction"
 	"github.com/CityOfZion/neo-go/pkg/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,9 +39,9 @@ func TestAddHeaders(t *testing.T) {
 func TestAddBlock(t *testing.T) {
 	bc := newTestChain(t)
 	blocks := []*Block{
-		newBlock(1),
-		newBlock(2),
-		newBlock(3),
+		newBlock(1, newTX(transaction.MinerType)),
+		newBlock(2, newTX(transaction.MinerType)),
+		newBlock(3, newTX(transaction.MinerType)),
 	}
 
 	for i := 0; i < len(blocks); i++ {
@@ -69,7 +70,7 @@ func TestAddBlock(t *testing.T) {
 
 func TestGetHeader(t *testing.T) {
 	bc := newTestChain(t)
-	block := newBlock(1)
+	block := newBlock(1, newTX(transaction.MinerType))
 	err := bc.AddBlock(block)
 	assert.Nil(t, err)
 

--- a/pkg/core/blockchainer.go
+++ b/pkg/core/blockchainer.go
@@ -24,7 +24,7 @@ type Blockchainer interface {
 	GetAssetState(util.Uint256) *AssetState
 	GetAccountState(util.Uint160) *AccountState
 	GetTransaction(util.Uint256) (*transaction.Transaction, uint32, error)
-	References(t *transaction.Transaction) map[util.Uint256]*transaction.Output
+	References(t *transaction.Transaction) map[transaction.Input]*transaction.Output
 	Feer // fee interface
 	Verify(t *transaction.Transaction) error
 	GetMemPool() MemPool

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -22,7 +22,7 @@ func (chain testChain) GetConfig() config.ProtocolConfiguration {
 	panic("TODO")
 }
 
-func (chain testChain) References(t *transaction.Transaction) map[util.Uint256]*transaction.Output {
+func (chain testChain) References(t *transaction.Transaction) map[transaction.Input]*transaction.Output {
 	panic("TODO")
 }
 

--- a/pkg/util/uint160.go
+++ b/pkg/util/uint160.go
@@ -59,6 +59,18 @@ func (u Uint160) Equals(other Uint160) bool {
 	return u == other
 }
 
+// Less returns true if this value is less than given Uint160 value. It's
+// primarily intended to be used for sorting purposes.
+func (u Uint160) Less(other Uint160) bool {
+	for k := range u {
+		if u[k] == other[k] {
+			continue
+		}
+		return u[k] < other[k]
+	}
+	return false
+}
+
 // UnmarshalJSON implements the json unmarshaller interface.
 func (u *Uint160) UnmarshalJSON(data []byte) (err error) {
 	var js string

--- a/pkg/util/uint160_test.go
+++ b/pkg/util/uint160_test.go
@@ -76,6 +76,21 @@ func TestUInt160Equals(t *testing.T) {
 	}
 }
 
+func TestUInt160Less(t *testing.T) {
+	a := "2d3b96ae1bcc5a585e075e3b81920210dec16302"
+	b := "2d3b96ae1bcc5a585e075e3b81920210dec16303"
+
+	ua, err := Uint160DecodeString(a)
+	assert.Nil(t, err)
+	ua2, err := Uint160DecodeString(a)
+	assert.Nil(t, err)
+	ub, err := Uint160DecodeString(b)
+	assert.Nil(t, err)
+	assert.Equal(t, true, ua.Less(ub))
+	assert.Equal(t, false, ua.Less(ua2))
+	assert.Equal(t, false, ub.Less(ua))
+}
+
 func TestUInt160String(t *testing.T) {
 	hexStr := "b28427088a3729b2536d10122960394e8be6721f"
 	hexRevStr := "1f72e68b4e39602912106d53b229378a082784b2"


### PR DESCRIPTION
### Problem

Changing `verifyBlocks` to `true` breaks synchronization with Testnet.

### Solution

This set of fixes allows to proceed up to the block number 4586, the block number 4587 fails at `APPCALL` invocation at the moment, but that's for the next set of fixes (not sure how much time it would take).
