### PR TITLE
Implement limitations on maximum collection size

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -786,10 +786,16 @@ func (v *VM) execute(ctx *Context, op Instruction, parameter []byte) {
 		switch t := arrElem.value.(type) {
 		case *ArrayItem:
 			arr := t.Value().([]StackItem)
+			if len(arr) >= MaxArraySize {
+				panic("too long array")
+			}
 			arr = append(arr, val)
 			t.value = arr
 		case *StructItem:
 			arr := t.Value().([]StackItem)
+			if len(arr) >= MaxArraySize {
+				panic("too long struct")
+			}
 			arr = append(arr, val)
 			t.value = arr
 		default:

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -753,8 +753,11 @@ func (v *VM) execute(ctx *Context, op Instruction, parameter []byte) {
 		case *ArrayItem:
 			v.estack.PushVal(t)
 		default:
-			n := item.BigInt()
-			items := makeArrayOfFalses(int(n.Int64()))
+			n := item.BigInt().Int64()
+			if n > MaxArraySize {
+				panic("too long array")
+			}
+			items := makeArrayOfFalses(int(n))
 			v.estack.PushVal(&ArrayItem{items})
 		}
 
@@ -766,8 +769,11 @@ func (v *VM) execute(ctx *Context, op Instruction, parameter []byte) {
 		case *StructItem:
 			v.estack.PushVal(t)
 		default:
-			n := item.BigInt()
-			items := makeArrayOfFalses(int(n.Int64()))
+			n := item.BigInt().Int64()
+			if n > MaxArraySize {
+				panic("too long struct")
+			}
+			items := makeArrayOfFalses(int(n))
 			v.estack.PushVal(&StructItem{items})
 		}
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -871,6 +871,9 @@ func (v *VM) execute(ctx *Context, op Instruction, parameter []byte) {
 			}
 			arr[index] = item
 		case *MapItem:
+			if !t.Has(key.value) && len(t.value) >= MaxArraySize {
+				panic("too big map")
+			}
 			t.Add(key.value, item)
 
 		default:

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -804,7 +804,7 @@ func (v *VM) execute(ctx *Context, op Instruction, parameter []byte) {
 
 	case PACK:
 		n := int(v.estack.Pop().BigInt().Int64())
-		if n < 0 || n > v.estack.Len() {
+		if n < 0 || n > v.estack.Len() || n > MaxArraySize {
 			panic("OPACK: invalid length")
 		}
 

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -734,6 +734,38 @@ func TestSETITEMMap(t *testing.T) {
 	assert.Equal(t, makeStackItem([]byte{0, 1}), vm.estack.Pop().value)
 }
 
+func TestSETITEMBigMapBad(t *testing.T) {
+	prog := makeProgram(SETITEM)
+	vm := load(prog)
+
+	m := NewMapItem()
+	for i := 0; i < MaxArraySize; i++ {
+		m.Add(makeStackItem(i), makeStackItem(i))
+	}
+	vm.estack.Push(&Element{value: m})
+	vm.estack.PushVal(MaxArraySize)
+	vm.estack.PushVal(0)
+
+	vm.Run()
+	assert.Equal(t, true, vm.HasFailed())
+}
+
+func TestSETITEMBigMapGood(t *testing.T) {
+	prog := makeProgram(SETITEM)
+	vm := load(prog)
+
+	m := NewMapItem()
+	for i := 0; i < MaxArraySize; i++ {
+		m.Add(makeStackItem(i), makeStackItem(i))
+	}
+	vm.estack.Push(&Element{value: m})
+	vm.estack.PushVal(0)
+	vm.estack.PushVal(0)
+
+	vm.Run()
+	assert.Equal(t, false, vm.HasFailed())
+}
+
 func TestSIZENoArgument(t *testing.T) {
 	prog := makeProgram(SIZE)
 	vm := load(prog)

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -538,6 +538,14 @@ func TestNEWARRAYByteArray(t *testing.T) {
 	assert.Equal(t, &ArrayItem{[]StackItem{}}, vm.estack.Pop().value)
 }
 
+func TestNEWARRAYBadSize(t *testing.T) {
+	prog := makeProgram(NEWARRAY)
+	vm := load(prog)
+	vm.estack.PushVal(MaxArraySize + 1)
+	vm.Run()
+	assert.Equal(t, true, vm.state.HasFlag(faultState))
+}
+
 func TestNEWSTRUCTInteger(t *testing.T) {
 	prog := makeProgram(NEWSTRUCT)
 	vm := load(prog)
@@ -578,6 +586,14 @@ func TestNEWSTRUCTByteArray(t *testing.T) {
 	assert.Equal(t, false, vm.HasFailed())
 	assert.Equal(t, 1, vm.estack.Len())
 	assert.Equal(t, &StructItem{[]StackItem{}}, vm.estack.Pop().value)
+}
+
+func TestNEWSTRUCTBadSize(t *testing.T) {
+	prog := makeProgram(NEWSTRUCT)
+	vm := load(prog)
+	vm.estack.PushVal(MaxArraySize + 1)
+	vm.Run()
+	assert.Equal(t, true, vm.state.HasFlag(faultState))
 }
 
 func TestAPPENDArray(t *testing.T) {

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -652,6 +652,24 @@ func TestAPPENDWrongType(t *testing.T) {
 	assert.Equal(t, true, vm.HasFailed())
 }
 
+func TestAPPENDGoodSizeLimit(t *testing.T) {
+	prog := makeProgram(NEWARRAY, DUP, PUSH0, APPEND)
+	vm := load(prog)
+	vm.estack.PushVal(MaxArraySize - 1)
+	vm.Run()
+	assert.Equal(t, false, vm.state.HasFlag(faultState))
+	assert.Equal(t, 1, vm.estack.Len())
+	assert.Equal(t, MaxArraySize, len(vm.estack.Pop().Array()))
+}
+
+func TestAPPENDBadSizeLimit(t *testing.T) {
+	prog := makeProgram(NEWARRAY, DUP, PUSH0, APPEND)
+	vm := load(prog)
+	vm.estack.PushVal(MaxArraySize)
+	vm.Run()
+	assert.Equal(t, true, vm.state.HasFlag(faultState))
+}
+
 func TestPICKITEMBadIndex(t *testing.T) {
 	prog := makeProgram(PICKITEM)
 	vm := load(prog)

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1604,6 +1604,17 @@ func TestPACKBadLen(t *testing.T) {
 	assert.Equal(t, true, vm.HasFailed())
 }
 
+func TestPACKBigLen(t *testing.T) {
+	prog := makeProgram(PACK)
+	vm := load(prog)
+	for i := 0; i <= MaxArraySize; i++ {
+		vm.estack.PushVal(0)
+	}
+	vm.estack.PushVal(MaxArraySize + 1)
+	vm.Run()
+	assert.Equal(t, true, vm.HasFailed())
+}
+
 func TestPACKGoodZeroLen(t *testing.T) {
 	prog := makeProgram(PACK)
 	vm := load(prog)


### PR DESCRIPTION
Arrays, Structs and Maps have maximum size defined as MaxArraySize.
We need to return an error in case collection becomes too big.
