### PR TITLE
Add minimum go version to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,3 +33,5 @@ require (
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 )
+
+go 1.12


### PR DESCRIPTION
### Problem

Right now go.mod has no version, so `go` tries to insert it on every ocassion. It is rather annoying to remove it every time.

### Solution

Add minimum go version to go.mod.
