### PR TITLE
vm: make SYSCALL accept 4-byte id

### DIFF
--- a/pkg/vm/compiler/emit.go
+++ b/pkg/vm/compiler/emit.go
@@ -83,9 +83,8 @@ func emitSyscall(w *bytes.Buffer, api string) error {
 	if len(api) == 0 {
 		return errors.New("syscall api cannot be of length 0")
 	}
-	buf := make([]byte, len(api)+1)
-	buf[0] = byte(len(api))
-	copy(buf[1:], []byte(api))
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, vm.InteropFuncID(api))
 	return emit(w, vm.SYSCALL, buf)
 }
 

--- a/pkg/vm/context.go
+++ b/pkg/vm/context.go
@@ -46,7 +46,7 @@ func (c *Context) Next() (Instruction, []byte, error) {
 
 	var numtoread int
 	switch instr {
-	case PUSHDATA1, SYSCALL:
+	case PUSHDATA1:
 		var n byte
 		r.ReadLE(&n)
 		numtoread = int(n)
@@ -61,6 +61,8 @@ func (c *Context) Next() (Instruction, []byte, error) {
 		r.ReadLE(&n)
 		numtoread = int(n)
 		c.nextip += 4
+	case SYSCALL:
+		numtoread = 4
 	case JMP, JMPIF, JMPIFNOT, CALL:
 		numtoread = 2
 	case APPCALL, TAILCALL:

--- a/pkg/vm/emit.go
+++ b/pkg/vm/emit.go
@@ -89,9 +89,8 @@ func EmitSyscall(w *bytes.Buffer, api string) error {
 	if len(api) == 0 {
 		return errors.New("syscall api cannot be of length 0")
 	}
-	buf := make([]byte, len(api)+1)
-	buf[0] = byte(len(api))
-	copy(buf[1:], []byte(api))
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, InteropFuncID(api))
 	return Emit(w, SYSCALL, buf)
 }
 

--- a/pkg/vm/emit_test.go
+++ b/pkg/vm/emit_test.go
@@ -48,9 +48,10 @@ func TestEmitSyscall(t *testing.T) {
 	buf := new(bytes.Buffer)
 	for _, syscall := range syscalls {
 		EmitSyscall(buf, syscall)
-		assert.Equal(t, Instruction(buf.Bytes()[0]), SYSCALL)
-		assert.Equal(t, buf.Bytes()[1], uint8(len(syscall)))
-		assert.Equal(t, buf.Bytes()[2:], []byte(syscall))
+		id := InteropFuncID(syscall)
+		b := buf.Bytes()
+		assert.Equal(t, Instruction(b[0]), SYSCALL)
+		assert.Equal(t, binary.LittleEndian.Uint32(b[1:]), id)
 		buf.Reset()
 	}
 }

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -35,7 +35,7 @@ func TestRegisterInterop(t *testing.T) {
 	currRegistered := len(v.interop)
 	v.RegisterInteropFunc("foo", func(evm *VM) error { return nil }, 1)
 	assert.Equal(t, currRegistered+1, len(v.interop))
-	_, ok := v.interop["foo"]
+	_, ok := v.interop[InteropFuncID("foo")]
 	assert.Equal(t, true, ok)
 }
 


### PR DESCRIPTION
To my current understanding, `syscall`'s in NEO 3.0 are registered using a 4-byte ID, as can be seen here:
https://github.com/neo-project/neo-vm/blob/master/src/neo-vm/Instruction.cs#L69
https://github.com/neo-project/neo-vm/blob/master/src/neo-vm/ScriptBuilder.cs#L89

The exact commit where API was changed:
https://github.com/neo-project/neo-vm/commit/a208c847e832b1b863a58b1d6b33da2766d004e5

The exact algorithm of calculating `uint` id from a string can be seen here:
https://github.com/neo-project/neo/blob/master/neo/SmartContract/Helper.cs#L245