### PR TITLE
Restrict max item size on stack

### DIFF
--- a/pkg/vm/context.go
+++ b/pkg/vm/context.go
@@ -59,6 +59,9 @@ func (c *Context) Next() (Instruction, []byte, error) {
 	case PUSHDATA4:
 		var n uint32
 		r.ReadLE(&n)
+		if n > MaxItemSize {
+			return instr, nil, errors.New("parameter is too big")
+		}
 		numtoread = int(n)
 		c.nextip += 4
 	case JMP, JMPIF, JMPIFNOT, CALL:

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -28,8 +28,12 @@ var (
 const (
 	// MaxArraySize is the maximum array size allowed in the VM.
 	MaxArraySize = 1024
-	maxSHLArg    = 256
-	minSHLArg    = -256
+
+	// MaxItemSize is the maximum item size allowed in the VM.
+	MaxItemSize = 1024 * 1024
+
+	maxSHLArg = 256
+	minSHLArg = -256
 )
 
 // VM represents the virtual machine.
@@ -439,6 +443,9 @@ func (v *VM) execute(ctx *Context, op Instruction, parameter []byte) {
 	case CAT:
 		b := v.estack.Pop().Bytes()
 		a := v.estack.Pop().Bytes()
+		if l := len(a) + len(b); l > MaxItemSize {
+			panic(fmt.Sprintf("too big item: %d", l))
+		}
 		ab := append(a, b...)
 		v.estack.PushVal(ab)
 	case SUBSTR:

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1413,6 +1413,15 @@ func TestCATBadOneArg(t *testing.T) {
 	assert.Equal(t, true, vm.HasFailed())
 }
 
+func TestCATBadBigItem(t *testing.T) {
+	prog := makeProgram(CAT)
+	vm := load(prog)
+	vm.estack.PushVal(make([]byte, MaxItemSize/2+1))
+	vm.estack.PushVal(make([]byte, MaxItemSize/2+1))
+	vm.Run()
+	assert.Equal(t, true, vm.HasFailed())
+}
+
 func TestCATGood(t *testing.T) {
 	prog := makeProgram(CAT)
 	vm := load(prog)

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"math/big"
 	"math/rand"
@@ -170,6 +171,16 @@ func TestPushData4BadN(t *testing.T) {
 
 func TestPushData4ShortN(t *testing.T) {
 	prog := []byte{byte(PUSHDATA4), 0, 0, 0}
+	vm := load(prog)
+	vm.Run()
+	assert.Equal(t, true, vm.HasFailed())
+}
+
+func TestPushData4BigN(t *testing.T) {
+	prog := make([]byte, 1+4+MaxItemSize+1)
+	prog[0] = byte(PUSHDATA4)
+	binary.LittleEndian.PutUint32(prog[1:], MaxItemSize+1)
+
 	vm := load(prog)
 	vm.Run()
 	assert.Equal(t, true, vm.HasFailed())


### PR DESCRIPTION
There is a limit on max size an item is allowed to have.
https://github.com/neo-project/neo-vm/blob/master/src/neo-vm/ExecutionEngine.cs#L39

This PR implements checks in CAT and PUSHDATA4. One more step towards #373 .