### PR TITLE
Access-Control-Allow-Origin has been added for rpc response

### DIFF
--- a/pkg/rpc/request.go
+++ b/pkg/rpc/request.go
@@ -110,6 +110,7 @@ func (r Request) WriteResponse(w http.ResponseWriter, result interface{}) {
 
 func (r Request) writeServerResponse(w http.ResponseWriter, response Response) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	encoder := json.NewEncoder(w)
 	err := encoder.Encode(response)
 


### PR DESCRIPTION
### Problem

No 'Access-Control-Allow-Origin' header is present on the requested resource.

### Solution

 'Access-Control-Allow-Origin' has been added.
