### PR TITLE
config: use logpath and address for server/rpc/monitoring

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path"
 
 	"github.com/CityOfZion/neo-go/config"
 	"github.com/CityOfZion/neo-go/pkg/core"
@@ -117,7 +116,7 @@ func handleLoggingParams(ctx *cli.Context, cfg config.ApplicationConfiguration) 
 	}
 
 	if logPath := cfg.LogPath; logPath != "" {
-		if err := makeDir(logPath); err != nil {
+		if err := io.MakeDirForFile(logPath, "logger"); err != nil {
 			return err
 		}
 		f, err := os.Create(logPath)
@@ -125,16 +124,6 @@ func handleLoggingParams(ctx *cli.Context, cfg config.ApplicationConfiguration) 
 			return err
 		}
 		log.SetOutput(f)
-	}
-	return nil
-}
-
-func makeDir(filePath string) error {
-	fileName := filePath
-	dir := path.Dir(fileName)
-	err := os.MkdirAll(dir, os.ModePerm)
-	if err != nil {
-		return fmt.Errorf("could not create dir for logger: %v", err)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -66,7 +66,9 @@ type (
 
 	// ApplicationConfiguration config specific to the node.
 	ApplicationConfiguration struct {
+		LogPath           string                   `yaml:"LogPath"`
 		DBConfiguration   storage.DBConfiguration  `yaml:"DBConfiguration"`
+		Address           string                   `yaml:"Address"`
 		NodePort          uint16                   `yaml:"NodePort"`
 		Relay             bool                     `yaml:"Relay"`
 		DialTimeout       time.Duration            `yaml:"DialTimeout"`

--- a/config/protocol.mainnet.yml
+++ b/config/protocol.mainnet.yml
@@ -31,6 +31,8 @@ ProtocolConfiguration:
   VerifyTransactions: false
 
 ApplicationConfiguration:
+  # LogPath could be set up in case you need stdout logs to some proper file.
+  # LogPath: "./log/neogo.log"
   DBConfiguration:
     Type: "leveldb" #other options: 'inmemory','redis','boltdb'.
     # DB type options. Uncomment those you need in case you want to switch DB type.
@@ -42,6 +44,8 @@ ApplicationConfiguration:
   #      DB: 0
   #    BoltDBOptions:
   #      FilePath: "./chains/mainnet.bolt"
+  #  Uncomment in order to set up custom address for node.
+  #  Address: 127.0.0.1
   NodePort: 10333
   Relay: true
   DialTimeout: 3

--- a/config/protocol.privnet.docker.four.yml
+++ b/config/protocol.privnet.docker.four.yml
@@ -19,6 +19,8 @@ ProtocolConfiguration:
   VerifyTransactions: true
 
 ApplicationConfiguration:
+  # LogPath could be set up in case you need stdout logs to some proper file.
+  # LogPath: "./log/neogo.log"
   DBConfiguration:
     Type: "leveldb" #other options: 'inmemory','redis','boltdb'.
     # DB type options. Uncomment those you need in case you want to switch DB type.
@@ -30,6 +32,8 @@ ApplicationConfiguration:
   #      DB: 0
   #    BoltDBOptions:
   #      FilePath: "./chains/privnet.bolt"
+  #  Uncomment in order to set up custom address for node.
+  #  Address: 127.0.0.1
   NodePort: 20337
   Relay: true
   DialTimeout: 3

--- a/config/protocol.privnet.docker.one.yml
+++ b/config/protocol.privnet.docker.one.yml
@@ -16,6 +16,8 @@ ProtocolConfiguration:
   VerifyTransactions: true
 
 ApplicationConfiguration:
+  # LogPath could be set up in case you need stdout logs to some proper file.
+  # LogPath: "./log/neogo.log"
   DBConfiguration:
     Type: "leveldb" #other options: 'inmemory','redis','boltdb'.
     # DB type options. Uncomment those you need in case you want to switch DB type.
@@ -27,6 +29,8 @@ ApplicationConfiguration:
   #      DB: 0
   #    BoltDBOptions:
   #      FilePath: "./chains/privnet.bolt"
+  #  Uncomment in order to set up custom address for node.
+  #  Address: 127.0.0.1
   NodePort: 20334
   Relay: true
   DialTimeout: 3

--- a/config/protocol.privnet.docker.three.yml
+++ b/config/protocol.privnet.docker.three.yml
@@ -16,6 +16,8 @@ ProtocolConfiguration:
   VerifyTransactions: true
 
 ApplicationConfiguration:
+  # LogPath could be set up in case you need stdout logs to some proper file.
+  # LogPath: "./log/neogo.log"
   DBConfiguration:
     Type: "leveldb" #other options: 'inmemory','redis','boltdb'.
     # DB type options. Uncomment those you need in case you want to switch DB type.
@@ -27,6 +29,8 @@ ApplicationConfiguration:
   #      DB: 0
   #    BoltDBOptions:
   #      FilePath: "./chains/privnet.bolt"
+  #  Uncomment in order to set up custom address for node.
+  #  Address: 127.0.0.1
   NodePort: 20336
   Relay: true
   DialTimeout: 3

--- a/config/protocol.privnet.docker.two.yml
+++ b/config/protocol.privnet.docker.two.yml
@@ -16,6 +16,8 @@ ProtocolConfiguration:
   VerifyTransactions: true
 
 ApplicationConfiguration:
+  # LogPath could be set up in case you need stdout logs to some proper file.
+  # LogPath: "./log/neogo.log"
   DBConfiguration:
     Type: "leveldb" #other options: 'inmemory','redis','boltdb'.
     # DB type options. Uncomment those you need in case you want to switch DB type.
@@ -27,6 +29,8 @@ ApplicationConfiguration:
   #      DB: 0
   #    BoltDBOptions:
   #      FilePath: "./chains/privnet.bolt"
+  #  Uncomment in order to set up custom address for node.
+  #  Address: 127.0.0.1
   NodePort: 20335
   Relay: true
   DialTimeout: 3

--- a/config/protocol.privnet.yml
+++ b/config/protocol.privnet.yml
@@ -22,6 +22,8 @@ ProtocolConfiguration:
   VerifyTransactions: true
 
 ApplicationConfiguration:
+  # LogPath could be set up in case you need stdout logs to some proper file.
+  # LogPath: "./log/neogo.log"
   DBConfiguration:
     Type: "leveldb" #other options: 'inmemory','redis','boltdb'.
     # DB type options. Uncomment those you need in case you want to switch DB type.
@@ -33,6 +35,8 @@ ApplicationConfiguration:
   #      DB: 0
   #    BoltDBOptions:
   #      FilePath: "./chains/privnet.bolt"
+  #  Uncomment in order to set up custom address for node.
+  #  Address: 127.0.0.1
   NodePort: 20332
   Relay: true
   DialTimeout: 3

--- a/config/protocol.testnet.yml
+++ b/config/protocol.testnet.yml
@@ -31,6 +31,8 @@ ProtocolConfiguration:
   VerifyTransactions: false
 
 ApplicationConfiguration:
+  # LogPath could be set up in case you need stdout logs to some proper file.
+  # LogPath: "./log/neogo.log"
   DBConfiguration:
     Type: "leveldb" #other options: 'inmemory','redis','boltdb'.
     # DB type options. Uncomment those you need in case you want to switch DB type.
@@ -42,6 +44,8 @@ ApplicationConfiguration:
   #      DB: 0
   #    BoltDBOptions:
   #      FilePath: "./chains/testnet.bolt"
+  #  Uncomment in order to set up custom address for node.
+  #  Address: 127.0.0.1
   NodePort: 20333
   Relay: true
   DialTimeout: 3

--- a/config/protocol.unit_testnet.yml
+++ b/config/protocol.unit_testnet.yml
@@ -21,6 +21,8 @@ ProtocolConfiguration:
   VerifyTransactions: true
 
 ApplicationConfiguration:
+  # LogPath could be set up in case you need stdout logs to some proper file.
+  # LogPath: "./log/neogo.log"
   DBConfiguration:
     Type: "inmemory" #other options: 'inmemory','redis','boltdb'.
     # DB type options. Uncomment those you need in case you want to switch DB type.
@@ -32,6 +34,8 @@ ApplicationConfiguration:
   #      DB: 0
   #    BoltDBOptions:
   #      FilePath: "./chains/unit_testnet.bolt"
+  #  Uncomment in order to set up custom address for node.
+  #  Address: 127.0.0.1
   NodePort: 20333
   Relay: true
   DialTimeout: 3

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,6 @@ require (
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mr-tron/base58 v1.1.2
 	github.com/nspcc-dev/rfc6979 v0.1.0
 	github.com/onsi/gomega v1.4.2 // indirect

--- a/pkg/core/storage/boltdb_store.go
+++ b/pkg/core/storage/boltdb_store.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path"
 
+	"github.com/CityOfZion/neo-go/pkg/io"
 	"github.com/etcd-io/bbolt"
 	log "github.com/sirupsen/logrus"
 	"github.com/syndtr/goleveldb/leveldb/util"
@@ -30,10 +30,8 @@ func NewBoltDBStore(cfg BoltDBOptions) (*BoltDBStore, error) {
 	var opts *bbolt.Options       // should be exposed via BoltDBOptions if anything needed
 	fileMode := os.FileMode(0600) // should be exposed via BoltDBOptions if anything needed
 	fileName := cfg.FilePath
-	dir := path.Dir(fileName)
-	err := os.MkdirAll(dir, os.ModePerm)
-	if err != nil {
-		return nil, fmt.Errorf("could not create dir for BoltDB: %v", err)
+	if err := io.MakeDirForFile(fileName, "BoltDB"); err != nil {
+		return nil, err
 	}
 	db, err := bbolt.Open(fileName, fileMode, opts)
 	if err != nil {

--- a/pkg/io/fileWriter.go
+++ b/pkg/io/fileWriter.go
@@ -1,0 +1,18 @@
+package io
+
+import (
+	"fmt"
+	"os"
+	"path"
+)
+
+// MakeDirForFile creates directory provided in filePath.
+func MakeDirForFile(filePath string, creator string) error {
+	fileName := filePath
+	dir := path.Dir(fileName)
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("could not create dir for %s: %v", creator, err)
+	}
+	return nil
+}

--- a/pkg/io/fileWriter_test.go
+++ b/pkg/io/fileWriter_test.go
@@ -1,0 +1,39 @@
+package io
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeDirForFile_HappyPath(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "test")
+	require.NoError(t, err)
+
+	filePath := tempDir + "/testDir/testFile.test"
+	err = MakeDirForFile(filePath, "test")
+	defer removeDir(t, tempDir)
+	require.NoError(t, err)
+
+	_, errChDir := os.Create(filePath)
+	require.NoError(t, errChDir)
+}
+
+func removeDir(t *testing.T, dirName string) {
+	err := os.RemoveAll(dirName)
+	require.NoError(t, err)
+}
+
+func TestMakeDirForFile_Negative(t *testing.T) {
+	file, err := ioutil.TempFile("", "test")
+	require.NoError(t, err)
+
+	filePath := file.Name() + "/error"
+	dir := path.Dir(filePath)
+	err = MakeDirForFile(filePath, "test")
+	defer removeDir(t, dir)
+	require.Errorf(t, err, "could not create dir for test: mkdir %s : not a directory", filePath)
+}

--- a/pkg/network/metrics/metrics.go
+++ b/pkg/network/metrics/metrics.go
@@ -18,6 +18,7 @@ type Service struct {
 // Additional information about Prometheus could be found here: https://prometheus.io/docs/guides/go-application.
 type PrometheusConfig struct {
 	Enabled bool   `yaml:"Enabled"`
+	Address string `yaml:"Address"`
 	Port    string `yaml:"Port"`
 }
 
@@ -25,7 +26,7 @@ type PrometheusConfig struct {
 func NewMetricsService(cfg PrometheusConfig) *Service {
 	return &Service{
 		&http.Server{
-			Addr:    ":" + cfg.Port,
+			Addr:   cfg.Address + ":" + cfg.Port,
 			Handler: promhttp.Handler(),
 		}, cfg,
 	}

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -104,7 +104,7 @@ func NewServer(config ServerConfig, chain core.Blockchainer) *Server {
 		s.AttemptConnPeers = defaultAttemptConnPeers
 	}
 
-	s.transport = NewTCPTransport(s, fmt.Sprintf(":%d", config.ListenTCP))
+	s.transport = NewTCPTransport(s, fmt.Sprintf("%s:%d", config.Address, config.Port))
 	s.discovery = NewDefaultDiscovery(
 		s.DialTimeout,
 		s.transport,
@@ -282,7 +282,7 @@ func (s *Server) startProtocol(p Peer) {
 func (s *Server) sendVersion(p Peer) error {
 	payload := payload.NewVersion(
 		s.id,
-		s.ListenTCP,
+		s.Port,
 		s.UserAgent,
 		s.chain.BlockHeight(),
 		s.Relay,

--- a/pkg/network/server_config.go
+++ b/pkg/network/server_config.go
@@ -27,8 +27,11 @@ type (
 		// The user agent of the server.
 		UserAgent string
 
-		// The listen address of the TCP server.
-		ListenTCP uint16
+		// Address. Example: "127.0.0.1".
+		Address string
+
+		// Port. Example: 20332.
+		Port uint16
 
 		// The network mode the server will operate on.
 		// ModePrivNet docker private network.
@@ -62,7 +65,8 @@ func NewServerConfig(cfg config.Config) ServerConfig {
 
 	return ServerConfig{
 		UserAgent:         cfg.GenerateUserAgent(),
-		ListenTCP:         appConfig.NodePort,
+		Address:           appConfig.Address,
+		Port:              appConfig.NodePort,
 		Net:               protoConfig.Magic,
 		Relay:             appConfig.Relay,
 		Seeds:             protoConfig.SeedList,

--- a/pkg/network/server_test.go
+++ b/pkg/network/server_test.go
@@ -14,7 +14,7 @@ func TestSendVersion(t *testing.T) {
 		s = newTestServer()
 		p = newLocalPeer(t)
 	)
-	s.ListenTCP = 3000
+	s.Port = 3000
 	s.UserAgent = "/test/"
 
 	p.messageHandler = func(t *testing.T, msg *Message) {

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -179,7 +179,7 @@ Methods:
 	case "getversion":
 		getversionCalled.Inc()
 		results = result.Version{
-			Port:      s.coreServer.ListenTCP,
+			Port:      s.coreServer.Port,
 			Nonce:     s.coreServer.ID(),
 			UserAgent: s.coreServer.UserAgent,
 		}


### PR DESCRIPTION
### Problem
#460 
...

### Solution
This patchset.

HowTo

1. Set up log path:
```
LogPath: "./log/neogo.log"
```
2. Set up binging address for node: (In config)
```
  #  Uncomment in order to set up custom address for node.
  #  Address: 127.0.0.1
```

Additional options:
3. Set up separate RPC, Monitoring. Node addresses is the same as above but you can do it for each module.
```
  RPC:
    Address: 127.0.0.1
    Enabled: true
    EnableCORSWorkaround: false
    Port: 20332
```
or
```
  Monitoring:
    Address: 127.0.0.1
    Enabled: true
    Port: 2112
```
...
