### PR TITLE
Minor RPC fixes

### DIFF
--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -157,7 +157,7 @@ Methods:
 		results = wrappers.NewBlock(block, s.chain)
 	case "getblockcount":
 		getblockcountCalled.Inc()
-		results = s.chain.BlockHeight()
+		results = s.chain.BlockHeight() + 1
 
 	case "getblockhash":
 		getblockHashCalled.Inc()

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -117,7 +117,7 @@ Methods:
 	switch req.Method {
 	case "getbestblockhash":
 		getbestblockhashCalled.Inc()
-		results = s.chain.CurrentBlockHash().ReverseString()
+		results = "0x" + s.chain.CurrentBlockHash().ReverseString()
 
 	case "getblock":
 		getbestblockCalled.Inc()

--- a/pkg/rpc/server_test.go
+++ b/pkg/rpc/server_test.go
@@ -51,7 +51,7 @@ func TestRPC(t *testing.T) {
 		var res IntResultResponse
 		err := json.Unmarshal(bytes.TrimSpace(body), &res)
 		assert.NoErrorf(t, err, "could not parse response: %s", body)
-		assert.Equal(t, chain.BlockHeight(), uint32(res.Result))
+		assert.Equal(t, chain.BlockHeight()+1, uint32(res.Result))
 	})
 
 	t.Run("getblockhash", func(t *testing.T) {

--- a/pkg/rpc/server_test.go
+++ b/pkg/rpc/server_test.go
@@ -28,7 +28,7 @@ func TestRPC(t *testing.T) {
 		var res StringResultResponse
 		err := json.Unmarshal(bytes.TrimSpace(body), &res)
 		assert.NoErrorf(t, err, "could not parse response: %s", body)
-		assert.Equal(t, chain.CurrentBlockHash().ReverseString(), res.Result)
+		assert.Equal(t, "0x"+chain.CurrentBlockHash().ReverseString(), res.Result)
 	})
 
 	t.Run("getblock", func(t *testing.T) {


### PR DESCRIPTION
### Problem

Our node responds to some RPC methods in a different way from C# nodes.

### Solution

Make our responses consistent with the C# node behaviour.