### PR TITLE
network: wait for both Version messages before ACKing

### DIFF
--- a/pkg/network/tcp_peer.go
+++ b/pkg/network/tcp_peer.go
@@ -108,6 +108,9 @@ func (p *TCPPeer) SendVersionAck(msg *Message) error {
 	if p.handShake&versionReceived == 0 {
 		return errors.New("invalid handshake: tried to send VersionAck, but no version received yet")
 	}
+	if p.handShake&versionSent == 0 {
+		return errors.New("invalid handshake: tried to send VersionAck, but didn't send Version yet")
+	}
 	if p.handShake&verAckSent != 0 {
 		return errors.New("invalid handshake: already sent VersionAck")
 	}
@@ -125,6 +128,9 @@ func (p *TCPPeer) HandleVersionAck() error {
 	defer p.lock.Unlock()
 	if p.handShake&versionSent == 0 {
 		return errors.New("invalid handshake: received VersionAck, but no version sent yet")
+	}
+	if p.handShake&versionReceived == 0 {
+		return errors.New("invalid handshake: received VersionAck, but no version received yet")
 	}
 	if p.handShake&verAckReceived != 0 {
 		return errors.New("invalid handshake: already received VersionAck")

--- a/pkg/network/tcp_peer_test.go
+++ b/pkg/network/tcp_peer_test.go
@@ -46,7 +46,9 @@ func TestPeerHandshake(t *testing.T) {
 	// Now send and handle versions, but in a different order on client and
 	// server.
 	require.NoError(t, tcpC.SendVersion(&Message{}))
+	require.Error(t, tcpC.HandleVersionAck()) // Didn't receive version yet.
 	require.NoError(t, tcpS.HandleVersion(&payload.Version{}))
+	require.Error(t, tcpS.SendVersionAck(&Message{})) // Didn't send version yet.
 	require.NoError(t, tcpC.HandleVersion(&payload.Version{}))
 	require.NoError(t, tcpS.SendVersion(&Message{}))
 


### PR DESCRIPTION
Otherwise the node might crash in `startProtocol` because of missing Version
field in the peer. And it also keeps the sequence correct, Version MUST be
sent first and ACKs can only follow it. A follow-up to #478.