### PR TITLE
network: write messages atomically

### DIFF
--- a/pkg/network/tcp_peer.go
+++ b/pkg/network/tcp_peer.go
@@ -63,8 +63,14 @@ func (p *TCPPeer) writeMsg(msg *Message) error {
 	case err := <-p.done:
 		return err
 	default:
-		w := io.NewBinWriterFromIO(p.conn)
-		return msg.Encode(w)
+		w := io.NewBufBinWriter()
+		if err := msg.Encode(w.BinWriter); err != nil {
+			return err
+		}
+
+		_, err := p.conn.Write(w.Bytes())
+
+		return err
 	}
 }
 


### PR DESCRIPTION
Right now message can be written in several `Write`'s so
concurrent calls to `writeMsg` can in theory interleave.
This commit fixes it.
