### PR TITLE
Fix interim block changes store

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1216,7 +1216,7 @@ func (bc *Blockchain) GetStandByValidators() (keys.PublicKeys, error) {
 
 // GetValidators returns validators.
 // Golang implementation of GetValidators method in C# (https://github.com/neo-project/neo/blob/c64748ecbac3baeb8045b16af0d518398a6ced24/neo/Persistence/Snapshot.cs#L182)
-func (bc *Blockchain) GetValidators(txes... *transaction.Transaction) ([]*keys.PublicKey, error) {
+func (bc *Blockchain) GetValidators(txes ...*transaction.Transaction) ([]*keys.PublicKey, error) {
 	chainState := NewBlockChainState(bc.store)
 	if len(txes) > 0 {
 		for _, tx := range txes {
@@ -1320,7 +1320,7 @@ func (bc *Blockchain) GetValidators(txes... *transaction.Transaction) ([]*keys.P
 	return result, nil
 }
 
-func processStateTX(chainState *BlockChainState, tx *transaction.StateTX, ) error {
+func processStateTX(chainState *BlockChainState, tx *transaction.StateTX) error {
 	for _, desc := range tx.Descriptors {
 		switch desc.Type {
 		case transaction.Account:

--- a/pkg/core/blockchain_state.go
+++ b/pkg/core/blockchain_state.go
@@ -31,7 +31,7 @@ func NewBlockChainState(store *storage.MemCachedStore) *BlockChainState {
 }
 
 // commit commits all the data in current state into storage.
-func (state *BlockChainState) commit() error  {
+func (state *BlockChainState) commit() error {
 	if err := state.accounts.commit(state.store); err != nil {
 		return err
 	}

--- a/pkg/core/blockchain_state.go
+++ b/pkg/core/blockchain_state.go
@@ -19,8 +19,9 @@ type BlockChainState struct {
 
 // NewBlockChainState creates blockchain state with it's memchached store.
 func NewBlockChainState(store *storage.MemCachedStore) *BlockChainState {
+	tmpStore := storage.NewMemCachedStore(store)
 	return &BlockChainState{
-		store:        store,
+		store:        tmpStore,
 		unspentCoins: make(UnspentCoins),
 		spentCoins:   make(SpentCoins),
 		accounts:     make(Accounts),


### PR DESCRIPTION
### Problem

Commit c80ee952a1a8a5a971cf2579d0985ee091cc39a5 removed temporary store used
to contain changes of the block being processed. It's wrong in that the block
changes should be applied to the database in a single transaction so that
there wouldn't be any intermediate state observed from the outside (which is
possible now). Also, this made changes commiting persist them to the
underlying store effectively making our persist loop a no-op (and not
producing `persist completed` log lines that we love so much).


### Solution

Add the interim store back into the system.