### PR TITLE
Proper blockchained invocation TX

### DIFF
--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -31,6 +31,11 @@ var (
 	errNoScriptHash        = errors.New("no smart contract hash was provided, specify one as the first argument")
 	errNoSmartContractName = errors.New("no name was provided, specify the '--name or -n' flag")
 	errFileExist           = errors.New("A file with given smart-contract name already exists")
+
+	endpointFlag = cli.StringFlag{
+		Name:  "endpoint, e",
+		Usage: "trusted RPC endpoint address (like 'http://localhost:20331')",
+	}
 )
 
 const (
@@ -83,10 +88,7 @@ func NewCommands() []cli.Command {
 						Name:  "config, c",
 						Usage: "configuration input file (*.yml)",
 					},
-					cli.StringFlag{
-						Name:  "endpoint, e",
-						Usage: "RPC endpoint address (like 'http://seed4.ngd.network:20332')",
-					},
+					endpointFlag,
 					cli.StringFlag{
 						Name:  "wif, w",
 						Usage: "key to sign deployed transaction (in wif format)",
@@ -114,10 +116,7 @@ func NewCommands() []cli.Command {
 `,
 				Action: testInvoke,
 				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "endpoint, e",
-						Usage: "RPC endpoint address (like 'http://seed4.ngd.network:20332')",
-					},
+					endpointFlag,
 				},
 			},
 			{
@@ -188,10 +187,7 @@ func NewCommands() []cli.Command {
 `,
 				Action: testInvokeFunction,
 				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "endpoint, e",
-						Usage: "RPC endpoint address (like 'http://seed4.ngd.network:20332')",
-					},
+					endpointFlag,
 				},
 			},
 			{
@@ -199,10 +195,7 @@ func NewCommands() []cli.Command {
 				Usage:  "Invoke compiled AVM code on the blockchain (test mode, not creating a transaction for it)",
 				Action: testInvokeScript,
 				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "endpoint, e",
-						Usage: "RPC endpoint address (like 'http://seed4.ngd.network:20332')",
-					},
+					endpointFlag,
 					cli.StringFlag{
 						Name:  "in, i",
 						Usage: "Input location of the avm file that needs to be invoked",

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -33,7 +33,7 @@ var (
 	errFileExist           = errors.New("A file with given smart-contract name already exists")
 )
 
-var (
+const (
 	// smartContractTmpl is written to a file when used with `init` command.
 	// %s is parsed to be the smartContractName
 	smartContractTmpl = `package %s

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -93,7 +93,7 @@ func NewCommands() []cli.Command {
 						Name:  "wif, w",
 						Usage: "key to sign deployed transaction (in wif format)",
 					},
-					cli.IntFlag{
+					cli.Float64Flag{
 						Name:  "gas, g",
 						Usage: "gas to pay for contract deployment",
 					},
@@ -470,7 +470,7 @@ func contractDeploy(ctx *cli.Context) error {
 	if len(wifStr) == 0 {
 		return cli.NewExitError(errNoWIF, 1)
 	}
-	gas := util.Fixed8FromInt64(int64(ctx.Int("gas")))
+	gas := util.Fixed8FromFloat(ctx.Float64("gas"))
 
 	wif, err := keys.WIFDecode(wifStr, 0)
 	if err != nil {

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -503,9 +503,14 @@ func contractDeploy(ctx *cli.Context) error {
 		return cli.NewExitError(err, 1)
 	}
 
-	txHash, err := client.DeployContract(avm, &conf.Contract, wif, gas)
+	txScript, err := rpc.CreateDeploymentScript(avm, &conf.Contract)
 	if err != nil {
-		return cli.NewExitError(fmt.Errorf("failed to deploy: %v", err), 1)
+		return cli.NewExitError(fmt.Errorf("failed to create deployment script: %v", err), 1)
+	}
+
+	txHash, err := client.SignAndPushInvocationTx(txScript, wif, gas)
+	if err != nil {
+		return cli.NewExitError(fmt.Errorf("failed to push invocation tx: %v", err), 1)
 	}
 	fmt.Printf("Sent deployment transaction %s for contract %s\n", txHash.ReverseString(), hash.Hash160(avm).ReverseString())
 	return nil

--- a/pkg/rpc/rpc.go
+++ b/pkg/rpc/rpc.go
@@ -153,20 +153,17 @@ func (c *Client) SendToAddress(asset util.Uint256, address string, amount util.F
 	return response, nil
 }
 
-// DeployContract deploys given contract to the blockchain using given wif to
-// sign the transaction and spending the amount of gas specified. It returns
-// a hash of the deployment transaction and an error.
-func (c *Client) DeployContract(avm []byte, contract *ContractDetails, wif *keys.WIF, gas util.Fixed8) (util.Uint256, error) {
+// SignAndPushInvocationTx signs and pushes given script as an invocation
+// transaction  using given wif to sign it and spending the amount of gas
+// specified. It returns a hash of the invocation transaction and an error.
+func (c *Client) SignAndPushInvocationTx(script []byte, wif *keys.WIF, gas util.Fixed8) (util.Uint256, error) {
 	var txHash util.Uint256
+	var err error
 
 	gasIDB, _ := hex.DecodeString("602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7")
 	gasID, _ := util.Uint256DecodeReverseBytes(gasIDB)
 
-	txScript, err := CreateDeploymentScript(avm, contract)
-	if err != nil {
-		return txHash, errors.Wrap(err, "failed creating deployment script")
-	}
-	tx := transaction.NewInvocationTX(txScript, gas)
+	tx := transaction.NewInvocationTX(script, gas)
 
 	fromAddress := wif.PrivateKey.Address()
 

--- a/pkg/rpc/rpc.go
+++ b/pkg/rpc/rpc.go
@@ -167,8 +167,10 @@ func (c *Client) SignAndPushInvocationTx(script []byte, wif *keys.WIF, gas util.
 
 	fromAddress := wif.PrivateKey.Address()
 
-	if err = AddInputsAndUnspentsToTx(tx, fromAddress, gasID, gas, c); err != nil {
-		return txHash, errors.Wrap(err, "failed to add inputs and unspents to transaction")
+	if gas > 0 {
+		if err = AddInputsAndUnspentsToTx(tx, fromAddress, gasID, gas, c); err != nil {
+			return txHash, errors.Wrap(err, "failed to add inputs and unspents to transaction")
+		}
 	}
 
 	if err = SignTx(tx, wif); err != nil {


### PR DESCRIPTION
### Problem

We can only make test invocations.

### Solution

Now we can send proper TXes to the net! Like this:
```
$ ./bin/neo-go contract invokefunction -e http://localhost:20331 -w KxDgvEKzgSBPPfuVfw67oPQBSjidEiqTHURKSDL1R7yGaGYAeYnr -g 0.00001 50befd26fdf6e4d957c11e078b24ebce6291456f
```
The only caveat is that you have to specify some gas for it not to fail verification.