### PR TITLE
network: add Pprof metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ Available network flags:
 - `--privnet, -p`
 - `--testnet, -t`
 
+#Developer notes
+Nodes have such features as [Prometheus](https://prometheus.io/docs/guides/go-application) and 
+[Pprof](https://golang.org/pkg/net/http/pprof/) in order to have additional information about them for debugging.
+
+How to configure Prometheus or Pprof:
+In `config/protocol.*.yml` there is 
+```
+  Prometheus:
+    Enabled: true
+    Port: 2112
+```
+where you can switch on/off and define port. Prometheus is enabled and Pprof is disabled by default.
+
 # Contributing
 
 Feel free to contribute to this project after reading the

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -134,6 +134,22 @@ func getCountAndSkipFromContext(ctx *cli.Context) (uint32, uint32) {
 	return count, skip
 }
 
+func initBCWithMetrics(cfg config.Config) (*core.Blockchain, *metrics.Service, *metrics.Service, error) {
+	chain, err := initBlockChain(cfg)
+	if err != nil {
+		return nil, nil, nil, cli.NewExitError(err, 1)
+	}
+	configureAddresses(cfg.ApplicationConfiguration)
+	prometheus := metrics.NewPrometheusService(cfg.ApplicationConfiguration.Prometheus)
+	pprof := metrics.NewPprofService(cfg.ApplicationConfiguration.Pprof)
+
+	go chain.Run()
+	go prometheus.Start()
+	go pprof.Start()
+
+	return chain, prometheus, pprof, nil
+}
+
 func dumpDB(ctx *cli.Context) error {
 	cfg, err := getConfigFromContext(ctx)
 	if err != nil {
@@ -154,11 +170,10 @@ func dumpDB(ctx *cli.Context) error {
 	defer outStream.Close()
 	writer := io.NewBinWriterFromIO(outStream)
 
-	chain, err := initBlockChain(cfg)
+	chain, prometheus, pprof, err := initBCWithMetrics(cfg)
 	if err != nil {
-		return cli.NewExitError(err, 1)
+		return err
 	}
-	go chain.Run()
 
 	chainHeight := chain.BlockHeight()
 	if skip+count > chainHeight {
@@ -182,9 +197,12 @@ func dumpDB(ctx *cli.Context) error {
 			return cli.NewExitError(err, 1)
 		}
 	}
+	pprof.ShutDown()
+	prometheus.ShutDown()
 	chain.Close()
 	return nil
 }
+
 func restoreDB(ctx *cli.Context) error {
 	cfg, err := getConfigFromContext(ctx)
 	if err != nil {
@@ -205,11 +223,10 @@ func restoreDB(ctx *cli.Context) error {
 	defer inStream.Close()
 	reader := io.NewBinReaderFromIO(inStream)
 
-	chain, err := initBlockChain(cfg)
+	chain, prometheus, pprof, err := initBCWithMetrics(cfg)
 	if err != nil {
 		return err
 	}
-	go chain.Run()
 
 	var allBlocks = reader.ReadU32LE()
 	if reader.Err != nil {
@@ -241,8 +258,9 @@ func restoreDB(ctx *cli.Context) error {
 			return cli.NewExitError(fmt.Errorf("failed to add block %d: %s", i, err), 1)
 		}
 	}
+	pprof.ShutDown()
+	prometheus.ShutDown()
 	chain.Close()
-
 	return nil
 }
 
@@ -271,23 +289,17 @@ func startServer(ctx *cli.Context) error {
 
 	serverConfig := network.NewServerConfig(cfg)
 
-	chain, err := initBlockChain(cfg)
+	chain, prometheus, pprof, err := initBCWithMetrics(cfg)
 	if err != nil {
 		return err
 	}
 
-	configureAddresses(cfg.ApplicationConfiguration)
 	server := network.NewServer(serverConfig, chain)
 	rpcServer := rpc.NewServer(chain, cfg.ApplicationConfiguration.RPC, server)
 	errChan := make(chan error)
-	prometheus := metrics.NewPrometheusService(cfg.ApplicationConfiguration.Prometheus)
-	pprof := metrics.NewPprofService(cfg.ApplicationConfiguration.Pprof)
 
-	go chain.Run()
 	go server.Start(errChan)
 	go rpcServer.Start(errChan)
-	go prometheus.Start()
-	go pprof.Start()
 
 	fmt.Println(logo())
 	fmt.Println(server.UserAgent)

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,8 @@ type (
 		MaxPeers          int                      `yaml:"MaxPeers"`
 		AttemptConnPeers  int                      `yaml:"AttemptConnPeers"`
 		MinPeers          int                      `yaml:"MinPeers"`
-		Monitoring        metrics.PrometheusConfig `yaml:"Monitoring"`
+		Prometheus        metrics.Config           `yaml:"Prometheus"`
+		Pprof             metrics.Config           `yaml:"Pprof"`
 		RPC               RPCConfig                `yaml:"RPC"`
 		UnlockWallet      WalletConfig             `yaml:"UnlockWallet"`
 	}

--- a/config/protocol.mainnet.yml
+++ b/config/protocol.mainnet.yml
@@ -57,6 +57,9 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 10332
-  Monitoring:
+  Prometheus:
     Enabled: true
     Port: 2112
+  Pprof:
+    Enabled: false
+    Port: 2113

--- a/config/protocol.privnet.docker.four.yml
+++ b/config/protocol.privnet.docker.four.yml
@@ -48,9 +48,12 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 30336
-  Monitoring:
+  Prometheus:
     Enabled: true
     Port: 20004
+  Pprof:
+    Enabled: false
+    Port: 20014
   UnlockWallet:
     Path: "6PYRXVwHSqFSukL3CuXxdQ75VmsKpjeLgQLEjt83FrtHf1gCVphHzdD4nc"
     Password: "four"

--- a/config/protocol.privnet.docker.one.yml
+++ b/config/protocol.privnet.docker.one.yml
@@ -48,9 +48,12 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 30333
-  Monitoring:
+  Prometheus:
     Enabled: true
     Port: 20001
+  Pprof:
+    Enabled: false
+    Port: 20011
   UnlockWallet:
     Path: "6PYLmjBYJ4wQTCEfqvnznGJwZeW9pfUcV5m5oreHxqryUgqKpTRAFt9L8Y"
     Password: "one"

--- a/config/protocol.privnet.docker.three.yml
+++ b/config/protocol.privnet.docker.three.yml
@@ -48,9 +48,12 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 30335
-  Monitoring:
+  Prometheus:
     Enabled: true
     Port: 20003
+  Pprof:
+    Enabled: false
+    Port: 20013
   UnlockWallet:
     Path: "6PYX86vYiHfUbpD95hfN1xgnvcSxy5skxfWYKu3ztjecxk6ikYs2kcWbeh"
     Password: "three"

--- a/config/protocol.privnet.docker.two.yml
+++ b/config/protocol.privnet.docker.two.yml
@@ -48,9 +48,12 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 30334
-  Monitoring:
+  Prometheus:
     Enabled: true
     Port: 20002
+  Pprof:
+    Enabled: false
+    Port: 20012
   UnlockWallet:
     Path: "6PYXHjPaNvW8YknSXaKsTWjf9FRxo1s4naV2jdmSQEgzaqKGX368rndN3L"
     Password: "two"

--- a/config/protocol.privnet.yml
+++ b/config/protocol.privnet.yml
@@ -48,6 +48,9 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 20331
-  Monitoring:
+  Prometheus:
     Enabled: true
     Port: 2112
+  Pprof:
+    Enabled: false
+    Port: 2113

--- a/config/protocol.testnet.yml
+++ b/config/protocol.testnet.yml
@@ -57,6 +57,9 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 20332
-  Monitoring:
+  Prometheus:
     Enabled: true
     Port: 2112
+  Pprof:
+    Enabled: false
+    Port: 2113

--- a/config/protocol.unit_testnet.yml
+++ b/config/protocol.unit_testnet.yml
@@ -47,6 +47,9 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 20332
-  Monitoring:
+  Prometheus:
     Enabled: false #since it's not useful for unit tests.
     Port: 2112
+  Pprof:
+    Enabled: false #since it's not useful for unit tests.
+    Port: 2113

--- a/pkg/network/metrics/pprof.go
+++ b/pkg/network/metrics/pprof.go
@@ -1,0 +1,25 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/pprof"
+)
+// PprofService https://golang.org/pkg/net/http/pprof/.
+type PprofService Service
+
+// NewPprofService created new service for gathering pprof metrics.
+func NewPprofService(cfg Config) *Service {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/debug/pprof", pprof.Index)
+	handler.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	handler.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	handler.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	handler.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	return &Service{
+		&http.Server{
+			Addr:    cfg.Address + ":" + cfg.Port,
+			Handler: handler,
+		}, cfg, "Pprof",
+	}
+}

--- a/pkg/network/metrics/prometheus.go
+++ b/pkg/network/metrics/prometheus.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// PrometheusService https://prometheus.io/docs/guides/go-application.
+type PrometheusService Service
+
+// NewPrometheusService creates new service for gathering prometheus metrics.
+func NewPrometheusService(cfg Config) *Service {
+	return &Service{
+		&http.Server{
+			Addr:    cfg.Address + ":" + cfg.Port,
+			Handler: promhttp.Handler(),
+		}, cfg, "Prometheus",
+	}
+}


### PR DESCRIPTION
Since we have some perf issues from time to time it is good to have pprof debugger

Usage: 
addr (host + port) + 
```
	"/debug/pprof/"
	"/debug/pprof/cmdline"
	"/debug/pprof/profile"
	"/debug/pprof/symbol"
	"/debug/pprof/trace"
```
Link for documentation: https://golang.org/pkg/net/http/pprof/