### PR TITLE
core: fix wrong data being read in interops (part of #501)

### DIFF
--- a/pkg/core/interop_system.go
+++ b/pkg/core/interop_system.go
@@ -410,9 +410,6 @@ func (ic *interopContext) storageDelete(v *vm.VM) error {
 	}
 	key := v.Estack().Pop().Bytes()
 	si := getStorageItemFromStore(ic.mem, stc.ScriptHash, key)
-	if si == nil {
-		si = ic.bc.GetStorageItem(stc.ScriptHash, key)
-	}
 	if si != nil && si.IsConst {
 		return errors.New("storage item is constant")
 	}
@@ -432,9 +429,6 @@ func (ic *interopContext) storageGet(v *vm.VM) error {
 	}
 	key := v.Estack().Pop().Bytes()
 	si := getStorageItemFromStore(ic.mem, stc.ScriptHash, key)
-	if si == nil {
-		si = ic.bc.GetStorageItem(stc.ScriptHash, key)
-	}
 	if si != nil && si.Value != nil {
 		v.Estack().PushVal(si.Value)
 	} else {
@@ -479,10 +473,7 @@ func (ic *interopContext) putWithContextAndFlags(stc *StorageContext, key []byte
 	}
 	si := getStorageItemFromStore(ic.mem, stc.ScriptHash, key)
 	if si == nil {
-		si = ic.bc.GetStorageItem(stc.ScriptHash, key)
-		if si == nil {
-			si = &StorageItem{}
-		}
+		si = &StorageItem{}
 	}
 	if si.IsConst {
 		return errors.New("storage item exists and is read-only")


### PR DESCRIPTION
When 74590551 introduced this code we had no proper caching layer, so there
were these strange fallbacks in the code. fc0031e5 should'd removed them, but
failed to do so, so do it now and fix processing of transactions that touch
storage for the same key (address) in the same block.