### PR TITLE
rpc: simplify uint160 handling

### DIFF
--- a/pkg/rpc/param.go
+++ b/pkg/rpc/param.go
@@ -85,11 +85,7 @@ func (p Param) GetUint160FromHex() (util.Uint160, error) {
 		return util.Uint160{}, err
 	}
 
-	scriptHashLE, err := util.Uint160DecodeStringBE(s)
-	if err != nil {
-		return util.Uint160{}, err
-	}
-	return util.Uint160DecodeBytesBE(scriptHashLE.BytesLE())
+	return util.Uint160DecodeStringLE(s)
 }
 
 // GetUint160FromAddress returns Uint160 value of the parameter that was

--- a/pkg/rpc/param_test.go
+++ b/pkg/rpc/param_test.go
@@ -112,8 +112,7 @@ func TestParamGetUint256(t *testing.T) {
 
 func TestParamGetUint160FromHex(t *testing.T) {
 	in := "50befd26fdf6e4d957c11e078b24ebce6291456f"
-	u160, _ := util.Uint160DecodeStringBE(in)
-	u160, _ = util.Uint160DecodeBytesBE(util.ArrayReverse(u160[:]))
+	u160, _ := util.Uint160DecodeStringLE(in)
 	p := Param{stringT, in}
 	u, err := p.GetUint160FromHex()
 	assert.Equal(t, u160, u)


### PR DESCRIPTION
Use new Uint160DecodeStringLE() function.
