### PR TITLE
vm/core: improve block import speed with PublicKey caching

### DIFF
--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -41,6 +41,25 @@ func TestRegisterInterop(t *testing.T) {
 	assert.Equal(t, true, ok)
 }
 
+func TestBytesToPublicKey(t *testing.T) {
+	v := New()
+	cache := v.GetPublicKeys()
+	assert.Equal(t, 0, len(cache))
+	keyHex := "03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c"
+	keyBytes, _ := hex.DecodeString(keyHex)
+	key := v.bytesToPublicKey(keyBytes)
+	assert.NotNil(t, key)
+	key2 := v.bytesToPublicKey(keyBytes)
+	assert.Equal(t, key, key2)
+
+	cache = v.GetPublicKeys()
+	assert.Equal(t, 1, len(cache))
+	assert.NotNil(t, cache[string(keyBytes)])
+
+	keyBytes[0] = 0xff
+	require.Panics(t, func() { v.bytesToPublicKey(keyBytes) })
+}
+
 func TestPushBytes1to75(t *testing.T) {
 	buf := new(bytes.Buffer)
 	for i := 1; i <= 75; i++ {


### PR DESCRIPTION
This change (closely related to the neo-project/neo#1321 proposal) speeds up
1.4M mainnet blocks import by 30%. Basically, we're eliminating key decoding
for block's multisignature that has the same keys most of the time.

Things I don't like about this patch:
 * yet another parameter for verifyHashAgainstScript()
 * vm keys are not copied in/out

But it's rather simple and solves the problem for this particular case, so I
think it's worth it.