### PR TITLE
performance: add performance test

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,20 @@
+# Integration package
+The main goal is to have integration tests here.
+
+### Performance test
+Right now we have `performance_test.go` to measure number of processed TX per second.
+In order to run it:
+```
+$ cd integration
+$ go test -bench=. -benchmem
+```
+
+Result:
+```
+10000            402421 ns/op          177370 B/op         90 allocs/op
+PASS
+ok      github.com/CityOfZion/neo-go/integration        4.360s
+
+```
+
+Which means that in 4.360 seconds neo-go processes 10 000 transactions.

--- a/integration/performance_test.go
+++ b/integration/performance_test.go
@@ -35,8 +35,12 @@ func BenchmarkTXPerformanceTest(t *testing.B) {
 	t.ResetTimer()
 
 	for n := 0; n < t.N; n++ {
-		require.Equal(t, server.RelayTxn(data[n]), network.RelaySucceed)
-		require.Equal(t, server.RelayTxn(data[n]), network.RelayAlreadyExists)
+		if server.RelayTxn(data[n]) != network.RelaySucceed {
+			t.Fail()
+		}
+		if server.RelayTxn(data[n]) != network.RelayAlreadyExists {
+			t.Fail()
+		}
 	}
 	chain.Close()
 }

--- a/integration/performance_test.go
+++ b/integration/performance_test.go
@@ -1,0 +1,76 @@
+package integration
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/CityOfZion/neo-go/config"
+	"github.com/CityOfZion/neo-go/pkg/core"
+	"github.com/CityOfZion/neo-go/pkg/core/storage"
+	"github.com/CityOfZion/neo-go/pkg/core/transaction"
+	"github.com/CityOfZion/neo-go/pkg/network"
+	"github.com/stretchr/testify/require"
+)
+
+// Benchmark test to measure number of processed TX.
+// Same benchmark made on reference C# node https://github.com/neo-project/neo/issues/1321.
+func BenchmarkTXPerformanceTest(t *testing.B) {
+	net := config.ModeUnitTestNet
+	configPath := "../config"
+	cfg, err := config.Load(configPath, net)
+	require.NoError(t, err, "could not load config")
+
+	memoryStore := storage.NewMemoryStore()
+	chain, err := core.NewBlockchain(memoryStore, cfg.ProtocolConfiguration)
+	require.NoError(t, err, "could not create chain")
+
+	go chain.Run()
+
+	serverConfig := network.NewServerConfig(cfg)
+	server := network.NewServer(serverConfig, chain)
+	for n := 0; n < t.N; n++ {
+		tx := getTX()
+		require.Equal(t, server.RelayTxn(tx), network.RelaySucceed)
+		require.Equal(t, server.RelayTxn(tx), network.RelayAlreadyExists)
+	}
+	chain.Close()
+}
+
+// getTX returns Invocation transaction with some random attributes in order to have different hashes.
+func getTX() *transaction.Transaction {
+	tx := &transaction.Transaction{
+		Type:    transaction.InvocationType,
+		Version: 0,
+		Data: &transaction.InvocationTX{
+			Script:  []byte{0x51},
+			Gas:     1,
+			Version: 1,
+		},
+		Attributes: []transaction.Attribute{},
+		Inputs:     []transaction.Input{},
+		Outputs:    []transaction.Output{},
+		Scripts:    []transaction.Witness{},
+		Trimmed:    false,
+	}
+	tx.Attributes = append(tx.Attributes,
+		transaction.Attribute{
+			Usage: transaction.Description,
+			Data:  []byte(randString(10)),
+		})
+	return tx
+}
+
+// String returns a random string with the n as its length.
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(Int(65, 90))
+	}
+
+	return string(b)
+}
+
+// Int returns a random integer in [min,max).
+func Int(min, max int) int {
+	return min + rand.Intn(max-min)
+}


### PR DESCRIPTION
Goal was to measure TX/Sec as in https://github.com/neo-project/neo/issues/1321

In order to run it:
```
$ cd integration
$ go test -bench=. -benchmem
```

Result 1 (without singing TX):
```
10000            402421 ns/op          177370 B/op         90 allocs/op
PASS
ok      github.com/CityOfZion/neo-go/integration        4.360s
```
Meaning that we have 10 000 tx'es per 4.360s. It's 2294 TX / Sec.

Result 2 (with singing TX):
```
    4743            398582 ns/op          132878 B/op        467 allocs/op
PASS
ok      github.com/CityOfZion/neo-go/integration        2.530s
```
Meaning that we have 4743 tx'es per 2.530s. It's 1874 TX / Sec.

Next step would be to run performance test with e2e scenario.
