### PR TITLE
io: remove Read/Write LE/BE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-redis/redis v6.10.2+incompatible
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/mr-tron/base58 v1.1.2
-	github.com/nspcc-dev/dbft v0.0.0-20191209120240-0d6b7568d9ae
+	github.com/nspcc-dev/dbft v0.0.0-20191213082456-c81c7a796775
 	github.com/nspcc-dev/rfc6979 v0.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/CityOfZion/neo-go v0.62.1-pre.0.20191114145240-e740fbe708f8/go.mod h1:MJCkWUBhi9pn/CrYO1Q3P687y2KeahrOPS9BD9LDGb0=
 github.com/CityOfZion/neo-go v0.70.1-pre.0.20191209120015-fccb0085941e/go.mod h1:0enZl0az8xA6PVkwzEOwPWVJGqlt/GO4hA4kmQ5Xzig=
+github.com/CityOfZion/neo-go v0.70.1-pre.0.20191212173117-32ac01130d4c/go.mod h1:JtlHfeqLywZLswKIKFnAp+yzezY4Dji9qlfQKB2OD/I=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=
 github.com/Workiva/go-datastructures v1.0.50/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
 github.com/abiosoft/ishell v2.0.0+incompatible h1:zpwIuEHc37EzrsIYah3cpevrIc8Oma7oZPxr03tlmmw=
@@ -93,6 +94,8 @@ github.com/nspcc-dev/dbft v0.0.0-20191205084618-dacb1a30c254 h1:A4OkQDQOSPsJF8qU
 github.com/nspcc-dev/dbft v0.0.0-20191205084618-dacb1a30c254/go.mod h1:w1Ln2aT+dBlPhLnuZhBV+DfPEdS2CHWWLp5JTScY3bw=
 github.com/nspcc-dev/dbft v0.0.0-20191209120240-0d6b7568d9ae h1:T5V1QANlNMKun0EPB3eqg2PTXG4rmLhzDyEiV63kdB0=
 github.com/nspcc-dev/dbft v0.0.0-20191209120240-0d6b7568d9ae/go.mod h1:3FjXOoHmA51EGfb5GS/HOv7VdmngNRTssSeQ729dvGY=
+github.com/nspcc-dev/dbft v0.0.0-20191213082456-c81c7a796775 h1:iqRxuEBrT2QbSdgmvGCwgn+lnOKmx1L5EiVTcOXUYt8=
+github.com/nspcc-dev/dbft v0.0.0-20191213082456-c81c7a796775/go.mod h1:IyIyVYKfi41kAlGWqicz9G8Iyni71Resuhtd9Y5ujJM=
 github.com/nspcc-dev/neofs-crypto v0.2.0 h1:ftN+59WqxSWz/RCgXYOfhmltOOqU+udsNQSvN6wkFck=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/rfc6979 v0.1.0 h1:Lwg7esRRoyK1Up/IN1vAef1EmvrBeMHeeEkek2fAJ6c=

--- a/pkg/io/binaryReader.go
+++ b/pkg/io/binaryReader.go
@@ -38,15 +38,6 @@ func NewBinReaderFromBuf(b []byte) *BinReader {
 	return NewBinReaderFromIO(r)
 }
 
-// ReadLE reads from the underlying io.Reader
-// into the interface v in little-endian format.
-func (r *BinReader) ReadLE(v interface{}) {
-	if r.Err != nil {
-		return
-	}
-	r.Err = binary.Read(r.r, binary.LittleEndian, v)
-}
-
 // ReadU64LE reads a little-endian encoded uint64 value from the underlying
 // io.Reader. On read failures it returns zero.
 func (r *BinReader) ReadU64LE() uint64 {
@@ -151,15 +142,6 @@ func (r *BinReader) ReadArray(t interface{}, maxSize ...int) {
 	}
 
 	value.Elem().Set(arr)
-}
-
-// ReadBE reads from the underlying io.Reader
-// into the interface v in big-endian format.
-func (r *BinReader) ReadBE(v interface{}) {
-	if r.Err != nil {
-		return
-	}
-	r.Err = binary.Read(r.r, binary.BigEndian, v)
 }
 
 // ReadVarUint reads a variable-length-encoded integer from the

--- a/pkg/io/binaryWriter.go
+++ b/pkg/io/binaryWriter.go
@@ -27,22 +27,6 @@ func NewBinWriterFromIO(iow io.Writer) *BinWriter {
 	return &BinWriter{w: iow, u64: u64, u32: u32, u16: u16, u8: u8}
 }
 
-// WriteLE writes into the underlying io.Writer from an object v in little-endian format.
-func (w *BinWriter) WriteLE(v interface{}) {
-	if w.Err != nil {
-		return
-	}
-	w.Err = binary.Write(w.w, binary.LittleEndian, v)
-}
-
-// WriteBE writes into the underlying io.Writer from an object v in big-endian format.
-func (w *BinWriter) WriteBE(v interface{}) {
-	if w.Err != nil {
-		return
-	}
-	w.Err = binary.Write(w.w, binary.BigEndian, v)
-}
-
 // WriteU64LE writes an uint64 value into the underlying io.Writer in
 // little-endian format.
 func (w *BinWriter) WriteU64LE(u64 uint64) {


### PR DESCRIPTION
They were replaced with faster specialized versions earlier. The only obstacle on the way to removing them completely was dbft library, which is also updated in this PR.