### PR TITLE
compiler: implement assignment to a variable index

### DIFF
--- a/pkg/vm/tests/slice_test.go
+++ b/pkg/vm/tests/slice_test.go
@@ -1,0 +1,53 @@
+package vm_test
+
+import (
+	"math/big"
+	"testing"
+)
+
+var sliceTestCases = []testCase{
+	{
+		"constant index",
+		`
+		package foo
+		func Main() int {
+			a := []int{0,0}
+			a[1] = 42
+			return a[1]+0
+		}
+		`,
+		big.NewInt(42),
+	},
+	{
+		"variable index",
+		`
+		package foo
+		func Main() int {
+			a := []int{0,0}
+			i := 1
+			a[i] = 42
+			return a[1]+0
+		}
+		`,
+		big.NewInt(42),
+	},
+	{
+		"complex test",
+		`
+		package foo
+		func Main() int {
+			a := []int{1,2,3}
+			x := a[0]
+			a[x] = a[x] + 4
+			a[x] = a[x] + a[2]
+			return a[1]
+		}
+		`,
+		big.NewInt(9),
+	},
+}
+
+func TestSliceOperations(t *testing.T) {
+	runTestCases(t, sliceTestCases)
+}
+


### PR DESCRIPTION
Implement assignement to a variable slice index.
Fixes #564 .