### PR TITLE
integration: add integration test for measuring TX per seconds

### DIFF
--- a/config/protocol.privnet.integration.yml
+++ b/config/protocol.privnet.integration.yml
@@ -1,0 +1,53 @@
+ProtocolConfiguration:
+  Magic: 56753
+  AddressVersion: 23
+  SecondsPerBlock: 15
+  LowPriorityThreshold: 0.000
+  StandbyValidators:
+    - 02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2
+    - 02103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e
+    - 03d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee699
+    - 02a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd62
+  SeedList:
+    - node_one:20333
+    - node_two:20334
+    - node_three:20335
+    - node_four:20336
+  SystemFee:
+    EnrollmentTransaction: 1000
+    IssueTransaction: 500
+    PublishTransaction: 500
+    RegisterTransaction: 10000
+  VerifyBlocks: true
+  VerifyTransactions: true
+
+ApplicationConfiguration:
+  # LogPath could be set up in case you need stdout logs to some proper file.
+  # LogPath: "./log/neogo.log"
+  DBConfiguration:
+    Type: "leveldb" #other options: 'inmemory','redis','boltdb'.
+    # DB type options. Uncomment those you need in case you want to switch DB type.
+    LevelDBOptions:
+      DataDirectoryPath: "./chains/privnet"
+  #    RedisDBOptions:
+  #      Addr: "localhost:6379"
+  #      Password: ""
+  #      DB: 0
+  #    BoltDBOptions:
+  #      FilePath: "./chains/privnet.bolt"
+  #  Uncomment in order to set up custom address for node.
+  #  Address: 127.0.0.1
+  NodePort: 20332
+  Relay: true
+  DialTimeout: 3
+  ProtoTickInterval: 2
+  MaxPeers: 10
+  AttemptConnPeers: 5
+  MinPeers: 3
+  RPC:
+    Enabled: true
+    EnableCORSWorkaround: false
+    Port: 20331
+  Monitoring:
+    Enabled: true
+    Port: 2112

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/CityOfZion/neo-go
 require (
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/alicebob/miniredis v2.5.0+incompatible
+	github.com/docker/go-connections v0.4.0
 	github.com/etcd-io/bbolt v1.3.3
 	github.com/go-redis/redis v6.10.2+incompatible
 	github.com/go-yaml/yaml v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/etcd-io/bbolt v1.3.3 h1:gSJmxrs37LgTqR/oyJBWok6k6SvXEUerFTbltIhXkBM=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/integration/README.md
+++ b/integration/README.md
@@ -18,3 +18,43 @@ ok      github.com/CityOfZion/neo-go/integration        4.360s
 ```
 
 Which means that in 4.360 seconds neo-go processes 10 000 transactions.
+
+### Integration benchmark test
+#### Script run
+Use `./runIntegration.sh`
+
+#### Manual run
+This test requires to have:
+- privatenet running
+- node running
+
+To run privatenet use this command `$make env_up`.
+There are several nodes could be used (neo-go, neo-sharp, ...)
+- For neo-go node use docker image `nspccdev/neo-go-integration` which is built exactly for running with local privatenet.
+- For C# node use use docker image `nspccdev/neo-sharp-integration` 
+To run node: 
+
+neo-go:
+`$docker run --rm --network neo_go_network -p 20331-20332:20331-20332 -p 2112:2112 --name neo-go-integraion --ip 172.200.0.5 -t nspccdev/neo-go-integration
+`
+neo-sharp:
+`$docker run --rm --network neo_go_network -p 20331-20332:20331-20332 -p 2112:2112 --name neo-sharp-integraion --ip 172.200.0.5 -t nspccdev/neo-sharp-integration
+`
+
+After that use benchmark integration test `integration_test.go`.
+
+#### Update integration docker image
+To update nspccdev/neo-go-integration docker image there are several steps to be done:
+
+Neo-go:
+1. Change `protocol.privnet.yml`:
+```
+  SeedList:
+    - 172.200.0.1:20333
+    - 172.200.0.2:20334
+    - 172.200.0.3:20335
+    - 172.200.0.4:20336
+```
+Or use `protocol.privnet.integration.yml` by renaming it to `protocol.privnet.yml`.
+2. Build image `$ docker build -t nspccdev/neo-go-integration:0.70.1 .` where 0.70.1 is current release version.
+3. Push image `$  docker push nspccdev/neo-go-integration:0.70.1`

--- a/integration/generator.go
+++ b/integration/generator.go
@@ -1,0 +1,92 @@
+package integration
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/CityOfZion/neo-go/pkg/core/transaction"
+	"github.com/CityOfZion/neo-go/pkg/crypto"
+	"github.com/CityOfZion/neo-go/pkg/crypto/keys"
+	"github.com/CityOfZion/neo-go/pkg/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+// Generator goal is to generate tx for testing purposes.
+type Generator struct {}
+
+// getTransactions returns Invocation txes.
+func getTransactions(t require.TestingT, numberOfTX int) []*transaction.Transaction{
+	var data []*transaction.Transaction
+
+	wif, err := getWif()
+	require.NoError(t, err)
+
+	for n := 0; n < numberOfTX; n++ {
+		tx := getTX(t, wif)
+		require.NoError(t, rpc.SignTx(tx, wif))
+		data = append(data, tx)
+	}
+	return data
+}
+
+// getWif returns Wif.
+func getWif() (*keys.WIF, error) {
+	var (
+		wifEncoded = "KxhEDBQyyEFymvfJD96q8stMbJMbZUb6D1PmXqBWZDU2WvbvVs9o"
+		version    = byte(0x00)
+	)
+	return keys.WIFDecode(wifEncoded, version)
+}
+
+// getTX returns Invocation transaction with some random attributes in order to have different hashes.
+func getTX(t require.TestingT, wif *keys.WIF) *transaction.Transaction {
+	fromAddress := wif.PrivateKey.Address()
+	fromAddressHash, err := crypto.Uint160DecodeAddress(fromAddress)
+	require.NoError(t, err)
+
+	tx := &transaction.Transaction{
+		Type:    transaction.InvocationType,
+		Version: 1,
+		Data: &transaction.InvocationTX{
+			Script:  []byte{0x51},
+			Gas:     1,
+			Version: 1,
+		},
+		Attributes: []transaction.Attribute{},
+		Inputs:     []transaction.Input{},
+		Outputs:    []transaction.Output{},
+		Scripts:    []transaction.Witness{},
+		Trimmed:    false,
+	}
+	tx.Attributes = append(tx.Attributes,
+		transaction.Attribute{
+			Usage: transaction.Description,
+			Data:  []byte(randString(16)),
+		})
+	tx.Attributes = append(tx.Attributes,
+		transaction.Attribute{
+			Usage: transaction.Script,
+			Data:  fromAddressHash.BytesBE(),
+		})
+	return tx
+}
+
+// String returns a random string with the n as its length.
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(Int(32, 126))
+	}
+
+	return string(b)
+}
+
+// Int returns a random integer in [min,max).
+func Int(min, max int) int {
+	return min + rand.Intn(max-min)
+}
+
+// init is required for random initialization otherwise rand will use the same seed each time.
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,0 +1,147 @@
+package integration
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/CityOfZion/neo-go/pkg/core"
+	"github.com/CityOfZion/neo-go/pkg/core/transaction"
+	"github.com/CityOfZion/neo-go/pkg/io"
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/require"
+)
+
+// Main steps for testing are:
+// - prepare docker image with neo-go node or c# node
+// - start privatenet
+// - start docker nodeContainerReq
+// - create RPC client
+// - generate input for RPC client
+// - start sending txes to the node
+// - measure how much TX could be sent
+
+const (
+	// RPCPort for RPC calls to test nodes.
+	RPCPort = nat.Port("20331")
+	// NumberOfTx number of transactions to be generated.
+	NumberOfTx = 3000
+	// TimeoutInSeconds time in seconds to wait for test to finish.
+	TimeoutInSeconds = 500
+)
+
+// SendTXResponse struct for testing.
+type SendTXResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  bool   `json:"result"`
+	ID      int    `json:"id"`
+}
+
+// GetBlockCountResponse struct for testing.
+type GetBlockCountResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  int    `json:"result"`
+	ID      int    `json:"id"`
+}
+
+// GetBlockResponse struct for testing.
+type GetBlockResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Result  string `json:"result"`
+	ID      int    `json:"id"`
+}
+
+func TestIntegration(t *testing.T) {
+	// Comment t.Skip() to run this test. It's disabled so in CI it;s not running every time.
+	t.Skip()
+	callNode(t, RPCPort)
+}
+
+// makes a new RPC client and calls node by RPC.
+func callNode(t *testing.T, port nat.Port) {
+	client := NewRPCClient(port)
+	data := getTransactions(t, NumberOfTx)
+	startTime := uint32(time.Now().UTC().Unix())
+	// -1 since getBlockCount returns block count including first zero block
+	startBlockIndex := getBlockCount(t, client) - 1
+	log.Printf("Started test from block = %v at unix time = %v", startBlockIndex, startTime)
+	for _, tx := range data {
+		body := client.SendTX(tx, t)
+		var resp SendTXResponse
+		err := json.Unmarshal(body, &resp)
+		require.NoError(t, err)
+	}
+	log.Println("All transactions were sent")
+
+	lastBlockTimestamp := startTime
+	searchAllTX(t, client, startBlockIndex, data, &lastBlockTimestamp)
+
+	log.Printf("Sent %v transactions in %v seconds", NumberOfTx, lastBlockTimestamp-startTime)
+}
+
+// getBlockCount returns current block index.
+func getBlockCount(t *testing.T, client *RPCClient) int {
+	bodyBlockCount := client.GetBlockCount(t)
+	var respBlockCount GetBlockCountResponse
+	err := json.Unmarshal(bodyBlockCount, &respBlockCount)
+	require.NoError(t, err)
+	return respBlockCount.Result
+}
+
+// getBlock returns block by index.
+func getBlock(t *testing.T, client *RPCClient, index int) *core.Block {
+	bodyBlock := client.GetBlock(t, index)
+	var respBlock GetBlockResponse
+	err := json.Unmarshal(bodyBlock, &respBlock)
+	require.NoError(t, err)
+	decodedResp, _ := hex.DecodeString(respBlock.Result)
+	block := &core.Block{}
+	newReader := io.NewBinReaderFromBuf(decodedResp)
+	block.DecodeBinary(newReader)
+	return block
+}
+
+// searchAllTX performs search for all TX which were generated.
+// For searching used Hash of the transactions.
+func searchAllTX(t *testing.T, client *RPCClient, startBlockIndex int,
+	txToSearch []*transaction.Transaction, lastBlockTimestamp *uint32) {
+
+	allTX := txToSearch
+	timeout := time.After(TimeoutInSeconds * time.Second)
+	ticker := time.NewTicker(2 * time.Second)
+	counter := 0
+	passedBlocks := make(map[int]bool)
+	for {
+		select {
+		case <-timeout:
+			log.Fatal("timed out")
+			return
+		case tick := <-ticker.C:
+			log.Println("Tick at", tick)
+			log.Printf("Left to check: %v", len(allTX) - counter)
+			currentBlock := getBlockCount(t, client) - 1
+			if currentBlock > startBlockIndex && !passedBlocks[currentBlock] {
+				passedBlocks[currentBlock] = false
+				log.Printf("Current block height: %v", currentBlock)
+				block := getBlock(t, client, currentBlock)
+				*lastBlockTimestamp = block.Timestamp
+				for _, tx := range block.Transactions {
+					for _, txToSearch := range allTX {
+						if len(tx.Scripts) > 0 {
+							if tx.Hash() == txToSearch.Hash() {
+								counter ++
+							}
+						}
+					}
+				}
+				passedBlocks[currentBlock] = true
+				if len(allTX) == counter {
+					ticker.Stop()
+					return
+				}
+			}
+		}
+	}
+}

--- a/integration/performance_test.go
+++ b/integration/performance_test.go
@@ -1,17 +1,12 @@
 package integration
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/CityOfZion/neo-go/config"
 	"github.com/CityOfZion/neo-go/pkg/core"
 	"github.com/CityOfZion/neo-go/pkg/core/storage"
-	"github.com/CityOfZion/neo-go/pkg/core/transaction"
-	"github.com/CityOfZion/neo-go/pkg/crypto"
-	"github.com/CityOfZion/neo-go/pkg/crypto/keys"
 	"github.com/CityOfZion/neo-go/pkg/network"
-	"github.com/CityOfZion/neo-go/pkg/rpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,7 +26,7 @@ func BenchmarkTXPerformanceTest(t *testing.B) {
 
 	serverConfig := network.NewServerConfig(cfg)
 	server := network.NewServer(serverConfig, chain)
-	data := prepareData(t)
+	data := getTransactions(t, t.N)
 	t.ResetTimer()
 
 	for n := 0; n < t.N; n++ {
@@ -43,76 +38,4 @@ func BenchmarkTXPerformanceTest(t *testing.B) {
 		}
 	}
 	chain.Close()
-}
-
-func prepareData(t *testing.B) []*transaction.Transaction {
-	var data []*transaction.Transaction
-
-	wif := getWif(t)
-
-	for n := 0; n < t.N; n++ {
-		tx := getTX(t, wif)
-		require.NoError(t, rpc.SignTx(tx, wif))
-		data = append(data, tx)
-	}
-	return data
-}
-
-// getWif returns Wif.
-func getWif(t *testing.B) *keys.WIF {
-	var (
-		wifEncoded = "KxhEDBQyyEFymvfJD96q8stMbJMbZUb6D1PmXqBWZDU2WvbvVs9o"
-		version    = byte(0x00)
-	)
-	wif, err := keys.WIFDecode(wifEncoded, version)
-	require.NoError(t, err)
-	return wif
-}
-
-// getTX returns Invocation transaction with some random attributes in order to have different hashes.
-func getTX(t *testing.B, wif *keys.WIF) *transaction.Transaction {
-	fromAddress := wif.PrivateKey.Address()
-	fromAddressHash, err := crypto.Uint160DecodeAddress(fromAddress)
-	require.NoError(t, err)
-
-	tx := &transaction.Transaction{
-		Type:    transaction.InvocationType,
-		Version: 0,
-		Data: &transaction.InvocationTX{
-			Script:  []byte{0x51},
-			Gas:     1,
-			Version: 1,
-		},
-		Attributes: []transaction.Attribute{},
-		Inputs:     []transaction.Input{},
-		Outputs:    []transaction.Output{},
-		Scripts:    []transaction.Witness{},
-		Trimmed:    false,
-	}
-	tx.Attributes = append(tx.Attributes,
-		transaction.Attribute{
-			Usage: transaction.Description,
-			Data:  []byte(randString(10)),
-		})
-	tx.Attributes = append(tx.Attributes,
-		transaction.Attribute{
-			Usage: transaction.Script,
-			Data:  fromAddressHash.BytesBE(),
-		})
-	return tx
-}
-
-// String returns a random string with the n as its length.
-func randString(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = byte(Int(65, 90))
-	}
-
-	return string(b)
-}
-
-// Int returns a random integer in [min,max).
-func Int(min, max int) int {
-	return min + rand.Intn(max-min)
 }

--- a/integration/rpcClient.go
+++ b/integration/rpcClient.go
@@ -1,0 +1,70 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/CityOfZion/neo-go/pkg/core/transaction"
+	"github.com/CityOfZion/neo-go/pkg/io"
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
+)
+
+// RPCClient used in integration test.
+type RPCClient struct {
+	addr string
+	port nat.Port
+}
+
+// NewRPCClient creates new client for RPC communications.
+func NewRPCClient(port nat.Port) *RPCClient {
+	addr := "http://127.0.0.1" + ":" + port.Port()
+	return &RPCClient{port: port, addr: addr}
+}
+
+// SendTX sends transaction.
+func (c *RPCClient) SendTX(tx *transaction.Transaction, t *testing.T) []byte {
+	writer := io.NewBufBinWriter()
+	tx.EncodeBinary(writer.BinWriter)
+	rpc := fmt.Sprintf(`{"jsonrpc": "2.0", "id": 1, "method": "sendrawtransaction", "params": ["%s"]}`, hex.EncodeToString(writer.Bytes()))
+	return c.doRPCCall(rpc, t)
+}
+
+// GetBlock sends getblock RPC request.
+func (c *RPCClient) GetBlock(t *testing.T, index int) []byte {
+	rpc := fmt.Sprintf(`{"jsonrpc": "2.0", "id": 1, "method": "getblock", "params": [%v]}`, index)
+	return c.doRPCCall(rpc, t)
+}
+
+// GetBlockCount send getblockcount RPC request.
+func (c *RPCClient) GetBlockCount(t *testing.T) []byte {
+	rpc := fmt.Sprintf(`{"jsonrpc": "2.0", "id": 1, "method": "getblockcount", "params": []}`)
+	return c.doRPCCall(rpc, t)
+}
+
+func (c *RPCClient) doRPCCall(rpcCall string, t *testing.T) []byte {
+	req, err := http.NewRequest("POST", c.addr, strings.NewReader(rpcCall))
+	if err != nil {
+		log.Fatalf("can't create request %s", err)
+		return nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := new(http.Client)
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("error after calling rpc server %s", err)
+		return nil
+	}
+	if resp != nil {
+		body, err := ioutil.ReadAll(resp.Body)
+		assert.NoErrorf(t, err, "could not read response from the request: %s", rpcCall)
+		return bytes.TrimSpace(body)
+	}
+	return nil
+}

--- a/integration/runIntegration.sh
+++ b/integration/runIntegration.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+cd ..
+make env_up
+docker run --rm --network neo_go_network -p 20331-20332:20331-20332 -p 2112:2112 --name neo-go-integration --ip 172.200.0.5 -t nspccdev/neo-go-integration:0.70.1 &
+(sleep 5s
+cd integration || exit
+go test -run TestIntegration
+)
+docker stop neo-go-integration
+make env_down


### PR DESCRIPTION
Requires  #575 changes

- Add runIntegration.sh which could be used ro tun test
- Add integration test which calls RPC with generated Transactions
- Update Readme instruction how to use

How to use:
This test requires to have:
- privatenet running
- node running

To run privatenet use this command `$make env_up`.
There are several nodes could be used (neo-go, neo-sharp, ...)
- For neo-go node use docker image `nspccdev/neo-go-integration` which is built exactly for running with local privatenet.

neo-go:
`$docker run --rm --network neo_go_network -p 20331-20332:20331-20332 -p 2112:2112 --name neo-go-integraion --ip 172.200.0.5 -t nspccdev/neo-go-integration
`

After that use integration test `integration_test.go`.

Issue: as of now C# node can't sync with neo-go private network

Results with neo go:

2019/12/24 23:11:49 Sent 200 transactions in 5 seconds
2019/12/24 23:18:23 Sent 500 transactions in 4 seconds
2019/12/24 23:39:34 Sent 3000 transactions in 29 seconds