### PR TITLE
consensus: return nil interface from getTx

### DIFF
--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -253,7 +253,13 @@ func (s *service) getTx(h util.Uint256) block.Transaction {
 
 	tx, _, _ := s.Config.Chain.GetTransaction(h)
 
-	return tx
+	// this is needed because in case of absent tx dBFT expects to
+	// get nil interface, not a nil pointer to any concrete type
+	if tx != nil {
+		return tx
+	}
+
+	return nil
 }
 
 func (s *service) verifyBlock(b block.Block) bool {

--- a/pkg/consensus/consensus_test.go
+++ b/pkg/consensus/consensus_test.go
@@ -56,6 +56,37 @@ func TestService_ValidatePayload(t *testing.T) {
 	})
 }
 
+func TestService_getTx(t *testing.T) {
+	srv := newTestService(t)
+
+	t.Run("transaction in mempool", func(t *testing.T) {
+		tx := newMinerTx(1234)
+		h := tx.Hash()
+
+		require.Equal(t, nil, srv.getTx(h))
+
+		item := core.NewPoolItem(tx, new(feer))
+		srv.Chain.GetMemPool().TryAdd(h, item)
+
+		got := srv.getTx(h)
+		require.NotNil(t, got)
+		require.Equal(t, h, got.Hash())
+	})
+
+	t.Run("transaction in local cache", func(t *testing.T) {
+		tx := newMinerTx(4321)
+		h := tx.Hash()
+
+		require.Equal(t, nil, srv.getTx(h))
+
+		srv.txx.Add(tx)
+
+		got := srv.getTx(h)
+		require.NotNil(t, got)
+		require.Equal(t, h, got.Hash())
+	})
+}
+
 func TestService_OnPayload(t *testing.T) {
 	srv := newTestService(t)
 


### PR DESCRIPTION
This is a possible reason for a panic in certain circumstances (thanks @im-kulikov):
```
goroutine 226 [running]:
github.com/CityOfZion/neo-go/pkg/core.(*Blockchain).GetValidators(0xc00013e160, 0xc000cf4000, 0x24f7, 0x24f7, 0xd1a35d37ae62d3b6, 0xc0038bb5b0, 0x40e40e, 0xc2ea00, 0xc003b9ad48)
        github.com/CityOfZion/neo-go@/pkg/core/blockchain.go:1180 +0x7fe
github.com/CityOfZion/neo-go/pkg/consensus.(*service).getValidators(0xc00078efc0, 0xc004420000, 0x24f7, 0x24f7, 0xb05110, 0xdb8080, 0xc003b9ac60)
        github.com/CityOfZion/neo-go@/pkg/consensus/consensus.go:367 +0x1fc
github.com/nspcc-dev/dbft.(*DBFT).processMissingTx(0xc000154280)
        github.com/nspcc-dev/dbft@v0.0.0-20191213082456-c81c7a796775/dbft.go:335 +0x25d
github.com/nspcc-dev/dbft.(*DBFT).onPrepareRequest(0xc000154280, 0xdd8da0, 0xc001817b00)
        github.com/nspcc-dev/dbft@v0.0.0-20191213082456-c81c7a796775/dbft.go:309 +0x863
github.com/nspcc-dev/dbft.(*DBFT).OnReceive(0xc000154280, 0xdd8da0, 0xc001817b00)
        github.com/nspcc-dev/dbft@v0.0.0-20191213082456-c81c7a796775/dbft.go:234 +0xf43
github.com/CityOfZion/neo-go/pkg/consensus.(*service).eventLoop(0xc00078efc0)
        github.com/CityOfZion/neo-go@/pkg/consensus/consensus.go:160 +0x2d6
created by github.com/CityOfZion/neo-go/pkg/consensus.(*service).Start
        github.com/CityOfZion/neo-go@/pkg/consensus/consensus.go:149 +0x51
```