### PR TITLE
Wallet dump and keys/wallet API improvements

### DIFF
--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -14,7 +14,6 @@ import (
 	"github.com/CityOfZion/neo-go/pkg/smartcontract"
 	"github.com/CityOfZion/neo-go/pkg/util"
 	"github.com/CityOfZion/neo-go/pkg/vm/opcode"
-	"github.com/CityOfZion/neo-go/pkg/wallet"
 	"github.com/nspcc-dev/dbft"
 	"github.com/nspcc-dev/dbft/block"
 	"github.com/nspcc-dev/dbft/crypto"
@@ -178,13 +177,9 @@ func (s *service) validatePayload(p *Payload) bool {
 }
 
 func getKeyPair(cfg *config.WalletConfig) (crypto.PrivateKey, crypto.PublicKey) {
-	acc, err := wallet.DecryptAccount(cfg.Path, cfg.Password)
+	// TODO: replace with wallet opening from the given path (#588)
+	key, err := keys.NEP2Decrypt(cfg.Path, cfg.Password)
 	if err != nil {
-		return nil, nil
-	}
-
-	key := acc.PrivateKey()
-	if key == nil {
 		return nil, nil
 	}
 

--- a/pkg/crypto/keys/nep2_test.go
+++ b/pkg/crypto/keys/nep2_test.go
@@ -43,3 +43,39 @@ func TestNEP2Decrypt(t *testing.T) {
 		assert.Equal(t, testCase.Address, address)
 	}
 }
+
+func TestNEP2DecryptErrors(t *testing.T) {
+	p := "qwerty"
+
+	// Not a base58-encoded value
+	s := "qazwsx"
+	_, err := NEP2Decrypt(s, p)
+	assert.Error(t, err)
+
+	// Valid base58, but not a NEP-2 format.
+	s = "KxhEDBQyyEFymvfJD96q8stMbJMbZUb6D1PmXqBWZDU2WvbvVs9o"
+	_, err = NEP2Decrypt(s, p)
+	assert.Error(t, err)
+}
+
+func TestValidateNEP2Format(t *testing.T) {
+	// Wrong length.
+	s := []byte("gobbledygook")
+	assert.Error(t, validateNEP2Format(s))
+
+	// Wrong header 1.
+	s = []byte("gobbledygookgobbledygookgobbledygookgob")
+	assert.Error(t, validateNEP2Format(s))
+
+	// Wrong header 2.
+	s[0] = 0x01
+	assert.Error(t, validateNEP2Format(s))
+
+	// Wrong header 3.
+	s[1] = 0x42
+	assert.Error(t, validateNEP2Format(s))
+
+	// OK
+	s[2] = 0xe0
+	assert.NoError(t, validateNEP2Format(s))
+}

--- a/pkg/crypto/keys/nep2_test.go
+++ b/pkg/crypto/keys/nep2_test.go
@@ -27,18 +27,13 @@ func TestNEP2Encrypt(t *testing.T) {
 
 func TestNEP2Decrypt(t *testing.T) {
 	for _, testCase := range keytestcases.Arr {
-
-		privKeyString, err := NEP2Decrypt(testCase.EncryptedWif, testCase.Passphrase)
+		privKey, err := NEP2Decrypt(testCase.EncryptedWif, testCase.Passphrase)
 		if testCase.Invalid {
 			assert.Error(t, err)
 			continue
 		}
 
 		assert.Nil(t, err)
-
-		privKey, err := NewPrivateKeyFromWIF(privKeyString)
-		assert.Nil(t, err)
-
 		assert.Equal(t, testCase.PrivateKey, privKey.String())
 
 		wif := privKey.WIF()

--- a/pkg/wallet/account.go
+++ b/pkg/wallet/account.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"errors"
+
 	"github.com/CityOfZion/neo-go/pkg/crypto/keys"
 	"github.com/CityOfZion/neo-go/pkg/util"
 )
@@ -60,14 +62,16 @@ func NewAccount() (*Account, error) {
 	return newAccountFromPrivateKey(priv), nil
 }
 
-// DecryptAccount decrypts the encryptedWIF with the given passphrase and
-// return the decrypted Account.
-func DecryptAccount(encryptedWIF, passphrase string) (*Account, error) {
-	key, err := keys.NEP2Decrypt(encryptedWIF, passphrase)
-	if err != nil {
-		return nil, err
+// Decrypt decrypts the EncryptedWIF with the given passphrase returning error
+// if anything goes wrong.
+func (a *Account) Decrypt(passphrase string) error {
+	var err error
+
+	if a.EncryptedWIF == "" {
+		return errors.New("no encrypted wif in the account")
 	}
-	return newAccountFromPrivateKey(key), nil
+	a.privateKey, err = keys.NEP2Decrypt(a.EncryptedWIF, passphrase)
+	return err
 }
 
 // Encrypt encrypts the wallet's PrivateKey with the given passphrase

--- a/pkg/wallet/account.go
+++ b/pkg/wallet/account.go
@@ -63,11 +63,11 @@ func NewAccount() (*Account, error) {
 // DecryptAccount decrypts the encryptedWIF with the given passphrase and
 // return the decrypted Account.
 func DecryptAccount(encryptedWIF, passphrase string) (*Account, error) {
-	wif, err := keys.NEP2Decrypt(encryptedWIF, passphrase)
+	key, err := keys.NEP2Decrypt(encryptedWIF, passphrase)
 	if err != nil {
 		return nil, err
 	}
-	return NewAccountFromWIF(wif)
+	return newAccountFromPrivateKey(key), nil
 }
 
 // Encrypt encrypts the wallet's PrivateKey with the given passphrase

--- a/pkg/wallet/account_test.go
+++ b/pkg/wallet/account_test.go
@@ -10,16 +10,9 @@ import (
 )
 
 func TestNewAccount(t *testing.T) {
-	for _, testCase := range keytestcases.Arr {
-		acc, err := NewAccountFromWIF(testCase.Wif)
-		if testCase.Invalid {
-			assert.Error(t, err)
-			continue
-		}
-
-		assert.NoError(t, err)
-		compareFields(t, testCase, acc)
-	}
+	acc, err := NewAccount()
+	require.NoError(t, err)
+	require.NotNil(t, acc)
 }
 
 func TestDecryptAccount(t *testing.T) {

--- a/pkg/wallet/account_test.go
+++ b/pkg/wallet/account_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/CityOfZion/neo-go/pkg/internal/keytestcases"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewAccount(t *testing.T) {
@@ -23,15 +24,21 @@ func TestNewAccount(t *testing.T) {
 
 func TestDecryptAccount(t *testing.T) {
 	for _, testCase := range keytestcases.Arr {
-		acc, err := DecryptAccount(testCase.EncryptedWif, testCase.Passphrase)
+		acc := &Account{EncryptedWIF: testCase.EncryptedWif}
+		assert.Nil(t, acc.PrivateKey())
+		err := acc.Decrypt(testCase.Passphrase)
 		if testCase.Invalid {
 			assert.Error(t, err)
 			continue
 		}
 
 		assert.NoError(t, err)
-		compareFields(t, testCase, acc)
+		assert.NotNil(t, acc.PrivateKey())
+		assert.Equal(t, testCase.PrivateKey, acc.privateKey.String())
 	}
+	// No encrypted key.
+	acc := &Account{}
+	require.Error(t, acc.Decrypt("qwerty"))
 }
 
 func TestNewFromWif(t *testing.T) {


### PR DESCRIPTION
### Problem

Unimplemented `open` command, bad API, #26.

### Solution

I don't think `open` is actually of any use for our wallet, so I've renamed it to `dump` and implemented it fixing some things along the way. It's a part of #26, but I'm not going to implement more of it at the moment, it's just that I had this patchset half-baked already from the previous experiments.