### PR TITLE
consensus: close chain in tests

### DIFF
--- a/pkg/consensus/consensus_test.go
+++ b/pkg/consensus/consensus_test.go
@@ -29,6 +29,7 @@ func TestNewService(t *testing.T) {
 	require.NotPanics(t, func() { txx = srv.getVerifiedTx(1) })
 	require.Len(t, txx, 2)
 	require.Equal(t, tx, txx[1])
+	srv.Chain.Close()
 }
 
 func TestService_GetVerified(t *testing.T) {
@@ -76,6 +77,7 @@ func TestService_GetVerified(t *testing.T) {
 		require.Contains(t, txx, txs[1])
 		require.NotContains(t, txx, txs[2])
 	})
+	srv.Chain.Close()
 }
 
 func TestService_ValidatePayload(t *testing.T) {
@@ -105,6 +107,7 @@ func TestService_ValidatePayload(t *testing.T) {
 		require.NoError(t, p.Sign(priv))
 		require.True(t, srv.validatePayload(p))
 	})
+	srv.Chain.Close()
 }
 
 func TestService_getTx(t *testing.T) {
@@ -136,6 +139,7 @@ func TestService_getTx(t *testing.T) {
 		require.NotNil(t, got)
 		require.Equal(t, h, got.Hash())
 	})
+	srv.Chain.Close()
 }
 
 func TestService_OnPayload(t *testing.T) {
@@ -159,6 +163,7 @@ func TestService_OnPayload(t *testing.T) {
 	// payload has already been received
 	srv.OnPayload(p)
 	shouldNotReceive(t, srv.messages)
+	srv.Chain.Close()
 }
 
 func shouldReceive(t *testing.T, ch chan Payload) {


### PR DESCRIPTION
Avoid test failures like this one:
```
=== RUN   TestService_OnPayload
==================
WARNING: DATA RACE
Read at 0x00c00015a843 by goroutine 112:
  testing.(*common).logDepth()
      /usr/local/go/src/testing/testing.go:665 +0xa1
  testing.(*common).Logf()
      /usr/local/go/src/testing/testing.go:658 +0x8f
  testing.(*T).Logf()
      <autogenerated>:1 +0x75
  go.uber.org/zap/zaptest.testingWriter.Write()
      /go/pkg/mod/go.uber.org/zap@v1.10.0/zaptest/logger.go:130 +0x11f
  go.uber.org/zap/zaptest.(*testingWriter).Write()
      <autogenerated>:1 +0xa9
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /go/pkg/mod/go.uber.org/zap@v1.10.0/zapcore/core.go:90 +0x1c3
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /go/pkg/mod/go.uber.org/zap@v1.10.0/zapcore/entry.go:215 +0x1e7
  go.uber.org/zap.(*Logger).Info()
      /go/pkg/mod/go.uber.org/zap@v1.10.0/logger.go:187 +0x95
  github.com/CityOfZion/neo-go/pkg/core.(*Blockchain).persist()
      /go/src/github.com/CityOfZion/neo-go/pkg/core/blockchain.go:720 +0x6bb
  github.com/CityOfZion/neo-go/pkg/core.(*Blockchain).Run.func2()
      /go/src/github.com/CityOfZion/neo-go/pkg/core/blockchain.go:228 +0x53

Previous write at 0x00c00015a843 by goroutine 98:
  testing.tRunner.func1()
      /usr/local/go/src/testing/testing.go:900 +0x353
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:913 +0x1bb

Goroutine 112 (running) created at:
  github.com/CityOfZion/neo-go/pkg/core.(*Blockchain).Run()
      /go/src/github.com/CityOfZion/neo-go/pkg/core/blockchain.go:227 +0x264

Goroutine 98 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:162 +0x337
==================
--- FAIL: TestService_OnPayload (4.11s)
```
https://circleci.com/gh/nspcc-dev/neo-go/9813