### PR TITLE
Fix SIGSEGV on bad consensus config

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -321,7 +321,10 @@ func startServer(ctx *cli.Context) error {
 		return err
 	}
 
-	server := network.NewServer(serverConfig, chain, log)
+	server, err := network.NewServer(serverConfig, chain, log)
+	if err != nil {
+		return cli.NewExitError(fmt.Errorf("failed to create network server: %v", err), 1)
+	}
 	rpcServer := rpc.NewServer(chain, cfg.ApplicationConfiguration.RPC, server, log)
 	errChan := make(chan error)
 

--- a/integration/performance_test.go
+++ b/integration/performance_test.go
@@ -32,7 +32,8 @@ func BenchmarkTXPerformanceTest(t *testing.B) {
 	go chain.Run()
 
 	serverConfig := network.NewServerConfig(cfg)
-	server := network.NewServer(serverConfig, chain, logger)
+	server, err := network.NewServer(serverConfig, chain, logger)
+	require.NoError(t, err, "could not create server")
 	data := prepareData(t)
 	t.ResetTimer()
 

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -86,9 +86,9 @@ func randomID() uint32 {
 }
 
 // NewServer returns a new Server, initialized with the given configuration.
-func NewServer(config ServerConfig, chain core.Blockchainer, log *zap.Logger) *Server {
+func NewServer(config ServerConfig, chain core.Blockchainer, log *zap.Logger) (*Server, error) {
 	if log == nil {
-		return nil
+		return nil, errors.New("logger is a required parameter")
 	}
 
 	s := &Server{
@@ -117,7 +117,7 @@ func NewServer(config ServerConfig, chain core.Blockchainer, log *zap.Logger) *S
 		TimePerBlock: config.TimePerBlock,
 	})
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	s.consensus = srv
@@ -149,7 +149,7 @@ func NewServer(config ServerConfig, chain core.Blockchainer, log *zap.Logger) *S
 		s.transport,
 	)
 
-	return s
+	return s, nil
 }
 
 // ID returns the servers ID.

--- a/pkg/rpc/server_helper_test.go
+++ b/pkg/rpc/server_helper_test.go
@@ -201,7 +201,8 @@ func initServerWithInMemoryChain(t *testing.T) (*core.Blockchain, http.HandlerFu
 	}
 
 	serverConfig := network.NewServerConfig(cfg)
-	server := network.NewServer(serverConfig, chain, logger)
+	server, err := network.NewServer(serverConfig, chain, logger)
+	require.NoError(t, err)
 	rpcServer := NewServer(chain, cfg.ApplicationConfiguration.RPC, server, logger)
 	handler := http.HandlerFunc(rpcServer.requestHandler)
 


### PR DESCRIPTION
It can return nil in two cases, so we're better return an error and handle
it.