### PR TITLE
compiler: support for loops with no init/post condition

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -585,7 +585,9 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 		)
 
 		// Walk the initializer and condition.
-		ast.Walk(c, n.Init)
+		if n.Init != nil {
+			ast.Walk(c, n.Init)
+		}
 
 		// Set label and walk the condition.
 		c.setLabel(fstart)
@@ -596,7 +598,9 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 
 		// Walk body followed by the iterator (post stmt).
 		ast.Walk(c, n.Body)
-		ast.Walk(c, n.Post)
+		if n.Post != nil {
+			ast.Walk(c, n.Post)
+		}
 
 		// Jump back to condition.
 		emitJmp(c.prog.BinWriter, opcode.JMP, int16(fstart))

--- a/pkg/compiler/for_test.go
+++ b/pkg/compiler/for_test.go
@@ -370,3 +370,30 @@ func TestForLoopBigIter(t *testing.T) {
 	`
 	eval(t, src, big.NewInt(99999))
 }
+
+func TestForLoopNoInit(t *testing.T) {
+	src := `
+	package foo
+		func Main() int {
+			i := 0
+			for ; i < 10; i++ {
+			}
+			return i
+		}
+	`
+	eval(t, src, big.NewInt(10))
+}
+
+func TestForLoopNoPost(t *testing.T) {
+	src := `
+	package foo
+		func Main() int {
+			i := 0
+			for i < 10 {
+				i++
+			}
+			return i
+		}
+	`
+	eval(t, src, big.NewInt(10))
+}


### PR DESCRIPTION
Make it possible to use `for` loop with a single condition.
