### PR TITLE
compiler: support variables in slice literals

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -365,7 +365,7 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 				return nil
 			}
 			for i := ln - 1; i >= 0; i-- {
-				c.emitLoadConst(c.typeInfo.Types[n.Elts[i]])
+				ast.Walk(c, n.Elts[i])
 			}
 			emitInt(c.prog.BinWriter, int64(ln))
 			emitOpcode(c.prog.BinWriter, opcode.PACK)

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -45,9 +45,32 @@ var sliceTestCases = []testCase{
 		`,
 		big.NewInt(9),
 	},
+	{
+		"slice literals with variables",
+		`
+		package foo
+		func Main() int {
+			elem := 7
+			a := []int{6, elem, 8}
+			return a[1]
+		}
+		`,
+		big.NewInt(7),
+	},
+	{
+		"slice literals with expressions",
+		`
+		package foo
+		func Main() int {
+			elem := []int{3, 7}
+			a := []int{6, elem[1]*2+1, 24}
+			return a[1]
+		}
+		`,
+		big.NewInt(15),
+	},
 }
 
 func TestSliceOperations(t *testing.T) {
 	runTestCases(t, sliceTestCases)
 }
-


### PR DESCRIPTION
Support using variables in slice literals.
Right know something like is necessary:
```golang
var nums []int
nums = append(nums, first)
nums = append(nums, second)
```
After this PR it will be possible to just:
```golang
nums := []int{first, second}
```