### PR TITLE
Prepare build and publish images

### DIFF
--- a/.docker/privnet-entrypoint.sh
+++ b/.docker/privnet-entrypoint.sh
@@ -1,6 +1,19 @@
 #!/bin/sh
-if test -f /privnet-blocks.acc.gz; then
-	gunzip /privnet-blocks.acc.gz
-	/usr/bin/neo-go db restore -i /privnet-blocks.acc
+
+BIN=/usr/bin/neo-go
+
+if [ -z "$ACC"]; then
+  ACC=/6000-privnet-blocks.acc.gz
 fi
-/usr/bin/neo-go "$@"
+
+case $@ in
+  "node"*)
+  echo "=> Try to restore blocks before running node"
+  if test -f $ACC; then
+    gunzip --stdout /$ACC > /privnet.acc
+    ${BIN} db restore -p --config-path /config -i /privnet.acc
+  fi
+    ;;
+esac
+
+${BIN} "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ LABEL version=$VERSION
 WORKDIR /
 
 COPY --from=builder /neo-go/config /config
-COPY --from=builder /neo-go/.docker/6000-privnet-blocks.acc.gz /privnet-blocks.acc.gz
+COPY --from=builder /neo-go/.docker/6000-privnet-blocks.acc.gz /6000-privnet-blocks.acc.gz
+COPY --from=builder /neo-go/.docker/1600-privnet-blocks-single.acc.gz /1600-privnet-blocks-single.acc.gz
 COPY --from=builder /neo-go/.docker/privnet-entrypoint.sh /usr/bin/privnet-entrypoint.sh
 COPY --from=builder /go/bin/neo-go /usr/bin/neo-go
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ REPO ?= "$(shell go list -m)"
 VERSION ?= "$(shell git describe --tags 2>/dev/null | sed 's/^v//')"
 BUILD_FLAGS = "-X $(REPO)/config.Version=$(VERSION)"
 
+IMAGE_REPO=nspccdev/neo-go
+
 # All of the targets are phony here because we don't really use make dependency
 # tracking for files
 .PHONY: build deps image check-version clean-cluster push-tag push-to-registry \
@@ -48,8 +50,13 @@ postinst: install
 
 image: deps
 	@echo "=> Building image"
-	@docker build -t cityofzion/neo-go:latest --build-arg REPO=$(REPO) --build-arg VERSION=$(VERSION) .
-	@docker build -t cityofzion/neo-go:$(VERSION) --build-arg REPO=$(REPO) --build-arg VERSION=$(VERSION) .
+	@docker build -t $(IMAGE_REPO):latest --build-arg REPO=$(REPO) --build-arg VERSION=$(VERSION) .
+	@docker build -t $(IMAGE_REPO):$(VERSION) --build-arg REPO=$(REPO) --build-arg VERSION=$(VERSION) .
+
+image-push:
+	@echo "=> Publish image"
+	@docker push $(IMAGE_REPO):latest
+	@docker push $(IMAGE_REPO):$(VERSION)
 
 check-version:
 	git fetch && (! git rev-list ${VERSION})


### PR DESCRIPTION
- Update command to build and publish images
  - Use nspcc-dev docker hub repository
  - Add command to publish neo-go images
- Add a single node chain dump to image (`1600-privnet-blocks-single.acc.gz`)
- Add the possibility to import a different dump of chains
  - import dump only if `node` subcommand passed
  - ACC env variable default value is `6000-privnet-blocks.acc.gz`
  - ACC env variable can be declared in `docker-compose`
  - ACC env variable can be one of:
    - `/6000-privnet-blocks.acc.gz`
    - `/1600-privnet-blocks-single.acc.gz`
    - custom path to dump of blockchain