### PR TITLE
compiler: implement switch statement support

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -114,8 +114,7 @@ func (c *codegen) emitStoreLocal(pos int) {
 	}
 
 	emitInt(c.prog.BinWriter, int64(pos))
-	emitInt(c.prog.BinWriter, 2)
-	emitOpcode(c.prog.BinWriter, opcode.ROLL)
+	emitOpcode(c.prog.BinWriter, opcode.ROT)
 	emitOpcode(c.prog.BinWriter, opcode.SETITEM)
 }
 

--- a/pkg/compiler/switch_test.go
+++ b/pkg/compiler/switch_test.go
@@ -1,0 +1,138 @@
+package compiler_test
+
+import (
+	"math/big"
+	"testing"
+)
+
+var switchTestCases = []testCase{
+	{
+		"simple switch success",
+		`package main
+		func Main() int {
+			a := 5
+			switch a {
+			case 5: return 2
+			}
+			return 1
+		}`,
+		big.NewInt(2),
+	},
+	{
+		"simple switch fail",
+		`package main
+		func Main() int {
+			a := 6
+			switch a {
+			case 5:
+				return 2
+			}
+			return 1
+		}`,
+		big.NewInt(1),
+	},
+	{
+		"multiple cases success",
+		`package main
+		func Main() int {
+			a := 6
+			switch a {
+			case 5: return 2
+			case 6: return 3
+			}
+			return 1
+		}`,
+		big.NewInt(3),
+	},
+	{
+		"multiple cases fail",
+		`package main
+		func Main() int {
+			a := 7
+			switch a {
+			case 5: return 2
+			case 6: return 3
+			}
+			return 1
+		}`,
+		big.NewInt(1),
+	},
+	{
+		"default case",
+		`package main
+		func Main() int {
+			a := 7
+			switch a {
+			case 5: return 2
+			case 6: return 3
+			default: return 4
+			}
+			return 1
+		}`,
+		big.NewInt(4),
+	},
+	{
+		"empty case before default",
+		`package main
+		func Main() int {
+			a := 6
+			switch a {
+			case 5: return 2
+			case 6:
+			default: return 4
+			}
+			return 1
+		}`,
+		big.NewInt(1),
+	},
+	{
+		"expression in case clause",
+		`package main
+		func Main() int {
+			a := 6
+			b := 3
+			switch a {
+			case 5: return 2
+			case b*3-3: return 3
+			}
+			return 1
+		}`,
+		big.NewInt(3),
+	},
+	{
+		"multiple expressions in case",
+		`package main
+		func Main() int {
+			a := 8
+			b := 3
+			switch a {
+			case 5: return 2
+			case b*3-3, 7, 8: return 3
+			}
+			return 1
+		}`,
+		big.NewInt(3),
+	},
+	{
+		"string switch",
+		`package main
+		func Main() int {
+			name := "Valera"
+			switch name {
+			case "Misha": return 2
+			case "Katya", "Dima": return 3
+			case "Lera", "Valer" + "a": return 4
+			}
+			return 1
+		}`,
+		big.NewInt(4),
+	},
+}
+
+func TestSwitch(t *testing.T) {
+	for _, tc := range switchTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			eval(t, tc.src, tc.result)
+		})
+	}
+}


### PR DESCRIPTION
Most of the time writing something like
```golang
switch operation {
case "Add":
    ...
case "Remove":
    ...
}
```
is more readable than `if-then-else` chain. This PR implements basic support for `switch` statements.
Implements 1 & 2 from #628 .