### PR TITLE
compiler: fix a bug with assignment to underscore

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -253,8 +253,12 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 						ast.Walk(c, n.Rhs[i])
 					}
 
-					l := c.scope.loadLocal(t.Name)
-					c.emitStoreLocal(l)
+					if t.Name == "_" {
+						emitOpcode(c.prog.BinWriter, opcode.DROP)
+					} else {
+						l := c.scope.loadLocal(t.Name)
+						c.emitStoreLocal(l)
+					}
 				}
 
 			case *ast.SelectorExpr:

--- a/pkg/compiler/return_test.go
+++ b/pkg/compiler/return_test.go
@@ -37,6 +37,21 @@ func TestMultipleReturn2(t *testing.T) {
 	eval(t, src, big.NewInt(9))
 }
 
+func TestMultipleReturnUnderscore(t *testing.T) {
+	src := `
+		package hello
+		func f3() (int, int, int) {
+			return 5, 6, 7
+		}
+
+		func Main() int {
+			a, _, c := f3()
+			return a+c
+		}
+	`
+	eval(t, src, big.NewInt(12))
+}
+
 func TestMultipleReturnWithArg(t *testing.T) {
 	src := `
 		package hello


### PR DESCRIPTION
When using underscore it does not appear in the list of local variables, so it can't be assigned.
In this commit the value is dropped.