### PR TITLE
rpc: fix getaccountstate/getunspents for unknown addresses

### DIFF
--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/CityOfZion/neo-go/config"
 	"github.com/CityOfZion/neo-go/pkg/core"
+	"github.com/CityOfZion/neo-go/pkg/core/state"
 	"github.com/CityOfZion/neo-go/pkg/core/transaction"
 	"github.com/CityOfZion/neo-go/pkg/io"
 	"github.com/CityOfZion/neo-go/pkg/network"
@@ -320,7 +321,11 @@ func (s *Server) getAccountState(reqParams Params, unspents bool) (interface{}, 
 		return nil, errInvalidParams
 	} else if scriptHash, err := param.GetUint160FromAddress(); err != nil {
 		return nil, errInvalidParams
-	} else if as := s.chain.GetAccountState(scriptHash); as != nil {
+	} else {
+		as := s.chain.GetAccountState(scriptHash)
+		if as == nil {
+			as = state.NewAccount(scriptHash)
+		}
 		if unspents {
 			str, err := param.GetString()
 			if err != nil {
@@ -330,8 +335,6 @@ func (s *Server) getAccountState(reqParams Params, unspents bool) (interface{}, 
 		} else {
 			results = wrappers.NewAccountState(as)
 		}
-	} else {
-		results = "Invalid public account address"
 	}
 	return results, resultsErr
 }

--- a/pkg/rpc/server_test.go
+++ b/pkg/rpc/server_test.go
@@ -50,9 +50,15 @@ var rpcTestCases = map[string][]rpcTestCase{
 			},
 		},
 		{
-			name:   "negative",
+			name:   "positive null",
 			params: `["AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y"]`,
-			result: func(e *executor) interface{} { return "Invalid public account address" },
+			result: func(e *executor) interface{} { return &GetAccountStateResponse{} },
+			check: func(t *testing.T, e *executor, result interface{}) {
+				res, ok := result.(*GetAccountStateResponse)
+				require.True(t, ok)
+				assert.Equal(t, 0, len(res.Result.Balances))
+				assert.Equal(t, false, res.Result.Frozen)
+			},
 		},
 		{
 			name:   "no params",
@@ -235,9 +241,14 @@ var rpcTestCases = map[string][]rpcTestCase{
 			},
 		},
 		{
-			name:   "negative",
+			name:   "positive null",
 			params: `["AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y"]`,
-			result: func(e *executor) interface{} { return "Invalid public account address" },
+			result: func(e *executor) interface{} { return &GetUnspents{} },
+			check: func(t *testing.T, e *executor, result interface{}) {
+				res, ok := result.(*GetUnspents)
+				require.True(t, ok)
+				require.Equal(t, 0, len(res.Result.Balance))
+			},
 		},
 	},
 	"getversion": {


### PR DESCRIPTION
Returning error string as a result (not an error) is utterly wrong, but C#
implementation just returns a zero balance for unknown addresses, so we should
follow that.
