### PR TITLE
compiler: do not store constants as variables

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -138,7 +138,11 @@ func (c *codegen) convertGlobals(f ast.Node) {
 		case *ast.FuncDecl:
 			return false
 		case *ast.GenDecl:
-			ast.Walk(c, n)
+			// constants are loaded directly so there is no need
+			// to store them as a local variables
+			if n.Tok != token.CONST {
+				ast.Walk(c, n)
+			}
 		}
 		return true
 	})


### PR DESCRIPTION
Because the constants are loaded directly via `emitLoadConst`, there is no need to store
them in an array of locals. It can have a big overhead, because it
is done at the beginning of every function.

This PR reduced size of neofs smart-contract by almost a factor of 2. We have a lot of string constants and many functions.