### PR TITLE
Networking improvements

### DIFF
--- a/pkg/network/discovery.go
+++ b/pkg/network/discovery.go
@@ -18,6 +18,7 @@ type Discoverer interface {
 	RequestRemote(int)
 	RegisterBadAddr(string)
 	RegisterGoodAddr(string)
+	RegisterConnectedAddr(string)
 	UnregisterConnectedAddr(string)
 	UnconnectedPeers() []string
 	BadPeers() []string
@@ -153,8 +154,8 @@ func (d *DefaultDiscovery) UnregisterConnectedAddr(s string) {
 	d.lock.Unlock()
 }
 
-// registerConnectedAddr tells discoverer that given address is now connected.
-func (d *DefaultDiscovery) registerConnectedAddr(addr string) {
+// RegisterConnectedAddr tells discoverer that given address is now connected.
+func (d *DefaultDiscovery) RegisterConnectedAddr(addr string) {
 	d.lock.Lock()
 	delete(d.unconnectedAddrs, addr)
 	d.connectedAddrs[addr] = true
@@ -166,7 +167,7 @@ func (d *DefaultDiscovery) tryAddress(addr string) {
 		d.RegisterBadAddr(addr)
 		d.RequestRemote(1)
 	} else {
-		d.registerConnectedAddr(addr)
+		d.RegisterConnectedAddr(addr)
 	}
 }
 

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -193,6 +193,12 @@ func (p *localPeer) EnqueueMessage(msg *Message) error {
 func (p *localPeer) EnqueuePacket(m []byte) error {
 	return p.EnqueueHPPacket(m)
 }
+func (p *localPeer) EnqueueP2PMessage(msg *Message) error {
+	return p.EnqueueMessage(msg)
+}
+func (p *localPeer) EnqueueP2PPacket(m []byte) error {
+	return p.EnqueueHPPacket(m)
+}
 func (p *localPeer) EnqueueHPPacket(m []byte) error {
 	msg := &Message{}
 	r := io.NewBinReaderFromBuf(m)

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -136,6 +136,7 @@ func (d testDiscovery) BackFill(addrs ...string)       {}
 func (d testDiscovery) PoolCount() int                 { return 0 }
 func (d testDiscovery) RegisterBadAddr(string)         {}
 func (d testDiscovery) RegisterGoodAddr(string)        {}
+func (d testDiscovery) RegisterConnectedAddr(string)   {}
 func (d testDiscovery) UnregisterConnectedAddr(string) {}
 func (d testDiscovery) UnconnectedPeers() []string     { return []string{} }
 func (d testDiscovery) RequestRemote(n int)            {}

--- a/pkg/network/peer.go
+++ b/pkg/network/peer.go
@@ -30,6 +30,20 @@ type Peer interface {
 	// completed handshaking.
 	EnqueuePacket([]byte) error
 
+	// EnqueueP2PMessage is a temporary wrapper that sends a message via
+	// EnqueueP2PPacket if there is no error in serializing it.
+	EnqueueP2PMessage(*Message) error
+
+	// EnqueueP2PPacket is a blocking packet enqueuer, it doesn't return until
+	// it puts given packet into the queue. It accepts a slice of bytes that
+	// can be shared with other queues (so that message marshalling can be
+	// done once for all peers). Does nothing is the peer is not yet
+	// completed handshaking. This queue is intended to be used for unicast
+	// peer to peer communication that is more important than broadcasts
+	// (handled by EnqueuePacket), but less important than high-priority
+	// messages (handled by EnqueueHPPacket).
+	EnqueueP2PPacket([]byte) error
+
 	// EnqueueHPPacket is a blocking high priority packet enqueuer, it
 	// doesn't return until it puts given packet into the high-priority
 	// queue.

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -214,8 +214,8 @@ func (s *Server) run() {
 			s.lock.Lock()
 			s.peers[p] = true
 			s.lock.Unlock()
-			s.log.Info("new peer connected", zap.Stringer("addr", p.RemoteAddr()))
 			peerCount := s.PeerCount()
+			s.log.Info("new peer connected", zap.Stringer("addr", p.RemoteAddr()), zap.Int("peerCount", peerCount))
 			if peerCount > s.MaxPeers {
 				s.lock.RLock()
 				// Pick a random peer and drop connection to it.

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -388,7 +388,7 @@ func (s *Server) handleBlockCmd(p Peer, block *block.Block) error {
 
 // handlePing processes ping request.
 func (s *Server) handlePing(p Peer, ping *payload.Ping) error {
-	return p.EnqueueMessage(s.MkMsg(CMDPong, payload.NewPing(s.chain.BlockHeight(), s.id)))
+	return p.EnqueueP2PMessage(s.MkMsg(CMDPong, payload.NewPing(s.chain.BlockHeight(), s.id)))
 }
 
 // handlePing processes pong request.
@@ -430,7 +430,7 @@ func (s *Server) handleInvCmd(p Peer, inv *payload.Inventory) error {
 		if inv.Type == payload.ConsensusType {
 			return p.EnqueueHPPacket(pkt)
 		}
-		return p.EnqueuePacket(pkt)
+		return p.EnqueueP2PPacket(pkt)
 	}
 	return nil
 }
@@ -462,7 +462,7 @@ func (s *Server) handleGetDataCmd(p Peer, inv *payload.Inventory) error {
 				if inv.Type == payload.ConsensusType {
 					err = p.EnqueueHPPacket(pkt)
 				} else {
-					err = p.EnqueuePacket(pkt)
+					err = p.EnqueueP2PPacket(pkt)
 				}
 			}
 			if err != nil {
@@ -500,7 +500,7 @@ func (s *Server) handleGetBlocksCmd(p Peer, gb *payload.GetBlocks) error {
 	}
 	payload := payload.NewInventory(payload.BlockType, blockHashes)
 	msg := s.MkMsg(CMDInv, payload)
-	return p.EnqueueMessage(msg)
+	return p.EnqueueP2PMessage(msg)
 }
 
 // handleGetHeadersCmd processes the getheaders request.
@@ -530,7 +530,7 @@ func (s *Server) handleGetHeadersCmd(p Peer, gh *payload.GetBlocks) error {
 		return nil
 	}
 	msg := s.MkMsg(CMDHeaders, &resp)
-	return p.EnqueueMessage(msg)
+	return p.EnqueueP2PMessage(msg)
 }
 
 // handleConsensusCmd processes received consensus payload.
@@ -571,7 +571,7 @@ func (s *Server) handleGetAddrCmd(p Peer) error {
 		netaddr, _ := net.ResolveTCPAddr("tcp", addr)
 		alist.Addrs[i] = payload.NewAddressAndTime(netaddr, ts)
 	}
-	return p.EnqueueMessage(s.MkMsg(CMDAddr, alist))
+	return p.EnqueueP2PMessage(s.MkMsg(CMDAddr, alist))
 }
 
 // requestHeaders sends a getheaders message to the peer.
@@ -579,7 +579,7 @@ func (s *Server) handleGetAddrCmd(p Peer) error {
 func (s *Server) requestHeaders(p Peer) error {
 	start := []util.Uint256{s.chain.CurrentHeaderHash()}
 	payload := payload.NewGetBlocks(start, util.Uint256{})
-	return p.EnqueueMessage(s.MkMsg(CMDGetHeaders, payload))
+	return p.EnqueueP2PMessage(s.MkMsg(CMDGetHeaders, payload))
 }
 
 // requestBlocks sends a getdata message to the peer
@@ -598,7 +598,7 @@ func (s *Server) requestBlocks(p Peer) error {
 	}
 	if len(hashes) > 0 {
 		payload := payload.NewInventory(payload.BlockType, hashes)
-		return p.EnqueueMessage(s.MkMsg(CMDGetData, payload))
+		return p.EnqueueP2PMessage(s.MkMsg(CMDGetData, payload))
 	} else if s.chain.HeaderHeight() < p.LastBlockIndex() {
 		return s.requestHeaders(p)
 	}

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -548,7 +548,7 @@ func (s *Server) handleTxCmd(tx *transaction.Transaction) error {
 	// in the pool.
 	if s.verifyAndPoolTX(tx) == RelaySucceed {
 		s.consensus.OnTransaction(tx)
-		s.broadcastTX(tx)
+		go s.broadcastTX(tx)
 	}
 	return nil
 }

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -388,7 +388,7 @@ func (s *Server) handleBlockCmd(p Peer, block *block.Block) error {
 
 // handlePing processes ping request.
 func (s *Server) handlePing(p Peer, ping *payload.Ping) error {
-	return p.EnqueueMessage(s.MkMsg(CMDPong, payload.NewPing(s.id, s.chain.BlockHeight())))
+	return p.EnqueueMessage(s.MkMsg(CMDPong, payload.NewPing(s.chain.BlockHeight(), s.id)))
 }
 
 // handlePing processes pong request.

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -607,6 +607,10 @@ func (s *Server) requestBlocks(p Peer) error {
 
 // handleMessage processes the given message.
 func (s *Server) handleMessage(peer Peer, msg *Message) error {
+	s.log.Debug("got msg",
+		zap.Stringer("addr", peer.RemoteAddr()),
+		zap.String("type", string(msg.CommandType())))
+
 	// Make sure both server and peer are operating on
 	// the same network.
 	if msg.Magic != s.Net {

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -348,6 +348,7 @@ func (s *Server) handleVersionCmd(p Peer, version *payload.Version) error {
 		return errIdenticalID
 	}
 	peerAddr := p.PeerAddr().String()
+	s.discovery.RegisterConnectedAddr(peerAddr)
 	s.lock.RLock()
 	for peer := range s.peers {
 		if p == peer {

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -350,8 +350,12 @@ func (s *Server) handleVersionCmd(p Peer, version *payload.Version) error {
 	peerAddr := p.PeerAddr().String()
 	s.lock.RLock()
 	for peer := range s.peers {
+		if p == peer {
+			continue
+		}
+		ver := peer.Version()
 		// Already connected, drop this connection.
-		if peer.Handshaked() && peer.PeerAddr().String() == peerAddr && peer.Version().Nonce == version.Nonce {
+		if ver != nil && ver.Nonce == version.Nonce && peer.PeerAddr().String() == peerAddr {
 			s.lock.RUnlock()
 			return errAlreadyConnected
 		}

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -239,7 +239,7 @@ func (s *Server) run() {
 				addr := drop.peer.PeerAddr().String()
 				if drop.reason == errIdenticalID {
 					s.discovery.RegisterBadAddr(addr)
-				} else {
+				} else if drop.reason != errAlreadyConnected {
 					s.discovery.UnregisterConnectedAddr(addr)
 					s.discovery.BackFill(addr)
 				}

--- a/pkg/network/tcp_peer.go
+++ b/pkg/network/tcp_peer.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"strconv"
 	"sync"
@@ -131,6 +132,9 @@ func (p *TCPPeer) handleConn() {
 				break
 			}
 			if err = p.server.handleMessage(p, msg); err != nil {
+				if p.Handshaked() {
+					err = fmt.Errorf("handling %s message: %v", msg.CommandType(), err)
+				}
 				break
 			}
 		}

--- a/pkg/network/tcp_peer.go
+++ b/pkg/network/tcp_peer.go
@@ -333,7 +333,7 @@ func (p *TCPPeer) RemoteAddr() net.Addr {
 func (p *TCPPeer) PeerAddr() net.Addr {
 	remote := p.conn.RemoteAddr()
 	// The network can be non-tcp in unit tests.
-	if !p.Handshaked() || remote.Network() != "tcp" {
+	if p.version == nil || remote.Network() != "tcp" {
 		return p.RemoteAddr()
 	}
 	host, _, err := net.SplitHostPort(remote.String())


### PR DESCRIPTION
### Problem

Wrong connect/disconnect handling leading to connectivity issues (unable to reconnect/not attempting to reconnect/dead peers). Sub-optimal outgoing message queue management.

### Solution

This fixes connects/disconnects and give more priority to direct unicast communication between nodes. The set is well-tested now (as a part of `proto-fixes` branch), the latest change was done on January 29th. It even makes our consensus (before the latest changes) survive the neo-bench test more often than not.
