### PR TITLE
compiler: rewrite jump targets properly

### DIFF
--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -74,3 +74,14 @@ var sliceTestCases = []testCase{
 func TestSliceOperations(t *testing.T) {
 	runTestCases(t, sliceTestCases)
 }
+
+func TestJumps(t *testing.T) {
+	src := `
+	package foo
+	func Main() []byte {
+		buf := []byte{0x62, 0x01, 0x00}
+		return buf
+	}
+	`
+	eval(t, src, []byte{0x62, 0x01, 0x00})
+}

--- a/pkg/vm/context.go
+++ b/pkg/vm/context.go
@@ -47,6 +47,11 @@ func NewContext(b []byte) *Context {
 	}
 }
 
+// NextIP returns next instruction pointer.
+func (c *Context) NextIP() int {
+	return c.nextip
+}
+
 // Next returns the next instruction to execute with its parameter if any. After
 // its invocation the instruction pointer points to the instruction being
 // returned.


### PR DESCRIPTION
Closes #630 .

Old implementation could view 0x62 byte in
a script as a JMP instruction irregardless of whether it is
a real opcode or a part of a parameter of another instruction.
In this commit instructions are decoded together with parameters
during jump label rewriting.