### PR TITLE
cli: add possibility to dump storage changes on restore

### DIFF
--- a/cli/server/dump.go
+++ b/cli/server/dump.go
@@ -68,9 +68,14 @@ func batchToMap(index uint32, batch *storage.MemBatch) map[string]interface{} {
 			continue
 		}
 
+		op := "Added"
+		if batch.Put[i].Exists {
+			op = "Changed"
+		}
+
 		key = toNeoStorageKey(key[1:])
 		ops = append(ops, storageOp{
-			State: "Added",
+			State: op,
 			Key:   hex.EncodeToString(key),
 			Value: "00" + hex.EncodeToString(batch.Put[i].Value),
 		})
@@ -78,7 +83,7 @@ func batchToMap(index uint32, batch *storage.MemBatch) map[string]interface{} {
 
 	for i := range batch.Deleted {
 		key := batch.Deleted[i].Key
-		if len(key) == 0 || key[0] != byte(storage.STStorage) {
+		if len(key) == 0 || key[0] != byte(storage.STStorage) || !batch.Deleted[i].Exists {
 			continue
 		}
 

--- a/cli/server/dump.go
+++ b/cli/server/dump.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/CityOfZion/neo-go/pkg/core/storage"
+	"github.com/CityOfZion/neo-go/pkg/util"
+)
+
+type dump []interface{}
+
+type storageOp struct {
+	State string `json:"state"`
+	Key   string `json:"key"`
+	Value string `json:"value,omitempty"`
+}
+
+// NEO has some differences of key storing.
+// out format: script hash in LE + key
+// neo format: script hash in BE + byte(0) + key with 0 between every 16 bytes, padded to len 16.
+func toNeoStorageKey(key []byte) []byte {
+	if len(key) < util.Uint160Size {
+		panic("invalid key in storage")
+	}
+
+	var nkey []byte
+	for i := util.Uint160Size - 1; i >= 0; i-- {
+		nkey = append(nkey, key[i])
+	}
+
+	key = key[util.Uint160Size:]
+
+	index := 0
+	remain := len(key)
+	for remain >= 16 {
+		nkey = append(nkey, key[index:index+16]...)
+		nkey = append(nkey, 0)
+		index += 16
+		remain -= 16
+	}
+
+	if remain > 0 {
+		nkey = append(nkey, key[index:]...)
+	}
+
+	padding := 16 - remain
+	for i := 0; i < padding; i++ {
+		nkey = append(nkey, 0)
+	}
+
+	nkey = append(nkey, byte(padding))
+
+	return nkey
+}
+
+// batchToMap converts batch to a map so that JSON is compatible
+// with https://github.com/NeoResearch/neo-storage-audit/
+func batchToMap(index uint32, batch *storage.MemBatch) map[string]interface{} {
+	size := len(batch.Put) + len(batch.Deleted)
+	ops := make([]storageOp, 0, size)
+	for i := range batch.Put {
+		key := batch.Put[i].Key
+		if len(key) == 0 || key[0] != byte(storage.STStorage) {
+			continue
+		}
+
+		key = toNeoStorageKey(key[1:])
+		ops = append(ops, storageOp{
+			State: "Added",
+			Key:   hex.EncodeToString(key),
+			Value: "00" + hex.EncodeToString(batch.Put[i].Value),
+		})
+	}
+
+	for i := range batch.Deleted {
+		key := batch.Deleted[i].Key
+		if len(key) == 0 || key[0] != byte(storage.STStorage) {
+			continue
+		}
+
+		key = toNeoStorageKey(key[1:])
+		ops = append(ops, storageOp{
+			State: "Deleted",
+			Key:   hex.EncodeToString(key),
+		})
+	}
+
+	return map[string]interface{}{
+		"block":   index,
+		"size":    len(ops),
+		"storage": ops,
+	}
+}
+
+func newDump() *dump {
+	return new(dump)
+}
+
+func (d *dump) add(index uint32, batch *storage.MemBatch) {
+	m := batchToMap(index, batch)
+	*d = append(*d, m)
+}
+
+func (d *dump) tryPersist(prefix string, index uint32) error {
+	if index%1000 != 0 {
+		return nil
+	}
+
+	f, err := createFile(prefix, index)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", " ")
+	if err := enc.Encode(*d); err != nil {
+		return err
+	}
+
+	*d = (*d)[:0]
+
+	return nil
+}
+
+// createFile creates directory and file in it for storing blocks up to index.
+// Directory structure is the following:
+// https://github.com/NeoResearch/neo-storage-audit#folder-organization-where-to-find-the-desired-block
+// Dir `BlockStorage_$DIRNO` contains blocks up to $DIRNO (from $DIRNO-100k)
+// Inside it there are files grouped by 1k blocks.
+// File dump-block-$FILENO.json contains blocks from $FILENO-999, $FILENO
+// Example: file `BlockStorage_100000/dump-block-6000.json` contains blocks from 5001 to 6000.
+func createFile(prefix string, index uint32) (*os.File, error) {
+	dirN := (index-1)/100000 + 1
+	dir := fmt.Sprintf("BlockStorage_%d00000", dirN)
+
+	path := filepath.Join(prefix, dir)
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		err := os.MkdirAll(path, os.ModePerm)
+		if err != nil {
+			return nil, err
+		}
+	} else if !info.IsDir() {
+		return nil, fmt.Errorf("file `%s` is not a directory", path)
+	}
+
+	fileN := (index-1)/1000 + 1
+	file := fmt.Sprintf("dump-block-%d000.json", fileN)
+	path = filepath.Join(path, file)
+
+	return os.Create(path)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,8 @@ type (
 		VerifyTransactions bool `yaml:"VerifyTransactions"`
 		// FreeGasLimit is an amount of GAS which can be spent for free.
 		FreeGasLimit util.Fixed8 `yaml:"FreeGasLimit"`
+		// SaveStorageBatch enables storage batch saving before every persist.
+		SaveStorageBatch bool `yaml:"SaveStorageBatch"`
 	}
 
 	// SystemFee fees related to system.

--- a/pkg/core/storage/memcached_store.go
+++ b/pkg/core/storage/memcached_store.go
@@ -14,6 +14,8 @@ type (
 	KeyValue struct {
 		Key   []byte
 		Value []byte
+
+		Exists bool
 	}
 
 	// MemBatch represents a changeset to be persisted.
@@ -54,12 +56,16 @@ func (s *MemCachedStore) GetBatch() *MemBatch {
 
 	b.Put = make([]KeyValue, 0, len(s.mem))
 	for k, v := range s.mem {
-		b.Put = append(b.Put, KeyValue{Key: []byte(k), Value: v})
+		key := []byte(k)
+		_, err := s.ps.Get(key)
+		b.Put = append(b.Put, KeyValue{Key: key, Value: v, Exists: err == nil})
 	}
 
 	b.Deleted = make([]KeyValue, 0, len(s.del))
 	for k := range s.del {
-		b.Deleted = append(b.Deleted, KeyValue{Key: []byte(k)})
+		key := []byte(k)
+		_, err := s.ps.Get(key)
+		b.Deleted = append(b.Deleted, KeyValue{Key: key, Exists: err == nil})
 	}
 
 	return &b

--- a/pkg/core/storage/memcached_store_test.go
+++ b/pkg/core/storage/memcached_store_test.go
@@ -18,7 +18,7 @@ func TestMemCachedStorePersist(t *testing.T) {
 	assert.Equal(t, 0, c)
 	// persisting one key should result in one key in ps and nothing in ts
 	assert.NoError(t, ts.Put([]byte("key"), []byte("value")))
-	checkBatch(t, ts, []KeyValue{{[]byte("key"), []byte("value")}}, nil)
+	checkBatch(t, ts, []KeyValue{{Key: []byte("key"), Value: []byte("value")}}, nil)
 	c, err = ts.Persist()
 	checkBatch(t, ts, nil, nil)
 	assert.Equal(t, nil, err)
@@ -38,8 +38,8 @@ func TestMemCachedStorePersist(t *testing.T) {
 	assert.Equal(t, ErrKeyNotFound, err)
 	assert.Equal(t, []byte(nil), v)
 	checkBatch(t, ts, []KeyValue{
-		{[]byte("key"), []byte("newvalue")},
-		{[]byte("key2"), []byte("value2")},
+		{Key: []byte("key"), Value: []byte("newvalue"), Exists: true},
+		{Key: []byte("key2"), Value: []byte("value2")},
 	}, nil)
 	// two keys should be persisted (one overwritten and one new) and
 	// available in the ps
@@ -67,7 +67,7 @@ func TestMemCachedStorePersist(t *testing.T) {
 	// test persisting deletions
 	err = ts.Delete([]byte("key"))
 	assert.Equal(t, nil, err)
-	checkBatch(t, ts, nil, []KeyValue{{Key: []byte("key")}})
+	checkBatch(t, ts, nil, []KeyValue{{Key: []byte("key"), Exists: true}})
 	c, err = ts.Persist()
 	checkBatch(t, ts, nil, nil)
 	assert.Equal(t, nil, err)

--- a/scripts/compare-dumps
+++ b/scripts/compare-dumps
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+ARG1=$1
+ARG2=$2
+if [ -z "$ARG1" ] || [ -z "$ARG2" ]; then
+	echo one of the arguments is empty
+	exit 1
+fi
+
+
+compare() {
+	# replace replaces storage operation from "Changed" to "Added"
+	# normalize replaces performs replace and sorts keys in lexicographic order
+	# next we normalize every json file
+	# and finally compare them as a whole
+	jq --argfile x "$1" --argfile y "$2" \
+      -n 'def replace: map(if (.state == "Changed") then (.state="Added") else . end);
+          def normalize: .storage = (.storage | replace | sort_by(.key));
+          ($x | map(normalize)) as $x
+        | ($y | map(normalize)) as $y
+        | $x | range(length) | . as $i | select($x[$i] != $y[$i]) | $x[$i].block | halt_error(1)'
+}
+
+if [ -f "$ARG1" ] && [ -f "$ARG2" ]; then
+	compare "$ARG1" "$ARG2"
+	if [ $? -ne 0 ]; then
+		echo failed
+		exit 1
+	fi
+
+    exit 0
+fi
+
+if [ ! -d "$ARG1" ] || [ ! -d "$ARG2" ]; then
+	echo both arguments must have the same type and exist
+	exit 1
+fi
+
+FIRST=$3
+if [ -z "$FIRST" ]; then
+    FIRST=1
+fi
+
+LAST=$4
+if [ -z "$LAST" ]; then
+    LAST=40 # 40_00000 block
+fi
+
+# directories contain 100k blocks
+for i in `seq $FIRST $LAST`; do
+	dir=BlockStorage_${i}00000
+	echo Processing directory $dir
+
+	# files are grouped by 1k blocks
+	for j in `seq $(((i-1)*100 + 1)) $((i*100))`; do
+		file=dump-block-${j}000.json
+		compare "$ARG1/$dir/$file" "$ARG2/$dir/$file"
+		if [ $? -ne 0 ]; then
+			echo failed on file $dir/$file
+			exit 1
+		fi
+	done
+done


### PR DESCRIPTION
Dump all storage changes in a format similar to
https://github.com/NeoResearch/neo-storage-audit/

There are 2 differences with `neo-storage-audit` though:
1. We unify `Changed` and `Added` operations, as all `Changed` can be restored base on dump itself.
2. We count as `Deleted` all entries with which `storage.Delete` was invoked, not only items which were really deleted.