### PR TITLE
Handle bad notifications

### DIFF
--- a/pkg/vm/interop.go
+++ b/pkg/vm/interop.go
@@ -93,7 +93,7 @@ func runtimeNotify(vm *VM) error {
 // RuntimeSerialize handles syscalls System.Runtime.Serialize and Neo.Runtime.Serialize.
 func RuntimeSerialize(vm *VM) error {
 	item := vm.Estack().Pop()
-	data, err := serializeItem(item.value)
+	data, err := SerializeItem(item.value)
 	if err != nil {
 		return err
 	} else if len(data) > MaxItemSize {
@@ -109,7 +109,7 @@ func RuntimeSerialize(vm *VM) error {
 func RuntimeDeserialize(vm *VM) error {
 	data := vm.Estack().Pop().Bytes()
 
-	item, err := deserializeItem(data)
+	item, err := DeserializeItem(data)
 	if err != nil {
 		return err
 	}

--- a/pkg/vm/serialization.go
+++ b/pkg/vm/serialization.go
@@ -17,7 +17,8 @@ const (
 	mapT       stackItemType = 0x82
 )
 
-func serializeItem(item StackItem) ([]byte, error) {
+// SerializeItem encodes given StackItem into the byte slice.
+func SerializeItem(item StackItem) ([]byte, error) {
 	w := io.NewBufBinWriter()
 	EncodeBinaryStackItem(item, w.BinWriter)
 	if w.Err != nil {
@@ -78,7 +79,8 @@ func serializeItemTo(item StackItem, w *io.BinWriter, seen map[StackItem]bool) {
 	}
 }
 
-func deserializeItem(data []byte) (StackItem, error) {
+// DeserializeItem decodes StackItem from the given byte slice.
+func DeserializeItem(data []byte) (StackItem, error) {
 	r := io.NewBinReaderFromBuf(data)
 	item := DecodeBinaryStackItem(r)
 	if r.Err != nil {

--- a/pkg/vm/serialization.go
+++ b/pkg/vm/serialization.go
@@ -35,7 +35,7 @@ func EncodeBinaryStackItem(item StackItem, w *io.BinWriter) {
 
 func serializeItemTo(item StackItem, w *io.BinWriter, seen map[StackItem]bool) {
 	if seen[item] {
-		w.Err = errors.New("recursive structures are not supported")
+		w.Err = errors.New("recursive structures can't be serialized")
 		return
 	}
 
@@ -50,7 +50,7 @@ func serializeItemTo(item StackItem, w *io.BinWriter, seen map[StackItem]bool) {
 		w.WriteBytes([]byte{byte(integerT)})
 		w.WriteVarBytes(IntToBytes(t.value))
 	case *InteropItem:
-		w.Err = errors.New("not supported")
+		w.Err = errors.New("interop item can't be serialized")
 	case *ArrayItem, *StructItem:
 		seen[item] = true
 

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -653,7 +653,7 @@ func TestDeserializeUnknown(t *testing.T) {
 	prog := append(getSyscallProg("Neo.Runtime.Deserialize"), byte(opcode.RET))
 	vm := load(prog)
 
-	data, err := serializeItem(NewBigIntegerItem(123))
+	data, err := SerializeItem(NewBigIntegerItem(123))
 	require.NoError(t, err)
 
 	data[0] = 0xFF


### PR DESCRIPTION
### Problem

Node fails to sync with testnet:
```
    Feb 07 00:04:19 nodoka neo-go[1747]: 2020-02-07T00:04:19.838+0300        WARN        blockQueue: failed adding block into the blockchain        {"error": "failed to store notifications: not supported", "blockHeight": 713984, "nextIndex": 713985}
```

### Solution

Don't attempt to store bad notifications.
