### PR TITLE
core: fix FreeGasLimit constraint

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -547,7 +547,7 @@ func (bc *Blockchain) storeBlock(block *block.Block) error {
 			v.SetCheckedHash(tx.VerificationHash().BytesBE())
 			v.LoadScript(t.Script)
 			v.SetPriceGetter(getPrice)
-			if bc.config.FreeGasLimit >= 0 {
+			if bc.config.FreeGasLimit > 0 {
 				v.SetGasLimit(bc.config.FreeGasLimit + t.Gas)
 			}
 


### PR DESCRIPTION
### Problem

Lack of FreeGasLimit in privnet leads to "gas limit exceeding" in case of transactions with small amount of GAS to be used for invoke operation (< real cost of the transaction).

### Solution

Fixed constraint in case when FreeGasLimit == 0. So now we are able to perform transactions in privnet with FreeGasLimit = 0 for free.
...
