### PR TITLE
compiler: support sub-slicing

### DIFF
--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -189,6 +189,12 @@ func isBuiltin(expr ast.Expr) bool {
 
 func isByteArray(lit *ast.CompositeLit, tInfo *types.Info) bool {
 	if len(lit.Elts) == 0 {
+		if typ, ok := lit.Type.(*ast.ArrayType); ok {
+			if name, ok := typ.Elt.(*ast.Ident); ok {
+				return name.Name == "byte" || name.Name == "uint8"
+			}
+		}
+
 		return false
 	}
 

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -309,6 +309,29 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 		}
 		return nil
 
+	case *ast.SliceExpr:
+		name := n.X.(*ast.Ident).Name
+		c.emitLoadLocal(name)
+
+		if n.Low != nil {
+			ast.Walk(c, n.Low)
+		} else {
+			emit.Opcode(c.prog.BinWriter, opcode.PUSH0)
+		}
+
+		if n.High != nil {
+			ast.Walk(c, n.High)
+		} else {
+			emit.Opcode(c.prog.BinWriter, opcode.OVER)
+			emit.Opcode(c.prog.BinWriter, opcode.ARRAYSIZE)
+		}
+
+		emit.Opcode(c.prog.BinWriter, opcode.OVER)
+		emit.Opcode(c.prog.BinWriter, opcode.SUB)
+		emit.Opcode(c.prog.BinWriter, opcode.SUBSTR)
+
+		return nil
+
 	case *ast.ReturnStmt:
 		l := c.newLabel()
 		c.setLabel(l)

--- a/pkg/compiler/for_test.go
+++ b/pkg/compiler/for_test.go
@@ -293,6 +293,18 @@ func TestAppendByte(t *testing.T) {
 	eval(t, src, []uint8{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06})
 }
 
+func TestAppendByteToEmpty(t *testing.T) {
+	src := `
+	package foo
+	func Main() []byte {
+		out := []byte{}
+		out = append(out, 1)
+		out = append(out, 2)
+		return out
+	}`
+	eval(t, src, []byte{1, 2})
+}
+
 func TestAppendString(t *testing.T) {
 	src := `
 	package foo

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -69,6 +69,65 @@ var sliceTestCases = []testCase{
 		`,
 		big.NewInt(15),
 	},
+	{
+		"sub-slice with literal bounds",
+		`
+		package foo
+		func Main() []byte {
+			a := []byte{0, 1, 2, 3}
+			b := a[1:3]
+			return b
+		}`,
+		[]byte{1, 2},
+	},
+	{
+		"sub-slice with constant bounds",
+		`
+		package foo
+		const x = 1
+		const y = 3
+		func Main() []byte {
+			a := []byte{0, 1, 2, 3}
+			b := a[x:y]
+			return b
+		}`,
+		[]byte{1, 2},
+	},
+	{
+		"sub-slice with variable bounds",
+		`
+		package foo
+		func Main() []byte {
+			a := []byte{0, 1, 2, 3}
+			x := 1
+			y := 3
+			b := a[x:y]
+			return b
+		}`,
+		[]byte{1, 2},
+	},
+	{
+		"sub-slice with no lower bound",
+		`
+		package foo
+		func Main() []byte {
+			a := []byte{0, 1, 2, 3}
+			b := a[:3]
+			return b
+		}`,
+		[]byte{0, 1, 2},
+	},
+	{
+		"sub-slice with no upper bound",
+		`
+		package foo
+		func Main() []byte {
+			a := []byte{0, 1, 2, 3}
+			b := a[2:]
+			return b
+		}`,
+		[]byte{2, 3},
+	},
 }
 
 func TestSliceOperations(t *testing.T) {


### PR DESCRIPTION
Implement sub-slice support. Only bytearrays are considered. 