### PR TITLE
Add JSON tags for RPC response types

### DIFF
--- a/pkg/core/transaction/attribute.go
+++ b/pkg/core/transaction/attribute.go
@@ -10,8 +10,8 @@ import (
 
 // Attribute represents a Transaction attribute.
 type Attribute struct {
-	Usage AttrUsage
-	Data  []byte
+	Usage AttrUsage `json:"usage"`
+	Data  []byte    `json:"data"`
 }
 
 // DecodeBinary implements Serializable interface.

--- a/pkg/core/transaction/output.go
+++ b/pkg/core/transaction/output.go
@@ -11,17 +11,17 @@ import (
 // Output represents a Transaction output.
 type Output struct {
 	// The NEO asset id used in the transaction.
-	AssetID util.Uint256
+	AssetID util.Uint256 `json:"asset"`
 
 	// Amount of AssetType send or received.
-	Amount util.Fixed8
+	Amount util.Fixed8 `json:"value"`
 
 	// The address of the recipient.
-	ScriptHash util.Uint160
+	ScriptHash util.Uint160 `json:"address"`
 
 	// The position of the Output in slice []Output. This is actually set in NewTransactionOutputRaw
 	// and used for displaying purposes.
-	Position int
+	Position int `json:"n"`
 }
 
 // NewOutput returns a new transaction output.

--- a/pkg/core/transaction/witness.go
+++ b/pkg/core/transaction/witness.go
@@ -11,8 +11,8 @@ import (
 
 // Witness contains 2 scripts.
 type Witness struct {
-	InvocationScript   []byte
-	VerificationScript []byte
+	InvocationScript   []byte `json:"invocation"`
+	VerificationScript []byte `json:"verification"`
 }
 
 // DecodeBinary implements Serializable interface.


### PR DESCRIPTION
- `Attribute` should have 2 fields (usage, data)
- `VOut` should have 4 (5) fields (asset, value, address, n)
- `Script` should have 2 fields (invocation, verification)