### PR TITLE
core: reschedule the next persist in a second from previous one

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -278,8 +278,8 @@ func (bc *Blockchain) Run() {
 				if err != nil {
 					bc.log.Warn("failed to persist blockchain", zap.Error(err))
 				}
+				persistTimer.Reset(persistInterval)
 			}()
-			persistTimer.Reset(persistInterval)
 		}
 	}
 }


### PR DESCRIPTION
It makes little sense queueing up several persistence goroutines (or actually
even running them concurrently).