### PR TITLE
core: verify headers in AddHeaders()

### DIFF
--- a/integration/performance_test.go
+++ b/integration/performance_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/CityOfZion/neo-go/pkg/encoding/address"
 	"github.com/CityOfZion/neo-go/pkg/network"
 	"github.com/CityOfZion/neo-go/pkg/rpc/request"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
@@ -38,12 +39,8 @@ func BenchmarkTXPerformanceTest(t *testing.B) {
 	t.ResetTimer()
 
 	for n := 0; n < t.N; n++ {
-		if server.RelayTxn(data[n]) != network.RelaySucceed {
-			t.Fail()
-		}
-		if server.RelayTxn(data[n]) != network.RelayAlreadyExists {
-			t.Fail()
-		}
+		assert.Equal(t, network.RelaySucceed, server.RelayTxn(data[n]))
+		assert.Equal(t, network.RelayAlreadyExists, server.RelayTxn(data[n]))
 	}
 	chain.Close()
 }

--- a/pkg/compiler/vm_test.go
+++ b/pkg/compiler/vm_test.go
@@ -51,9 +51,7 @@ func vmAndCompile(t *testing.T, src string) *vm.VM {
 	vm.RegisterInteropGetter(storePlugin.getInterop)
 
 	b, err := compiler.Compile(strings.NewReader(src))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	vm.Load(b)
 	return vm
 }

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -67,9 +67,8 @@ func TestAddBlock(t *testing.T) {
 
 	for _, block := range blocks {
 		key := storage.AppendPrefix(storage.DataBlock, block.Hash().BytesLE())
-		if _, err := bc.dao.store.Get(key); err != nil {
-			t.Fatalf("block %s not persisted", block.Hash())
-		}
+		_, err := bc.dao.store.Get(key)
+		require.NoErrorf(t, err, "block %s not persisted", block.Hash())
 	}
 
 	assert.Equal(t, lastBlock.Index, bc.BlockHeight())
@@ -126,9 +125,7 @@ func TestGetBlock(t *testing.T) {
 	for j := 0; j < 2; j++ {
 		for i := 0; i < len(blocks); i++ {
 			block, err := bc.GetBlock(blocks[i].Hash())
-			if err != nil {
-				t.Fatalf("can't get block %d: %s, attempt %d", i, err, j)
-			}
+			require.NoErrorf(t, err, "can't get block %d: %s, attempt %d", i, err, j)
 			assert.Equal(t, blocks[i].Index, block.Index)
 			assert.Equal(t, blocks[i].Hash(), block.Hash())
 		}

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestAddHeaders(t *testing.T) {
 	bc := newTestChain(t)
+	defer bc.Close()
 	lastBlock := bc.topBlock.Load().(*block.Block)
 	h1 := newBlock(bc.config, 1, lastBlock.Hash()).Header()
 	h2 := newBlock(bc.config, 2, h1.Hash()).Header()

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"testing"
 
-	"github.com/CityOfZion/neo-go/pkg/core/block"
 	"github.com/CityOfZion/neo-go/pkg/core/storage"
 	"github.com/CityOfZion/neo-go/pkg/core/transaction"
 	"github.com/CityOfZion/neo-go/pkg/crypto/hash"
@@ -38,18 +37,10 @@ func TestAddHeaders(t *testing.T) {
 }
 
 func TestAddBlock(t *testing.T) {
+	const size = 3
 	bc := newTestChain(t)
-	blocks := []*block.Block{
-		newBlock(1, newMinerTX()),
-		newBlock(2, newMinerTX()),
-		newBlock(3, newMinerTX()),
-	}
-
-	for i := 0; i < len(blocks); i++ {
-		if err := bc.AddBlock(blocks[i]); err != nil {
-			t.Fatal(err)
-		}
-	}
+	blocks, err := bc.genBlocks(size)
+	require.NoError(t, err)
 
 	lastBlock := blocks[len(blocks)-1]
 	assert.Equal(t, lastBlock.Index, bc.HeaderHeight())
@@ -112,13 +103,8 @@ func TestGetHeader(t *testing.T) {
 
 func TestGetBlock(t *testing.T) {
 	bc := newTestChain(t)
-	blocks := makeBlocks(100)
-
-	for i := 0; i < len(blocks); i++ {
-		if err := bc.AddBlock(blocks[i]); err != nil {
-			t.Fatal(err)
-		}
-	}
+	blocks, err := bc.genBlocks(100)
+	require.NoError(t, err)
 
 	// Test unpersisted and persisted access
 	for j := 0; j < 2; j++ {
@@ -136,13 +122,8 @@ func TestGetBlock(t *testing.T) {
 
 func TestHasBlock(t *testing.T) {
 	bc := newTestChain(t)
-	blocks := makeBlocks(50)
-
-	for i := 0; i < len(blocks); i++ {
-		if err := bc.AddBlock(blocks[i]); err != nil {
-			t.Fatal(err)
-		}
-	}
+	blocks, err := bc.genBlocks(50)
+	require.NoError(t, err)
 
 	// Test unpersisted and persisted access
 	for j := 0; j < 2; j++ {
@@ -187,10 +168,8 @@ func TestClose(t *testing.T) {
 		assert.NotNil(t, r)
 	}()
 	bc := newTestChain(t)
-	blocks := makeBlocks(10)
-	for i := 0; i < len(blocks); i++ {
-		require.NoError(t, bc.AddBlock(blocks[i]))
-	}
+	_, err := bc.genBlocks(10)
+	require.NoError(t, err)
 	bc.Close()
 	// It's a hack, but we use internal knowledge of MemoryStore
 	// implementation which makes it completely unusable (up to panicing)

--- a/pkg/core/gas_price_test.go
+++ b/pkg/core/gas_price_test.go
@@ -14,6 +14,7 @@ import (
 // https://github.com/neo-project/neo/blob/master-2.x/neo.UnitTests/UT_InteropPrices.cs#L245
 func TestGetPrice(t *testing.T) {
 	bc := newTestChain(t)
+	defer bc.Close()
 	systemInterop := bc.newInteropContext(trigger.Application, storage.NewMemoryStore(), nil, nil)
 
 	v := bc.spawnVMWithInterops(systemInterop)

--- a/pkg/core/helper_test.go
+++ b/pkg/core/helper_test.go
@@ -96,12 +96,15 @@ func newBlock(index uint32, txs ...*transaction.Transaction) *block.Block {
 	return b
 }
 
-func makeBlocks(n int) []*block.Block {
+func (bc *Blockchain) genBlocks(n int) ([]*block.Block, error) {
 	blocks := make([]*block.Block, n)
 	for i := 0; i < n; i++ {
-		blocks[i] = newBlock(uint32(i+1), newMinerTX())
+		blocks[i] = newBlock(uint32(i)+1, newMinerTX())
+		if err := bc.AddBlock(blocks[i]); err != nil {
+			return blocks, err
+		}
 	}
-	return blocks
+	return blocks, nil
 }
 
 func newMinerTX() *transaction.Transaction {
@@ -175,13 +178,8 @@ func newDumbBlock() *block.Block {
 func _(t *testing.T) {
 	bc := newTestChain(t)
 	n := 50
-	blocks := makeBlocks(n)
-
-	for i := 0; i < len(blocks); i++ {
-		if err := bc.AddBlock(blocks[i]); err != nil {
-			t.Fatal(err)
-		}
-	}
+	_, err := bc.genBlocks(n)
+	require.NoError(t, err)
 
 	tx1 := newMinerTX()
 

--- a/pkg/core/helper_test.go
+++ b/pkg/core/helper_test.go
@@ -24,9 +24,6 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-var newBlockPrevHash util.Uint256
-var unitTestNetCfg config.Config
-
 var privNetKeys = []string{
 	"KxyjQ8eUa4FHt3Gvioyt1Wz29cTUrE4eTqX3yFSk1YFCsPL8uNsY",
 	"KzfPUYDC9n2yf4fK5ro4C8KMcdeXtFuEnStycbZgX3GomiUsvX6W",
@@ -37,8 +34,7 @@ var privNetKeys = []string{
 // newTestChain should be called before newBlock invocation to properly setup
 // global state.
 func newTestChain(t *testing.T) *Blockchain {
-	var err error
-	unitTestNetCfg, err = config.Load("../../config", config.ModeUnitTestNet)
+	unitTestNetCfg, err := config.Load("../../config", config.ModeUnitTestNet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,14 +43,16 @@ func newTestChain(t *testing.T) *Blockchain {
 		t.Fatal(err)
 	}
 	go chain.Run()
-	zeroHash, err := chain.GetHeader(chain.GetHeaderHash(0))
-	require.Nil(t, err)
-	newBlockPrevHash = zeroHash.Hash()
 	return chain
 }
 
-func newBlock(index uint32, txs ...*transaction.Transaction) *block.Block {
-	validators, _ := getValidators(unitTestNetCfg.ProtocolConfiguration)
+func (bc *Blockchain) newBlock(txs ...*transaction.Transaction) *block.Block {
+	lastBlock := bc.topBlock.Load().(*block.Block)
+	return newBlock(bc.config, lastBlock.Index+1, lastBlock.Hash(), txs...)
+}
+
+func newBlock(cfg config.ProtocolConfiguration, index uint32, prev util.Uint256, txs ...*transaction.Transaction) *block.Block {
+	validators, _ := getValidators(cfg)
 	vlen := len(validators)
 	valScript, _ := smartcontract.CreateMultiSigRedeemScript(
 		vlen-(vlen-1)/3,
@@ -66,7 +64,7 @@ func newBlock(index uint32, txs ...*transaction.Transaction) *block.Block {
 	b := &block.Block{
 		Base: block.Base{
 			Version:       0,
-			PrevHash:      newBlockPrevHash,
+			PrevHash:      prev,
 			Timestamp:     uint32(time.Now().UTC().Unix()) + index,
 			Index:         index,
 			ConsensusData: 1111,
@@ -76,7 +74,6 @@ func newBlock(index uint32, txs ...*transaction.Transaction) *block.Block {
 		Transactions: txs,
 	}
 	_ = b.RebuildMerkleRoot()
-	newBlockPrevHash = b.Hash()
 
 	invScript := make([]byte, 0)
 	for _, wif := range privNetKeys {
@@ -98,11 +95,13 @@ func newBlock(index uint32, txs ...*transaction.Transaction) *block.Block {
 
 func (bc *Blockchain) genBlocks(n int) ([]*block.Block, error) {
 	blocks := make([]*block.Block, n)
+	lastHash := bc.topBlock.Load().(*block.Block).Hash()
 	for i := 0; i < n; i++ {
-		blocks[i] = newBlock(uint32(i)+1, newMinerTX())
+		blocks[i] = newBlock(bc.config, uint32(i)+1, lastHash, newMinerTX())
 		if err := bc.AddBlock(blocks[i]); err != nil {
 			return blocks, err
 		}
+		lastHash = blocks[i].Hash()
 	}
 	return blocks, nil
 }
@@ -207,7 +206,7 @@ func _(t *testing.T) {
 
 	tx2 := transaction.NewInvocationTX(txScript, util.Fixed8FromFloat(100))
 
-	block := newBlock(uint32(n+1), tx1, tx2)
+	block := bc.newBlock(tx1, tx2)
 	if err := bc.AddBlock(block); err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +220,7 @@ func _(t *testing.T) {
 	emit.AppCall(script.BinWriter, hash.Hash160(avm), false)
 
 	tx3 := transaction.NewInvocationTX(script.Bytes(), util.Fixed8FromFloat(100))
-	b := newBlock(uint32(n+2), newMinerTX(), tx3)
+	b := bc.newBlock(newMinerTX(), tx3)
 	require.NoError(t, bc.AddBlock(b))
 
 	outStream, err := os.Create("../rpc/testdata/testblocks.acc")

--- a/pkg/core/helper_test.go
+++ b/pkg/core/helper_test.go
@@ -35,13 +35,9 @@ var privNetKeys = []string{
 // global state.
 func newTestChain(t *testing.T) *Blockchain {
 	unitTestNetCfg, err := config.Load("../../config", config.ModeUnitTestNet)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	chain, err := NewBlockchain(storage.NewMemoryStore(), unitTestNetCfg.ProtocolConfiguration, zaptest.NewLogger(t))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	go chain.Run()
 	return chain
 }
@@ -115,21 +111,15 @@ func newMinerTX() *transaction.Transaction {
 
 func getDecodedBlock(t *testing.T, i int) *block.Block {
 	data, err := getBlockData(i)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	b, err := hex.DecodeString(data["raw"].(string))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	block := &block.Block{}
 	r := io.NewBinReaderFromBuf(b)
 	block.DecodeBinary(r)
-	if r.Err != nil {
-		t.Fatal(r.Err)
-	}
+	require.NoError(t, r.Err)
 
 	return block
 }
@@ -183,9 +173,7 @@ func _(t *testing.T) {
 	tx1 := newMinerTX()
 
 	avm, err := ioutil.ReadFile("../rpc/testdata/test_contract.avm")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var props smartcontract.PropertyState
 	script := io.NewBufBinWriter()
@@ -207,9 +195,7 @@ func _(t *testing.T) {
 	tx2 := transaction.NewInvocationTX(txScript, util.Fixed8FromFloat(100))
 
 	block := bc.newBlock(tx1, tx2)
-	if err := bc.AddBlock(block); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, bc.AddBlock(block))
 
 	script = io.NewBufBinWriter()
 	emit.String(script.BinWriter, "testvalue")
@@ -224,9 +210,7 @@ func _(t *testing.T) {
 	require.NoError(t, bc.AddBlock(b))
 
 	outStream, err := os.Create("../rpc/testdata/testblocks.acc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer outStream.Close()
 
 	writer := io.NewBinWriterFromIO(outStream)
@@ -237,15 +221,11 @@ func _(t *testing.T) {
 	for i := 1; i < int(count); i++ {
 		bh := bc.GetHeaderHash(i)
 		b, err := bc.GetBlock(bh)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		buf := io.NewBufBinWriter()
 		b.EncodeBinary(buf.BinWriter)
 		bytes := buf.Bytes()
 		writer.WriteBytes(bytes)
-		if writer.Err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, writer.Err)
 	}
 }

--- a/pkg/core/transaction/register_test.go
+++ b/pkg/core/transaction/register_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/CityOfZion/neo-go/pkg/io"
 	"github.com/CityOfZion/neo-go/pkg/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRegisterTX(t *testing.T) {
@@ -43,9 +44,7 @@ func TestRegisterTX(t *testing.T) {
 func TestDecodeRegisterTXFromRawString(t *testing.T) {
 	rawTX := "400000455b7b226c616e67223a227a682d434e222c226e616d65223a22e5b08fe89a81e882a1227d2c7b226c616e67223a22656e222c226e616d65223a22416e745368617265227d5d0000c16ff28623000000da1745e9b549bd0bfa1a569971c77eba30cd5a4b00000000"
 	b, err := hex.DecodeString(rawTX)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	tx := &Transaction{}
 	r := io.NewBinReaderFromBuf(b)

--- a/pkg/core/util_test.go
+++ b/pkg/core/util_test.go
@@ -6,18 +6,15 @@ import (
 	"github.com/CityOfZion/neo-go/config"
 	"github.com/CityOfZion/neo-go/pkg/encoding/address"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenesisBlockMainNet(t *testing.T) {
 	cfg, err := config.Load("../../config", config.ModeMainNet)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	block, err := createGenesisBlock(cfg.ProtocolConfiguration)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	expect := "d42561e3d30e15be6400b6df2f328e02d2bf6354c41dce433bc57687c82144bf"
 	assert.Equal(t, expect, block.Hash().StringLE())
@@ -30,19 +27,13 @@ func TestGetConsensusAddressMainNet(t *testing.T) {
 	)
 
 	cfg, err := config.Load("../../config", config.ModeMainNet)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	validators, err := getValidators(cfg.ProtocolConfiguration)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	script, err := getNextConsensusAddress(validators)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, consensusScript, script.String())
 	assert.Equal(t, consensusAddr, address.Uint160ToString(script))

--- a/pkg/crypto/hash/merkle_tree_test.go
+++ b/pkg/crypto/hash/merkle_tree_test.go
@@ -17,9 +17,7 @@ func testComputeMerkleTree(t *testing.T, hexHashes []string, result string) {
 	}
 
 	merkle, err := NewMerkleTree(hashes)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Equal(t, result, merkle.Root().StringLE())
 	assert.Equal(t, true, merkle.root.IsRoot())
 	assert.Equal(t, false, merkle.root.IsLeaf())

--- a/pkg/encoding/address/address_test.go
+++ b/pkg/encoding/address/address_test.go
@@ -15,9 +15,7 @@ func TestUint160DecodeEncodeAddress(t *testing.T) {
 	}
 	for _, addr := range addrs {
 		val, err := StringToUint160(addr)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		assert.Equal(t, addr, Uint160ToString(val))
 	}
 }
@@ -26,9 +24,7 @@ func TestUint160DecodeKnownAddress(t *testing.T) {
 	address := "AJeAEsmeD6t279Dx4n2HWdUvUmmXQ4iJvP"
 
 	val, err := StringToUint160(address)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, "b28427088a3729b2536d10122960394e8be6721f", val.StringLE())
 	assert.Equal(t, "1f72e68b4e39602912106d53b229378a082784b2", val.String())

--- a/pkg/network/server_test.go
+++ b/pkg/network/server_test.go
@@ -29,9 +29,7 @@ func TestSendVersion(t *testing.T) {
 		assert.Equal(t, uint32(0), version.StartHeight)
 	}
 
-	if err := p.SendVersion(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, p.SendVersion())
 }
 
 // Server should reply with a verack after receiving a valid version.
@@ -49,9 +47,7 @@ func TestVerackAfterHandleVersionCmd(t *testing.T) {
 	}
 	version := payload.NewVersion(1337, 3000, "/NEO-GO/", 0, true)
 
-	if err := s.handleVersionCmd(p, version); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, s.handleVersionCmd(p, version))
 }
 
 // Server should not reply with a verack after receiving a

--- a/pkg/smartcontract/contract_test.go
+++ b/pkg/smartcontract/contract_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/CityOfZion/neo-go/pkg/io"
 	"github.com/CityOfZion/neo-go/pkg/vm/opcode"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateMultiSigRedeemScript(t *testing.T) {
@@ -17,18 +18,14 @@ func TestCreateMultiSigRedeemScript(t *testing.T) {
 	validators := []*keys.PublicKey{val1, val2, val3}
 
 	out, err := CreateMultiSigRedeemScript(3, validators)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	br := io.NewBinReaderFromBuf(out)
 	assert.Equal(t, opcode.PUSH3, opcode.Opcode(br.ReadB()))
 
 	for i := 0; i < len(validators); i++ {
 		bb := br.ReadVarBytes()
-		if br.Err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, br.Err)
 		assert.Equal(t, validators[i].Bytes(), bb)
 	}
 

--- a/pkg/vm/json_test.go
+++ b/pkg/vm/json_test.go
@@ -124,9 +124,7 @@ func getTestingInterop(id uint32) *InteropFuncPrice {
 
 func testFile(t *testing.T, filename string) {
 	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// FIXME remove when NEO 3.0 https://github.com/nspcc-dev/neo-go/issues/477
 	if len(data) > 2 && data[0] == 0xef && data[1] == 0xbb && data[2] == 0xbf {
@@ -134,9 +132,7 @@ func testFile(t *testing.T, filename string) {
 	}
 
 	ut := new(vmUT)
-	if err = json.Unmarshal(data, ut); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, json.Unmarshal(data, ut))
 
 	t.Run(ut.Category+":"+ut.Name, func(t *testing.T) {
 		for i := range ut.Tests {

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1694,9 +1694,7 @@ func TestSimpleCall(t *testing.T) {
 	result := 12
 
 	prog, err := hex.DecodeString(progStr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	vm := load(prog)
 	runVM(t, vm)
 	assert.Equal(t, result, int(vm.estack.Pop().BigInt().Int64()))

--- a/pkg/wallet/account_test.go
+++ b/pkg/wallet/account_test.go
@@ -134,16 +134,12 @@ func convertPubs(t *testing.T, hexKeys []string) []*keys.PublicKey {
 }
 
 func compareFields(t *testing.T, tk keytestcases.Ktype, acc *Account) {
-	if want, have := tk.Address, acc.Address; want != have {
-		t.Fatalf("expected %s got %s", want, have)
-	}
-	if want, have := tk.Wif, acc.wif; want != have {
-		t.Fatalf("expected %s got %s", want, have)
-	}
-	if want, have := tk.PublicKey, hex.EncodeToString(acc.publicKey); want != have {
-		t.Fatalf("expected %s got %s", want, have)
-	}
-	if want, have := tk.PrivateKey, acc.privateKey.String(); want != have {
-		t.Fatalf("expected %s got %s", want, have)
-	}
+	want, have := tk.Address, acc.Address
+	require.Equalf(t, want, have, "expected %s got %s", want, have)
+	want, have = tk.Wif, acc.wif
+	require.Equalf(t, want, have, "expected %s got %s", want, have)
+	want, have = tk.PublicKey, hex.EncodeToString(acc.publicKey)
+	require.Equalf(t, want, have, "expected %s got %s", want, have)
+	want, have = tk.PrivateKey, acc.privateKey.String()
+	require.Equalf(t, want, have, "expected %s got %s", want, have)
 }


### PR DESCRIPTION
1. Headers need to be verified on adding.
2. Get rid of global variables in core tests.

Maybe now there is no need to verify block if it's header matches header in headerlist.