### PR TITLE
core: convert trigger.Type to byte when pushing on stack

### DIFF
--- a/pkg/core/interop_neo_test.go
+++ b/pkg/core/interop_neo_test.go
@@ -35,6 +35,12 @@ import (
  *  TestRuntimeDeserialize
  */
 
+func TestGetTrigger(t *testing.T) {
+	v, _, context, chain := createVMAndPushBlock(t)
+	defer chain.Close()
+	require.NoError(t, context.runtimeGetTrigger(v))
+}
+
 func TestStorageFind(t *testing.T) {
 	v, contractState, context, chain := createVMAndContractState(t)
 	defer chain.Close()

--- a/pkg/core/interop_system.go
+++ b/pkg/core/interop_system.go
@@ -288,7 +288,7 @@ func (ic *interopContext) runtimePlatform(v *vm.VM) error {
 
 // runtimeGetTrigger returns the script trigger.
 func (ic *interopContext) runtimeGetTrigger(v *vm.VM) error {
-	v.Estack().PushVal(ic.trigger)
+	v.Estack().PushVal(byte(ic.trigger))
 	return nil
 }
 


### PR DESCRIPTION
trigger.Type is not present in `makeStackItem`.