### PR TITLE
compiler: clean up stack on branch statements

### DIFF
--- a/pkg/compiler/function_call_test.go
+++ b/pkg/compiler/function_call_test.go
@@ -35,7 +35,10 @@ func TestNotAssignedFunctionCall(t *testing.T) {
 			return 0
 		}
 	`
-	eval(t, src, []byte{})
+	// disable stack checks because it is hard right now
+	// to distinguish between simple function call traversal
+	// and the same traversal inside an assignment.
+	evalWithoutStackChecks(t, src, []byte{})
 }
 
 func TestMultipleFunctionCalls(t *testing.T) {

--- a/pkg/compiler/vm_test.go
+++ b/pkg/compiler/vm_test.go
@@ -23,10 +23,17 @@ func runTestCases(t *testing.T, tcases []testCase) {
 	}
 }
 
+func evalWithoutStackChecks(t *testing.T, src string, result interface{}) {
+	v := vmAndCompile(t, src)
+	require.NoError(t, v.Run())
+	assertResult(t, v, result)
+}
+
 func eval(t *testing.T, src string, result interface{}) {
 	vm := vmAndCompile(t, src)
 	err := vm.Run()
 	require.NoError(t, err)
+	assert.Equal(t, 1, vm.Estack().Len(), "stack contains unexpected items")
 	assertResult(t, vm, result)
 }
 
@@ -35,6 +42,7 @@ func evalWithArgs(t *testing.T, src string, op []byte, args []vm.StackItem, resu
 	vm.LoadArgs(op, args)
 	err := vm.Run()
 	require.NoError(t, err)
+	assert.Equal(t, 1, vm.Estack().Len(), "stack contains unexpected items")
 	assertResult(t, vm, result)
 }
 


### PR DESCRIPTION
When `return` or `break` statement is encountered inside
a for/range/switch statement, top stack items can be auxilliary.
They need to be cleaned up before returning from the function.

 Related to #683 .
The only unfixed test RN is a function call used as a statement.