### PR TITLE
Fix GetReferences interop regression

### DIFF
--- a/pkg/core/interop_neo.go
+++ b/pkg/core/interop_neo.go
@@ -144,8 +144,13 @@ func (ic *interopContext) txGetReferences(v *vm.VM) error {
 	}
 
 	stackrefs := make([]vm.StackItem, 0, len(refs))
-	for _, tio := range refs {
-		stackrefs = append(stackrefs, vm.NewInteropItem(tio))
+	for i := range tx.Inputs {
+		for j := range refs {
+			if refs[j].In == tx.Inputs[i] {
+				stackrefs = append(stackrefs, vm.NewInteropItem(refs[j]))
+				break
+			}
+		}
 	}
 	v.Estack().PushVal(stackrefs)
 	return nil


### PR DESCRIPTION
### Problem

State difference with C# node in block 1444901.

### Solution

Broken by 9f7018503a12d4c6c7ae1e6e6a2835569f3bf502. Almost the same problem as
in 01082a8988cf049673e1857415f08534e879b512 (though it is deterministic now,
just not the way the contract expects).