### PR TITLE
Use wallet in smartcontract deploy/invoke commands and calculate GAS properly

### DIFF
--- a/pkg/core/gas_price.go
+++ b/pkg/core/gas_price.go
@@ -93,18 +93,7 @@ func getSyscallPrice(v *vm.VM, id uint32) util.Fixed8 {
 		arg := estack.Peek(1).BigInt().Int64()
 		return util.Fixed8FromInt64(arg * 5000)
 	case neoContractCreate, neoContractMigrate, antSharesContractCreate, antSharesContractMigrate:
-		fee := int64(100)
-		props := smartcontract.PropertyState(estack.Peek(3).BigInt().Int64())
-
-		if props&smartcontract.HasStorage != 0 {
-			fee += 400
-		}
-
-		if props&smartcontract.HasDynamicInvoke != 0 {
-			fee += 500
-		}
-
-		return util.Fixed8FromInt64(fee)
+		return smartcontract.GetDeploymentPrice(smartcontract.PropertyState(estack.Peek(3).BigInt().Int64()))
 	case systemStoragePut, systemStoragePutEx, neoStoragePut, antSharesStoragePut:
 		// price for storage PUT is 1 GAS per 1 KiB
 		keySize := len(estack.Peek(1).Bytes())

--- a/pkg/rpc/request/txBuilder.go
+++ b/pkg/rpc/request/txBuilder.go
@@ -80,17 +80,10 @@ func AddInputsAndUnspentsToTx(tx *transaction.Transaction, addr string, assetID 
 	return nil
 }
 
-// CreateDeploymentScript returns a script that deploys given smart contract
-// with its metadata.
-func CreateDeploymentScript(avm []byte, contract *ContractDetails) ([]byte, error) {
+// DetailsToSCProperties extract the fields needed from ContractDetails
+// and converts them to smartcontract.PropertyState.
+func DetailsToSCProperties(contract *ContractDetails) smartcontract.PropertyState {
 	var props smartcontract.PropertyState
-
-	script := io.NewBufBinWriter()
-	emit.Bytes(script.BinWriter, []byte(contract.Description))
-	emit.Bytes(script.BinWriter, []byte(contract.Email))
-	emit.Bytes(script.BinWriter, []byte(contract.Author))
-	emit.Bytes(script.BinWriter, []byte(contract.Version))
-	emit.Bytes(script.BinWriter, []byte(contract.ProjectName))
 	if contract.HasStorage {
 		props |= smartcontract.HasStorage
 	}
@@ -100,7 +93,19 @@ func CreateDeploymentScript(avm []byte, contract *ContractDetails) ([]byte, erro
 	if contract.IsPayable {
 		props |= smartcontract.IsPayable
 	}
-	emit.Int(script.BinWriter, int64(props))
+	return props
+}
+
+// CreateDeploymentScript returns a script that deploys given smart contract
+// with its metadata.
+func CreateDeploymentScript(avm []byte, contract *ContractDetails) ([]byte, error) {
+	script := io.NewBufBinWriter()
+	emit.Bytes(script.BinWriter, []byte(contract.Description))
+	emit.Bytes(script.BinWriter, []byte(contract.Email))
+	emit.Bytes(script.BinWriter, []byte(contract.Author))
+	emit.Bytes(script.BinWriter, []byte(contract.Version))
+	emit.Bytes(script.BinWriter, []byte(contract.ProjectName))
+	emit.Int(script.BinWriter, int64(DetailsToSCProperties(contract)))
 	emit.Int(script.BinWriter, int64(contract.ReturnType))
 	params := make([]byte, len(contract.Parameters))
 	for k := range contract.Parameters {

--- a/pkg/smartcontract/deployment_price.go
+++ b/pkg/smartcontract/deployment_price.go
@@ -1,0 +1,18 @@
+package smartcontract
+
+import "github.com/nspcc-dev/neo-go/pkg/util"
+
+// GetDeploymentPrice returns contract deployment price based on its properties.
+func GetDeploymentPrice(props PropertyState) util.Fixed8 {
+	fee := int64(100)
+
+	if props&HasStorage != 0 {
+		fee += 400
+	}
+
+	if props&HasDynamicInvoke != 0 {
+		fee += 500
+	}
+
+	return util.Fixed8FromInt64(fee)
+}


### PR DESCRIPTION
### Problem

Real GAS needed to deploy smartcontract was not calculated, so one could only try different GAS values to see which one fits. Wallets were also not integrated properly into this part of the CLI.
