### PR TITLE
rpc: support https

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,6 +111,16 @@ type (
 		// MaxGasInvoke is a maximum amount of gas which
 		// can be spent during RPC call.
 		MaxGasInvoke util.Fixed8 `yaml:"MaxGasInvoke"`
+		TLSConfig    TLSConfig   `yaml:"TLSConfig"`
+	}
+
+	// TLSConfig describes SSL/TLS configuration.
+	TLSConfig struct {
+		Enabled  bool   `yaml:"Enabled"`
+		Address  string `yaml:"Address"`
+		Port     uint16 `yaml:"Port"`
+		CertFile string `yaml:"CertFile"`
+		KeyFile  string `yaml:"KeyFile"`
 	}
 
 	// NetMode describes the mode the blockchain will operate on.

--- a/config/protocol.mainnet.yml
+++ b/config/protocol.mainnet.yml
@@ -65,6 +65,11 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 10332
+    TLSConfig:
+      Enabled: false
+      Port: 10331
+      CertFile: serv.crt
+      KeyFile: serv.key
   Prometheus:
     Enabled: true
     Port: 2112

--- a/config/protocol.privnet.yml
+++ b/config/protocol.privnet.yml
@@ -51,6 +51,11 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 20331
+    TLSConfig:
+        Enabled: false
+        Port: 20330
+        CertFile: serv.crt
+        KeyFile: serv.key
   Prometheus:
     Enabled: true
     Port: 2112

--- a/config/protocol.testnet.yml
+++ b/config/protocol.testnet.yml
@@ -65,6 +65,11 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: 20332
+    TLSConfig:
+      Enabled: false
+      Port: 20331
+      CertFile: serv.crt
+      KeyFile: serv.key
   Prometheus:
     Enabled: true
     Port: 2112


### PR DESCRIPTION
To generate test certificate:
```bash
openssl genrsa -out https-server.key 2048
openssl ecparam -genkey -name secp384r1 -out https-server.key
openssl req -new -x509 -sha256 -key https-server.key -out https-server.crt -days 3650
```

When testing in a postman, disable certificate checking.