### PR TITLE
rpc: fix invocations of contracts using hash160

### DIFF
--- a/pkg/rpc/request/param.go
+++ b/pkg/rpc/request/param.go
@@ -86,6 +86,9 @@ func (p Param) GetUint160FromHex() (util.Uint160, error) {
 	if err != nil {
 		return util.Uint160{}, err
 	}
+	if len(s) == 2*util.Uint160Size+2 && s[0] == '0' && s[1] == 'x' {
+		s = s[2:]
+	}
 
 	return util.Uint160DecodeStringLE(s)
 }


### PR DESCRIPTION
ERROR   Error encountered with rpc request      {"error": "expected string size of 40 got 42",...

