### PR TITLE
config: add default ping timeouts config value

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -155,7 +155,10 @@ func Load(path string, netMode NetMode) (Config, error) {
 		ProtocolConfiguration: ProtocolConfiguration{
 			SystemFee: SystemFee{},
 		},
-		ApplicationConfiguration: ApplicationConfiguration{},
+		ApplicationConfiguration: ApplicationConfiguration{
+			PingInterval: 30,
+			PingTimeout:  90,
+		},
 	}
 
 	err = yaml.Unmarshal(configData, &config)


### PR DESCRIPTION
closes #680

Problem: cannot connect to neo-go node with a client with default ping
timeouts values

Solution: added default config values for PingInterval=30 and PingTimeout=90