### PR TITLE
core: fix contract's state migration and don't swallow errors

### DIFF
--- a/pkg/core/interop_neo.go
+++ b/pkg/core/interop_neo.go
@@ -579,7 +579,10 @@ func (ic *interopContext) contractMigrate(v *vm.VM) error {
 			}
 			for k, v := range siMap {
 				v.IsConst = false
-				_ = ic.dao.PutStorageItem(hash, []byte(k), v)
+				err = ic.dao.PutStorageItem(contract.ScriptHash(), []byte(k), v)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes difference in state changes at mainnet's block 2442790 because contract
migration in b4eb2dc35226e6520ee4e09a56197dff91547b50a7f57edc82930fc18c75dffc
doesn't actually transfer the storage state, it only deletes the old one.

And add an error check just in case.
