### PR TITLE
smartcontract: marshal Integer values to JSON-strings

### DIFF
--- a/pkg/smartcontract/param_type.go
+++ b/pkg/smartcontract/param_type.go
@@ -181,7 +181,7 @@ func adjustValToType(typ ParamType, val string) (interface{}, error) {
 			return nil, errors.New("invalid boolean value")
 		}
 	case IntegerType:
-		return strconv.Atoi(val)
+		return strconv.ParseInt(val, 10, 64)
 	case Hash160Type:
 		u, err := address.StringToUint160(val)
 		if err == nil {

--- a/pkg/smartcontract/param_type_test.go
+++ b/pkg/smartcontract/param_type_test.go
@@ -185,15 +185,15 @@ func TestAdjustValToType(t *testing.T) {
 	}, {
 		typ: IntegerType,
 		val: "0",
-		out: 0,
+		out: int64(0),
 	}, {
 		typ: IntegerType,
 		val: "42",
-		out: 42,
+		out: int64(42),
 	}, {
 		typ: IntegerType,
 		val: "-42",
-		out: -42,
+		out: int64(-42),
 	}, {
 		typ: IntegerType,
 		val: "q",

--- a/pkg/smartcontract/parameter.go
+++ b/pkg/smartcontract/parameter.go
@@ -63,8 +63,16 @@ func (p *Parameter) MarshalJSON() ([]byte, error) {
 		resultErr      error
 	)
 	switch p.Type {
-	case BoolType, IntegerType, StringType, Hash256Type, Hash160Type:
+	case BoolType, StringType, Hash256Type, Hash160Type:
 		resultRawValue, resultErr = json.Marshal(p.Value)
+	case IntegerType:
+		val, ok := p.Value.(int64)
+		if !ok {
+			resultErr = errors.New("invalid integer value")
+			break
+		}
+		valStr := strconv.FormatInt(val, 10)
+		resultRawValue = json.RawMessage(`"` + valStr + `"`)
 	case PublicKeyType, ByteArrayType, SignatureType:
 		if p.Value == nil {
 			resultRawValue = []byte("null")

--- a/pkg/smartcontract/parameter_test.go
+++ b/pkg/smartcontract/parameter_test.go
@@ -384,13 +384,13 @@ func TestNewParameterFromString(t *testing.T) {
 		out: Parameter{StringType, "qwerty"},
 	}, {
 		in:  "42",
-		out: Parameter{IntegerType, 42},
+		out: Parameter{IntegerType, int64(42)},
 	}, {
 		in:  "Hello, 世界",
 		out: Parameter{StringType, "Hello, 世界"},
 	}, {
 		in:  `\4\2`,
-		out: Parameter{IntegerType, 42},
+		out: Parameter{IntegerType, int64(42)},
 	}, {
 		in:  `\\4\2`,
 		out: Parameter{StringType, `\42`},
@@ -399,7 +399,7 @@ func TestNewParameterFromString(t *testing.T) {
 		out: Parameter{StringType, `\42`},
 	}, {
 		in:  "int:42",
-		out: Parameter{IntegerType, 42},
+		out: Parameter{IntegerType, int64(42)},
 	}, {
 		in:  "true",
 		out: Parameter{BoolType, true},


### PR DESCRIPTION
It is done so in C# implementation, we better be
as compatible as possible.
Closes #770.