### PR TITLE
vm: make NewBigInteger accept int64

### DIFF
--- a/pkg/vm/cli/cli.go
+++ b/pkg/vm/cli/cli.go
@@ -434,7 +434,7 @@ func parseArgs(args []string) ([]vm.StackItem, error) {
 				return nil, errors.New("failed to parse bool parameter")
 			}
 		case intType:
-			val, err := strconv.Atoi(value)
+			val, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/vm/stack_item.go
+++ b/pkg/vm/stack_item.go
@@ -191,9 +191,9 @@ type BigIntegerItem struct {
 }
 
 // NewBigIntegerItem returns an new BigIntegerItem object.
-func NewBigIntegerItem(value int) *BigIntegerItem {
+func NewBigIntegerItem(value int64) *BigIntegerItem {
 	return &BigIntegerItem{
-		value: big.NewInt(int64(value)),
+		value: big.NewInt(value),
 	}
 }
 


### PR DESCRIPTION
It is more correct upconvert to int64 if needed,
so precision is never lost.