### PR TITLE
smartcontract: do not require pointer in MarshalYAML

### DIFF
--- a/pkg/smartcontract/param_type.go
+++ b/pkg/smartcontract/param_type.go
@@ -87,7 +87,7 @@ func (pt *ParamType) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalYAML implements the YAML Marshaler interface.
-func (pt *ParamType) MarshalYAML() (interface{}, error) {
+func (pt ParamType) MarshalYAML() (interface{}, error) {
 	return pt.String(), nil
 }
 


### PR DESCRIPTION
It is a single byte anyway.
Now `contract init` works properly.