### PR TITLE
rpc: push Integer in invocation script properly

### DIFF
--- a/pkg/rpc/request/txBuilder.go
+++ b/pkg/rpc/request/txBuilder.go
@@ -3,7 +3,6 @@ package request
 import (
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
@@ -195,7 +194,7 @@ func CreateFunctionInvocationScript(contract util.Uint160, params Params) ([]byt
 			if err != nil {
 				return nil, err
 			}
-			emit.String(script.BinWriter, strconv.Itoa(num))
+			emit.Int(script.BinWriter, int64(num))
 		case ArrayT:
 			slice, err := params[i].GetArray()
 			if err != nil {

--- a/pkg/rpc/request/tx_builder_test.go
+++ b/pkg/rpc/request/tx_builder_test.go
@@ -25,7 +25,7 @@ func TestInvocationScriptCreationGood(t *testing.T) {
 		script: "087472616e73666572676f459162ceeb248b071ec157d9e4f6fd26fdbe50",
 	}, {
 		ps:     Params{{Type: NumberT, Value: 42}},
-		script: "023432676f459162ceeb248b071ec157d9e4f6fd26fdbe50",
+		script: "012a676f459162ceeb248b071ec157d9e4f6fd26fdbe50",
 	}, {
 		ps:     Params{{Type: StringT, Value: "a"}, {Type: ArrayT, Value: []Param{}}},
 		script: "00c10161676f459162ceeb248b071ec157d9e4f6fd26fdbe50",


### PR DESCRIPTION
`String` is emitted as an `ByteArray` of ASCII symbols which is not the thing we need.