### PR TITLE
testutil: implement helpers for encode/decode routines

### DIFF
--- a/pkg/consensus/cache_test.go
+++ b/pkg/consensus/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/dbft/payload"
+	"github.com/nspcc-dev/neo-go/pkg/internal/random"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,7 +50,7 @@ func getDifferentPayloads(t *testing.T, n int) (payloads []Payload) {
 	payloads = make([]Payload, n)
 	for i := range payloads {
 		var sign [signatureSize]byte
-		fillRandom(t, sign[:])
+		random.Fill(sign[:])
 
 		payloads[i].SetValidatorIndex(uint16(i))
 		payloads[i].SetType(payload.MessageType(commitType))

--- a/pkg/consensus/commit_test.go
+++ b/pkg/consensus/commit_test.go
@@ -3,12 +3,13 @@ package consensus
 import (
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/internal/random"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCommit_Setters(t *testing.T) {
 	var sign [signatureSize]byte
-	fillRandom(t, sign[:])
+	random.Fill(sign[:])
 
 	var c commit
 	c.SetSignature(sign[:])

--- a/pkg/consensus/prepare_request_test.go
+++ b/pkg/consensus/prepare_request_test.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/internal/random"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/require"
 )
@@ -19,9 +20,7 @@ func TestPrepareRequest_Setters(t *testing.T) {
 	p.SetNonce(8765)
 	require.EqualValues(t, 8765, p.Nonce())
 
-	var hashes [2]util.Uint256
-	fillRandom(t, hashes[0][:])
-	fillRandom(t, hashes[1][:])
+	hashes := [2]util.Uint256{random.Uint256(), random.Uint256()}
 
 	p.SetTransactionHashes(hashes[:])
 	require.Equal(t, hashes[:], p.TransactionHashes())

--- a/pkg/core/block/header_test.go
+++ b/pkg/core/block/header_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -26,14 +26,10 @@ func TestHeaderEncodeDecode(t *testing.T) {
 		},
 	}}
 
-	buf := io.NewBufBinWriter()
-	header.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-
+	_ = header.Hash()
 	headerDecode := &Header{}
-	r := io.NewBinReaderFromBuf(buf.Bytes())
-	headerDecode.DecodeBinary(r)
-	assert.Nil(t, r.Err)
+	testserdes.EncodeDecodeBinary(t, &header, headerDecode)
+
 	assert.Equal(t, header.Version, headerDecode.Version, "expected both versions to be equal")
 	assert.Equal(t, header.PrevHash, headerDecode.PrevHash, "expected both prev hashes to be equal")
 	assert.Equal(t, header.MerkleRoot, headerDecode.MerkleRoot, "expected both merkle roots to be equal")

--- a/pkg/core/block/helper_test.go
+++ b/pkg/core/block/helper_test.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,9 +19,7 @@ func getDecodedBlock(t *testing.T, i int) *Block {
 	require.NoError(t, err)
 
 	block := &Block{}
-	r := io.NewBinReaderFromBuf(b)
-	block.DecodeBinary(r)
-	require.NoError(t, r.Err)
+	require.NoError(t, testserdes.DecodeBinary(b, block))
 
 	return block
 }

--- a/pkg/core/helper_test.go
+++ b/pkg/core/helper_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -119,9 +120,7 @@ func getDecodedBlock(t *testing.T, i int) *block.Block {
 	require.NoError(t, err)
 
 	block := &block.Block{}
-	r := io.NewBinReaderFromBuf(b)
-	block.DecodeBinary(r)
-	require.NoError(t, r.Err)
+	require.NoError(t, testserdes.DecodeBinary(b, block))
 
 	return block
 }
@@ -383,9 +382,8 @@ func TestCreateBasicChain(t *testing.T) {
 			bh := bc.GetHeaderHash(i)
 			b, err := bc.GetBlock(bh)
 			require.NoError(t, err)
-			buf := io.NewBufBinWriter()
-			b.EncodeBinary(buf.BinWriter)
-			bytes := buf.Bytes()
+			bytes, err := testserdes.EncodeBinary(b)
+			require.NoError(t, err)
 			writer.WriteU32LE(uint32(len(bytes)))
 			writer.WriteBytes(bytes)
 			require.NoError(t, writer.Err)
@@ -397,10 +395,9 @@ func TestCreateBasicChain(t *testing.T) {
 	var blocks []*block.Block
 	blocks = append(blocks, bc.newBlock(), bc.newBlock(newMinerTX()))
 	for _, b := range blocks {
-		buf := io.NewBufBinWriter()
-		b.EncodeBinary(buf.BinWriter)
-		require.NoError(t, buf.Err)
-		t.Log(hex.EncodeToString(buf.Bytes()))
+		data, err := testserdes.EncodeBinary(b)
+		require.NoError(t, err)
+		t.Log(hex.EncodeToString(data))
 	}
 }
 

--- a/pkg/core/state/account_test.go
+++ b/pkg/core/state/account_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/internal/random"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,25 +36,10 @@ func TestDecodeEncodeAccountState(t *testing.T) {
 		IsFrozen:   true,
 		Votes:      votes,
 		Balances:   balances,
+		Unclaimed:  UnclaimedBalances{Raw: []byte{}},
 	}
 
-	buf := io.NewBufBinWriter()
-	a.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-
-	aDecode := &Account{}
-	r := io.NewBinReaderFromBuf(buf.Bytes())
-	aDecode.DecodeBinary(r)
-	assert.Nil(t, r.Err)
-
-	assert.Equal(t, a.Version, aDecode.Version)
-	assert.Equal(t, a.ScriptHash, aDecode.ScriptHash)
-	assert.Equal(t, a.IsFrozen, aDecode.IsFrozen)
-
-	for i, vote := range a.Votes {
-		assert.Equal(t, vote.X, aDecode.Votes[i].X)
-	}
-	assert.Equal(t, a.Balances, aDecode.Balances)
+	testserdes.EncodeDecodeBinary(t, a, new(Account))
 }
 
 func TestAccountStateBalanceValues(t *testing.T) {

--- a/pkg/core/state/asset_test.go
+++ b/pkg/core/state/asset_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/internal/random"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,14 +27,7 @@ func TestEncodeDecodeAssetState(t *testing.T) {
 		IsFrozen:   false,
 	}
 
-	buf := io.NewBufBinWriter()
-	asset.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-	assetDecode := &Asset{}
-	r := io.NewBinReaderFromBuf(buf.Bytes())
-	assetDecode.DecodeBinary(r)
-	assert.Nil(t, r.Err)
-	assert.Equal(t, asset, assetDecode)
+	testserdes.EncodeDecodeBinary(t, asset, new(Asset))
 }
 
 func TestAssetState_GetName_NEO(t *testing.T) {

--- a/pkg/core/state/contract_test.go
+++ b/pkg/core/state/contract_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,14 +25,9 @@ func TestEncodeDecodeContractState(t *testing.T) {
 	}
 
 	assert.Equal(t, hash.Hash160(script), contract.ScriptHash())
-	buf := io.NewBufBinWriter()
-	contract.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
+
 	contractDecoded := &Contract{}
-	r := io.NewBinReaderFromBuf(buf.Bytes())
-	contractDecoded.DecodeBinary(r)
-	assert.Nil(t, r.Err)
-	assert.Equal(t, contract, contractDecoded)
+	testserdes.EncodeDecodeBinary(t, contract, contractDecoded)
 	assert.Equal(t, contract.ScriptHash(), contractDecoded.ScriptHash())
 }
 

--- a/pkg/core/state/nep5_test.go
+++ b/pkg/core/state/nep5_test.go
@@ -1,11 +1,11 @@
 package state
 
 import (
-	gio "io"
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/nspcc-dev/neo-go/pkg/internal/random"
 	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -15,10 +15,10 @@ import (
 func TestNEP5TransferLog_Append(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	expected := []*NEP5Transfer{
-		randomTransfer(t, r),
-		randomTransfer(t, r),
-		randomTransfer(t, r),
-		randomTransfer(t, r),
+		randomTransfer(r),
+		randomTransfer(r),
+		randomTransfer(r),
+		randomTransfer(r),
 	}
 
 	lg := new(NEP5TransferLog)
@@ -62,26 +62,18 @@ func TestNEP5Transfer_DecodeBinary(t *testing.T) {
 }
 
 func TestNEP5TransferSize(t *testing.T) {
-	tr := randomTransfer(t, rand.New(rand.NewSource(0)))
+	tr := randomTransfer(rand.New(rand.NewSource(0)))
 	size := io.GetVarSize(tr)
 	require.EqualValues(t, NEP5TransferSize, size)
 }
 
-func randomTransfer(t *testing.T, r *rand.Rand) *NEP5Transfer {
-	tr := &NEP5Transfer{
+func randomTransfer(r *rand.Rand) *NEP5Transfer {
+	return &NEP5Transfer{
 		Amount: int64(r.Uint64()),
 		Block:  r.Uint32(),
+		Asset:  random.Uint160(),
+		From:   random.Uint160(),
+		To:     random.Uint160(),
+		Tx:     random.Uint256(),
 	}
-
-	var err error
-	_, err = gio.ReadFull(r, tr.Asset[:])
-	require.NoError(t, err)
-	_, err = gio.ReadFull(r, tr.From[:])
-	require.NoError(t, err)
-	_, err = gio.ReadFull(r, tr.To[:])
-	require.NoError(t, err)
-	_, err = gio.ReadFull(r, tr.Tx[:])
-	require.NoError(t, err)
-
-	return tr
 }

--- a/pkg/core/state/nep5_test.go
+++ b/pkg/core/state/nep5_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/require"
@@ -43,7 +44,7 @@ func TestNEP5Tracker_EncodeBinary(t *testing.T) {
 		LastUpdatedBlock: rand.Uint32(),
 	}
 
-	testEncodeDecode(t, expected, new(NEP5Tracker))
+	testserdes.EncodeDecodeBinary(t, expected, new(NEP5Tracker))
 }
 
 func TestNEP5Transfer_DecodeBinary(t *testing.T) {
@@ -57,7 +58,7 @@ func TestNEP5Transfer_DecodeBinary(t *testing.T) {
 		Tx:        util.Uint256{8, 5, 3},
 	}
 
-	testEncodeDecode(t, expected, new(NEP5Transfer))
+	testserdes.EncodeDecodeBinary(t, expected, new(NEP5Transfer))
 }
 
 func TestNEP5TransferSize(t *testing.T) {
@@ -83,15 +84,4 @@ func randomTransfer(t *testing.T, r *rand.Rand) *NEP5Transfer {
 	require.NoError(t, err)
 
 	return tr
-}
-
-func testEncodeDecode(t *testing.T, expected, actual io.Serializable) {
-	w := io.NewBufBinWriter()
-	expected.EncodeBinary(w.BinWriter)
-	require.NoError(t, w.Err)
-
-	r := io.NewBinReaderFromBuf(w.Bytes())
-	actual.DecodeBinary(r)
-	require.NoError(t, r.Err)
-	require.Equal(t, expected, actual)
 }

--- a/pkg/core/state/notification_event_test.go
+++ b/pkg/core/state/notification_event_test.go
@@ -4,25 +4,18 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/internal/random"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
-	"github.com/stretchr/testify/assert"
+	"github.com/nspcc-dev/neo-go/pkg/vm"
 )
 
 func TestEncodeDecodeNotificationEvent(t *testing.T) {
 	event := &NotificationEvent{
 		ScriptHash: random.Uint160(),
-		Item:       nil,
+		Item:       vm.NewBoolItem(true),
 	}
 
-	buf := io.NewBufBinWriter()
-	event.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-
-	eventDecoded := &NotificationEvent{}
-	reader := io.NewBinReaderFromBuf(buf.Bytes())
-	eventDecoded.DecodeBinary(reader)
-	assert.Equal(t, event, eventDecoded)
+	testserdes.EncodeDecodeBinary(t, event, new(NotificationEvent))
 }
 
 func TestEncodeDecodeAppExecResult(t *testing.T) {
@@ -34,12 +27,6 @@ func TestEncodeDecodeAppExecResult(t *testing.T) {
 		Stack:       []smartcontract.Parameter{},
 		Events:      []NotificationEvent{},
 	}
-	buf := io.NewBufBinWriter()
-	appExecResult.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
 
-	appExecResultDecoded := &AppExecResult{}
-	reader := io.NewBinReaderFromBuf(buf.Bytes())
-	appExecResultDecoded.DecodeBinary(reader)
-	assert.Equal(t, appExecResult, appExecResultDecoded)
+	testserdes.EncodeDecodeBinary(t, appExecResult, new(AppExecResult))
 }

--- a/pkg/core/state/storage_item_test.go
+++ b/pkg/core/state/storage_item_test.go
@@ -3,9 +3,7 @@ package state
 import (
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 )
 
 func TestEncodeDecodeStorageItem(t *testing.T) {
@@ -13,14 +11,6 @@ func TestEncodeDecodeStorageItem(t *testing.T) {
 		Value:   []byte{},
 		IsConst: false,
 	}
-	buf := io.NewBufBinWriter()
-	storageItem.EncodeBinary(buf.BinWriter)
-	require.NoError(t, buf.Err)
 
-	decodedStorageItem := &StorageItem{}
-	r := io.NewBinReaderFromBuf(buf.Bytes())
-	decodedStorageItem.DecodeBinary(r)
-	require.NoError(t, r.Err)
-
-	assert.Equal(t, storageItem, decodedStorageItem)
+	testserdes.EncodeDecodeBinary(t, storageItem, new(StorageItem))
 }

--- a/pkg/core/state/unclaimed_test.go
+++ b/pkg/core/state/unclaimed_test.go
@@ -7,18 +7,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUnclaimedBalance_Structure(t *testing.T) {
 	b := randomUnclaimed(t)
-	w := io.NewBufBinWriter()
-	b.EncodeBinary(w.BinWriter)
-	require.NoError(t, w.Err)
-
-	buf := w.Bytes()
+	buf, err := testserdes.EncodeBinary(b)
+	require.NoError(t, err)
 	require.Equal(t, UnclaimedBalanceSize, len(buf))
 	require.Equal(t, b.Tx.BytesBE(), buf[:util.Uint256Size])
 	require.Equal(t, b.Index, binary.LittleEndian.Uint16(buf[util.Uint256Size:]))

--- a/pkg/core/state/unclaimed_test.go
+++ b/pkg/core/state/unclaimed_test.go
@@ -2,11 +2,10 @@ package state
 
 import (
 	"encoding/binary"
-	gio "io"
 	"math/rand"
 	"testing"
-	"time"
 
+	"github.com/nspcc-dev/neo-go/pkg/internal/random"
 	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/require"
@@ -64,10 +63,7 @@ func TestUnclaimedBalances_ForEach(t *testing.T) {
 
 func randomUnclaimed(t *testing.T) *UnclaimedBalance {
 	b := new(UnclaimedBalance)
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	_, err := gio.ReadFull(r, b.Tx[:])
-	require.NoError(t, err)
-
+	b.Tx = random.Uint256()
 	b.Index = uint16(rand.Uint32())
 	b.Start = rand.Uint32()
 	b.End = rand.Uint32()

--- a/pkg/core/state/unspent_coin_test.go
+++ b/pkg/core/state/unspent_coin_test.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/internal/random"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDecodeEncodeUnspentCoin(t *testing.T) {
@@ -44,11 +43,5 @@ func TestDecodeEncodeUnspentCoin(t *testing.T) {
 		},
 	}
 
-	buf := io.NewBufBinWriter()
-	unspent.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-	unspentDecode := &UnspentCoin{}
-	r := io.NewBinReaderFromBuf(buf.Bytes())
-	unspentDecode.DecodeBinary(r)
-	assert.Nil(t, r.Err)
+	testserdes.EncodeDecodeBinary(t, unspent, new(UnspentCoin))
 }

--- a/pkg/core/state/validator_test.go
+++ b/pkg/core/state/validator_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/require"
 )
@@ -16,15 +16,8 @@ func TestValidatorState_DecodeEncodeBinary(t *testing.T) {
 		Registered: false,
 		Votes:      util.Fixed8(10),
 	}
-	buf := io.NewBufBinWriter()
-	state.EncodeBinary(buf.BinWriter)
-	require.NoError(t, buf.Err)
 
-	decodedState := &Validator{}
-	reader := io.NewBinReaderFromBuf(buf.Bytes())
-	decodedState.DecodeBinary(reader)
-	require.NoError(t, reader.Err)
-	require.Equal(t, state, decodedState)
+	testserdes.EncodeDecodeBinary(t, state, new(Validator))
 }
 
 func TestRegisteredAndHasVotes_Registered(t *testing.T) {

--- a/pkg/core/transaction/contract_test.go
+++ b/pkg/core/transaction/contract_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,9 +30,7 @@ func TestEncodeDecodeContract(t *testing.T) {
 	assert.Equal(t, "bdf6cc3b9af12a7565bda80933a75ee8cef1bc771d0d58effc08e4c8b436da79", tx.Hash().StringLE())
 
 	// Encode
-	buf := io.NewBufBinWriter()
-
-	tx.EncodeBinary(buf.BinWriter)
-	assert.Equal(t, nil, buf.Err)
-	assert.Equal(t, rawtx, hex.EncodeToString(buf.Bytes()))
+	data, err := testserdes.EncodeBinary(tx)
+	assert.NoError(t, err)
+	assert.Equal(t, rawtx, hex.EncodeToString(data))
 }

--- a/pkg/core/transaction/enrollment_test.go
+++ b/pkg/core/transaction/enrollment_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,9 +16,7 @@ func TestEncodeDecodeEnrollment(t *testing.T) {
 	assert.IsType(t, tx.Data, &EnrollmentTX{})
 	assert.Equal(t, 0, int(tx.Version))
 
-	buf := io.NewBufBinWriter()
-	tx.EncodeBinary(buf.BinWriter)
-
-	assert.Equal(t, nil, buf.Err)
-	assert.Equal(t, rawtx, hex.EncodeToString(buf.Bytes()))
+	data, err := testserdes.EncodeBinary(tx)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, rawtx, hex.EncodeToString(data))
 }

--- a/pkg/core/transaction/helper_test.go
+++ b/pkg/core/transaction/helper_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,8 +21,6 @@ func decodeTransaction(rawTX string, t *testing.T) *Transaction {
 	b, err1 := hex.DecodeString(rawTX)
 	assert.Nil(t, err1)
 	tx := &Transaction{}
-	r := io.NewBinReaderFromBuf(b)
-	tx.DecodeBinary(r)
-	assert.Nil(t, r.Err)
+	assert.NoError(t, testserdes.DecodeBinary(b, tx))
 	return tx
 }

--- a/pkg/core/transaction/invocation_test.go
+++ b/pkg/core/transaction/invocation_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,18 +16,13 @@ func TestInvocationZeroScript(t *testing.T) {
 	require.NoError(t, err)
 
 	inv := &InvocationTX{Version: 1}
-	r := io.NewBinReaderFromBuf(in)
-
-	inv.DecodeBinary(r)
-	assert.Error(t, r.Err)
+	assert.Error(t, testserdes.DecodeBinary(in, inv))
 
 	// PUSH1 script.
 	in, err = hex.DecodeString("01510000000000000000")
 	require.NoError(t, err)
-	r = io.NewBinReaderFromBuf(in)
 
-	inv.DecodeBinary(r)
-	assert.NoError(t, r.Err)
+	assert.NoError(t, testserdes.DecodeBinary(in, inv))
 }
 
 func TestInvocationNegativeGas(t *testing.T) {
@@ -36,18 +31,13 @@ func TestInvocationNegativeGas(t *testing.T) {
 	require.NoError(t, err)
 
 	inv := &InvocationTX{Version: 1}
-	r := io.NewBinReaderFromBuf(in)
-
-	inv.DecodeBinary(r)
-	assert.Error(t, r.Err)
+	assert.Error(t, testserdes.DecodeBinary(in, inv))
 
 	// Positive GAS.
 	in, err = hex.DecodeString("01510100000000000000")
 	require.NoError(t, err)
-	r = io.NewBinReaderFromBuf(in)
 
-	inv.DecodeBinary(r)
-	assert.NoError(t, r.Err)
+	assert.NoError(t, testserdes.DecodeBinary(in, inv))
 	assert.Equal(t, util.Fixed8(1), inv.Gas)
 }
 
@@ -56,15 +46,9 @@ func TestInvocationVersionZero(t *testing.T) {
 	require.NoError(t, err)
 
 	inv := &InvocationTX{Version: 1}
-	r := io.NewBinReaderFromBuf(in)
-
-	inv.DecodeBinary(r)
-	assert.Error(t, r.Err)
+	assert.Error(t, testserdes.DecodeBinary(in, inv))
 
 	inv = &InvocationTX{Version: 0}
-	r = io.NewBinReaderFromBuf(in)
-
-	inv.DecodeBinary(r)
-	assert.NoError(t, r.Err)
+	assert.NoError(t, testserdes.DecodeBinary(in, inv))
 	assert.Equal(t, util.Fixed8(0), inv.Gas)
 }

--- a/pkg/core/transaction/miner_test.go
+++ b/pkg/core/transaction/miner_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,10 +21,7 @@ func TestEncodeDecodeMiner(t *testing.T) {
 	assert.Equal(t, "a1f219dc6be4c35eca172e65e02d4591045220221b1543f1a4b67b9e9442c264", tx.Hash().StringLE())
 
 	// Encode
-	buf := io.NewBufBinWriter()
-
-	tx.EncodeBinary(buf.BinWriter)
-	assert.Equal(t, nil, buf.Err)
-
-	assert.Equal(t, rawtx, hex.EncodeToString(buf.Bytes()))
+	data, err := testserdes.EncodeBinary(tx)
+	assert.NoError(t, err)
+	assert.Equal(t, rawtx, hex.EncodeToString(data))
 }

--- a/pkg/core/transaction/register_test.go
+++ b/pkg/core/transaction/register_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,21 +24,14 @@ func TestRegisterTX(t *testing.T) {
 			Precision: 8,
 			Admin:     someuint160,
 		},
+		Attributes: []Attribute{},
+		Inputs:     []Input{},
+		Outputs:    []Output{},
+		Scripts:    []Witness{},
 	}
+	_ = tx.Hash()
 
-	buf := io.NewBufBinWriter()
-	tx.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-
-	b := buf.Bytes()
-	txDecode := &Transaction{}
-	r := io.NewBinReaderFromBuf(b)
-	txDecode.DecodeBinary(r)
-	assert.Nil(t, r.Err)
-	txData := tx.Data.(*RegisterTX)
-	txDecodeData := txDecode.Data.(*RegisterTX)
-	assert.Equal(t, txData, txDecodeData)
-	assert.Equal(t, tx.Hash(), txDecode.Hash())
+	testserdes.EncodeDecodeBinary(t, tx, new(Transaction))
 }
 
 func TestDecodeRegisterTXFromRawString(t *testing.T) {
@@ -47,9 +40,7 @@ func TestDecodeRegisterTXFromRawString(t *testing.T) {
 	require.NoError(t, err)
 
 	tx := &Transaction{}
-	r := io.NewBinReaderFromBuf(b)
-	tx.DecodeBinary(r)
-	assert.Nil(t, r.Err)
+	assert.NoError(t, testserdes.DecodeBinary(b, tx))
 	assert.Equal(t, RegisterType, tx.Type)
 	txData := tx.Data.(*RegisterTX)
 	assert.Equal(t, GoverningToken, txData.AssetType)
@@ -60,14 +51,5 @@ func TestDecodeRegisterTXFromRawString(t *testing.T) {
 	assert.Equal(t, "Abf2qMs1pzQb8kYk9RuxtUb9jtRKJVuBJt", address.Uint160ToString(txData.Admin))
 	assert.Equal(t, "c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b", tx.Hash().StringLE())
 
-	buf := io.NewBufBinWriter()
-	tx.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-	benc := buf.Bytes()
-
-	txDecode := &Transaction{}
-	encreader := io.NewBinReaderFromBuf(benc)
-	txDecode.DecodeBinary(encreader)
-	assert.Nil(t, encreader.Err)
-	assert.Equal(t, tx, txDecode)
+	testserdes.EncodeDecodeBinary(t, tx, new(Transaction))
 }

--- a/pkg/core/transaction/state_test.go
+++ b/pkg/core/transaction/state_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,9 +30,7 @@ func TestEncodeDecodeState(t *testing.T) {
 	assert.Equal(t, Validator, descriptor.Type)
 
 	// Encode
-	buf := io.NewBufBinWriter()
-	tx.EncodeBinary(buf.BinWriter)
-
-	assert.Equal(t, nil, buf.Err)
-	assert.Equal(t, rawtx, hex.EncodeToString(buf.Bytes()))
+	data, err := testserdes.EncodeBinary(tx)
+	assert.NoError(t, err)
+	assert.Equal(t, rawtx, hex.EncodeToString(data))
 }

--- a/pkg/crypto/keys/publickey_test.go
+++ b/pkg/crypto/keys/publickey_test.go
@@ -7,16 +7,14 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEncodeDecodeInfinity(t *testing.T) {
 	key := &PublicKey{}
-	buf := io.NewBufBinWriter()
-	key.EncodeBinary(buf.BinWriter)
-	require.NoError(t, buf.Err)
-	b := buf.Bytes()
+	b, err := testserdes.EncodeBinary(key)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(b))
 
 	keyDecode := &PublicKey{}
@@ -29,24 +27,13 @@ func TestEncodeDecodePublicKey(t *testing.T) {
 		k, err := NewPrivateKey()
 		require.NoError(t, err)
 		p := k.PublicKey()
-		buf := io.NewBufBinWriter()
-		p.EncodeBinary(buf.BinWriter)
-		require.NoError(t, buf.Err)
-		b := buf.Bytes()
-
-		pDecode := &PublicKey{}
-		require.NoError(t, pDecode.DecodeBytes(b))
-		require.Equal(t, p.X, pDecode.X)
+		testserdes.EncodeDecodeBinary(t, p, new(PublicKey))
 	}
 
 	errCases := [][]byte{{}, {0x02}, {0x04}}
 
 	for _, tc := range errCases {
-		r := io.NewBinReaderFromBuf(tc)
-
-		var pDecode PublicKey
-		pDecode.DecodeBinary(r)
-		require.Error(t, r.Err)
+		require.Error(t, testserdes.DecodeBinary(tc, new(PublicKey)))
 	}
 }
 

--- a/pkg/internal/random/random_util.go
+++ b/pkg/internal/random/random_util.go
@@ -18,6 +18,20 @@ func String(n int) string {
 	return string(b)
 }
 
+// Bytes returns a random byte slice of specified length.
+func Bytes(n int) []byte {
+	b := make([]byte, n)
+	Fill(b)
+	return b
+}
+
+// Fill fills buffer with random bytes.
+func Fill(buf []byte) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// Rand reader returns no errors
+	r.Read(buf)
+}
+
 // Int returns a random integer in [min,max).
 func Int(min, max int) int {
 	return min + rand.Intn(max-min)

--- a/pkg/internal/testserdes/testing.go
+++ b/pkg/internal/testserdes/testing.go
@@ -1,0 +1,44 @@
+package testserdes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/stretchr/testify/require"
+)
+
+// MarshalUnmarshalJSON checks if expected stays the same after
+// marshal/unmarshal via JSON.
+func MarshalUnmarshalJSON(t *testing.T, expected, actual interface{}) {
+	data, err := json.Marshal(expected)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, actual))
+	require.Equal(t, expected, actual)
+}
+
+// EncodeDecodeBinary checks if expected stays the same after
+// serializing/deserializing via io.Serializable methods.
+func EncodeDecodeBinary(t *testing.T, expected, actual io.Serializable) {
+	data, err := EncodeBinary(expected)
+	require.NoError(t, err)
+	require.NoError(t, DecodeBinary(data, actual))
+	require.Equal(t, expected, actual)
+}
+
+// EncodeBinary serializes a to a byte slice.
+func EncodeBinary(a io.Serializable) ([]byte, error) {
+	w := io.NewBufBinWriter()
+	a.EncodeBinary(w.BinWriter)
+	if w.Err != nil {
+		return nil, w.Err
+	}
+	return w.Bytes(), nil
+}
+
+// DecodeBinary deserializes a from a byte slice.
+func DecodeBinary(data []byte, a io.Serializable) error {
+	r := io.NewBinReaderFromBuf(data)
+	a.DecodeBinary(r)
+	return r.Err
+}

--- a/pkg/network/payload/address_test.go
+++ b/pkg/network/payload/address_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +15,6 @@ func TestEncodeDecodeAddress(t *testing.T) {
 		e, _ = net.ResolveTCPAddr("tcp", "127.0.0.1:2000")
 		ts   = time.Now()
 		addr = NewAddressAndTime(e, ts)
-		buf  = io.NewBufBinWriter()
 	)
 
 	assert.Equal(t, ts.UTC().Unix(), int64(addr.Timestamp))
@@ -23,16 +22,8 @@ func TestEncodeDecodeAddress(t *testing.T) {
 	copy(aatip, addr.IP[:])
 	assert.Equal(t, e.IP, aatip)
 	assert.Equal(t, e.Port, int(addr.Port))
-	addr.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
 
-	b := buf.Bytes()
-	r := io.NewBinReaderFromBuf(b)
-	addrDecode := &AddressAndTime{}
-	addrDecode.DecodeBinary(r)
-	assert.Nil(t, r.Err)
-
-	assert.Equal(t, addr, addrDecode)
+	testserdes.EncodeDecodeBinary(t, addr, new(AddressAndTime))
 }
 
 func TestEncodeDecodeAddressList(t *testing.T) {
@@ -43,15 +34,5 @@ func TestEncodeDecodeAddressList(t *testing.T) {
 		addrList.Addrs[i] = NewAddressAndTime(e, time.Now())
 	}
 
-	buf := io.NewBufBinWriter()
-	addrList.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-
-	b := buf.Bytes()
-	r := io.NewBinReaderFromBuf(b)
-	addrListDecode := &AddressList{}
-	addrListDecode.DecodeBinary(r)
-	assert.Nil(t, r.Err)
-
-	assert.Equal(t, addrList, addrListDecode)
+	testserdes.EncodeDecodeBinary(t, addrList, new(AddressList))
 }

--- a/pkg/network/payload/getblocks_test.go
+++ b/pkg/network/payload/getblocks_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetBlockEncodeDecode(t *testing.T) {
@@ -18,16 +17,7 @@ func TestGetBlockEncodeDecode(t *testing.T) {
 	}
 
 	p := NewGetBlocks(start, util.Uint256{})
-	buf := io.NewBufBinWriter()
-	p.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-
-	b := buf.Bytes()
-	r := io.NewBinReaderFromBuf(b)
-	pDecode := &GetBlocks{}
-	pDecode.DecodeBinary(r)
-	assert.Nil(t, r.Err)
-	assert.Equal(t, p, pDecode)
+	testserdes.EncodeDecodeBinary(t, p, new(GetBlocks))
 }
 
 func TestGetBlockEncodeDecodeWithHashStop(t *testing.T) {
@@ -41,14 +31,5 @@ func TestGetBlockEncodeDecodeWithHashStop(t *testing.T) {
 		stop = hash.Sha256([]byte("e"))
 	)
 	p := NewGetBlocks(start, stop)
-	buf := io.NewBufBinWriter()
-	p.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-
-	b := buf.Bytes()
-	r := io.NewBinReaderFromBuf(b)
-	pDecode := &GetBlocks{}
-	pDecode.DecodeBinary(r)
-	assert.Nil(t, r.Err)
-	assert.Equal(t, p, pDecode)
+	testserdes.EncodeDecodeBinary(t, p, new(GetBlocks))
 }

--- a/pkg/network/payload/inventory_test.go
+++ b/pkg/network/payload/inventory_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	. "github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,24 +16,14 @@ func TestInventoryEncodeDecode(t *testing.T) {
 	}
 	inv := NewInventory(BlockType, hashes)
 
-	buf := io.NewBufBinWriter()
-	inv.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-
-	b := buf.Bytes()
-	r := io.NewBinReaderFromBuf(b)
-	invDecode := &Inventory{}
-	invDecode.DecodeBinary(r)
-	assert.Nil(t, r.Err)
-	assert.Equal(t, inv, invDecode)
+	testserdes.EncodeDecodeBinary(t, inv, new(Inventory))
 }
 
 func TestEmptyInv(t *testing.T) {
 	msgInv := NewInventory(TXType, []Uint256{})
 
-	buf := io.NewBufBinWriter()
-	msgInv.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-	assert.Equal(t, []byte{byte(TXType), 0}, buf.Bytes())
+	data, err := testserdes.EncodeBinary(msgInv)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{byte(TXType), 0}, data)
 	assert.Equal(t, 0, len(msgInv.Hashes))
 }

--- a/pkg/network/payload/ping_test.go
+++ b/pkg/network/payload/ping_test.go
@@ -3,7 +3,7 @@ package payload
 import (
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,14 +11,8 @@ func TestEncodeDecodeBinary(t *testing.T) {
 	payload := NewPing(uint32(1), uint32(2))
 	assert.NotEqual(t, 0, payload.Timestamp)
 
-	bufBinWriter := io.NewBufBinWriter()
-	payload.EncodeBinary(bufBinWriter.BinWriter)
-	assert.Nil(t, bufBinWriter.Err)
-
-	binReader := io.NewBinReaderFromBuf(bufBinWriter.Bytes())
 	decodedPing := &Ping{}
-	decodedPing.DecodeBinary(binReader)
-	assert.Nil(t, binReader.Err)
+	testserdes.EncodeDecodeBinary(t, payload, decodedPing)
 
 	assert.Equal(t, uint32(1), decodedPing.LastBlockIndex)
 	assert.Equal(t, uint32(2), decodedPing.Nonce)

--- a/pkg/network/payload/version_test.go
+++ b/pkg/network/payload/version_test.go
@@ -3,7 +3,7 @@ package payload
 import (
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,17 +15,9 @@ func TestVersionEncodeDecode(t *testing.T) {
 	var relay = true
 
 	version := NewVersion(id, port, useragent, height, relay)
-
-	buf := io.NewBufBinWriter()
-	version.EncodeBinary(buf.BinWriter)
-	assert.Nil(t, buf.Err)
-	b := buf.Bytes()
-	assert.Equal(t, io.GetVarSize(version), len(b))
-
-	r := io.NewBinReaderFromBuf(b)
 	versionDecoded := &Version{}
-	versionDecoded.DecodeBinary(r)
-	assert.Nil(t, r.Err)
+	testserdes.EncodeDecodeBinary(t, version, versionDecoded)
+
 	assert.Equal(t, versionDecoded.Nonce, id)
 	assert.Equal(t, versionDecoded.Port, port)
 	assert.Equal(t, versionDecoded.UserAgent, []byte(useragent))

--- a/pkg/smartcontract/context/context_test.go
+++ b/pkg/smartcontract/context/context_test.go
@@ -2,11 +2,11 @@ package context
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/vm"
@@ -137,12 +137,7 @@ func TestParameterContext_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	data, err = json.Marshal(expected)
-	require.NoError(t, err)
-
-	actual := new(ParameterContext)
-	require.NoError(t, json.Unmarshal(data, actual))
-	require.Equal(t, expected, actual)
+	testserdes.MarshalUnmarshalJSON(t, expected, new(ParameterContext))
 }
 
 func getPrivateKeys(t *testing.T, n int) ([]*keys.PrivateKey, []*keys.PublicKey) {

--- a/pkg/smartcontract/context/item_test.go
+++ b/pkg/smartcontract/context/item_test.go
@@ -2,12 +2,10 @@ package context
 
 import (
 	"encoding/hex"
-	"io"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neo-go/pkg/internal/random"
 	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -46,22 +44,13 @@ func TestContextItem_MarshalJSON(t *testing.T) {
 		Script: util.Uint160{1, 2, 3},
 		Parameters: []smartcontract.Parameter{{
 			Type:  smartcontract.SignatureType,
-			Value: getRandomSlice(t, 64),
+			Value: random.Bytes(64),
 		}},
 		Signatures: map[string][]byte{
-			hex.EncodeToString(priv1.PublicKey().Bytes()): getRandomSlice(t, 64),
-			hex.EncodeToString(priv2.PublicKey().Bytes()): getRandomSlice(t, 64),
+			hex.EncodeToString(priv1.PublicKey().Bytes()): random.Bytes(64),
+			hex.EncodeToString(priv2.PublicKey().Bytes()): random.Bytes(64),
 		},
 	}
 
 	testserdes.MarshalUnmarshalJSON(t, expected, new(Item))
-}
-
-func getRandomSlice(t *testing.T, n int) []byte {
-	src := rand.NewSource(time.Now().UnixNano())
-	r := rand.New(src)
-	data := make([]byte, n)
-	_, err := io.ReadFull(r, data)
-	require.NoError(t, err)
-	return data
 }

--- a/pkg/smartcontract/context/item_test.go
+++ b/pkg/smartcontract/context/item_test.go
@@ -2,17 +2,15 @@ package context
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"io"
 	"math/rand"
 	"testing"
 	"time"
 
-	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
-
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,12 +54,7 @@ func TestContextItem_MarshalJSON(t *testing.T) {
 		},
 	}
 
-	data, err := json.Marshal(expected)
-	require.NoError(t, err)
-
-	actual := new(Item)
-	require.NoError(t, json.Unmarshal(data, actual))
-	assert.Equal(t, expected, actual)
+	testserdes.MarshalUnmarshalJSON(t, expected, new(Item))
 }
 
 func getRandomSlice(t *testing.T, n int) []byte {

--- a/pkg/smartcontract/parameter_test.go
+++ b/pkg/smartcontract/parameter_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -446,25 +446,14 @@ func TestNewParameterFromString(t *testing.T) {
 
 func TestEncodeDecodeBinary(t *testing.T) {
 	for _, tc := range marshalJSONTestCases {
-		w := io.NewBufBinWriter()
-		tc.input.EncodeBinary(w.BinWriter)
-		require.NoError(t, w.Err)
-
-		r := io.NewBinReaderFromBuf(w.Bytes())
-		var p Parameter
-		p.DecodeBinary(r)
-		require.NoError(t, r.Err)
-		require.Equal(t, tc.input, p)
+		testserdes.EncodeDecodeBinary(t, &tc.input, new(Parameter))
 	}
 
 	t.Run("unknown", func(t *testing.T) {
 		p := Parameter{Type: UnknownType}
-		w := io.NewBufBinWriter()
-		p.EncodeBinary(w.BinWriter)
-		require.Error(t, w.Err)
+		_, err := testserdes.EncodeBinary(&p)
+		require.Error(t, err)
 
-		r := io.NewBinReaderFromBuf([]byte{0xAA})
-		p.DecodeBinary(r)
-		require.Error(t, r.Err)
+		require.Error(t, testserdes.DecodeBinary([]byte{0xAA}, &p))
 	})
 }

--- a/pkg/util/fixed8_test.go
+++ b/pkg/util/fixed8_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-yaml/yaml"
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -175,12 +175,5 @@ func TestFixed8_Arith(t *testing.T) {
 func TestFixed8_Serializable(t *testing.T) {
 	a := Fixed8(0x0102030405060708)
 
-	w := io.NewBufBinWriter()
-	a.EncodeBinary(w.BinWriter)
-	require.NoError(t, w.Err)
-
-	var b Fixed8
-	r := io.NewBinReaderFromBuf(w.Bytes())
-	b.DecodeBinary(r)
-	require.Equal(t, a, b)
+	testserdes.EncodeDecodeBinary(t, &a, new(Fixed8))
 }

--- a/pkg/util/uint160_test.go
+++ b/pkg/util/uint160_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,12 +20,7 @@ func TestUint160UnmarshalJSON(t *testing.T) {
 	assert.NoError(t, u1.UnmarshalJSON([]byte(`"`+str+`"`)))
 	assert.True(t, expected.Equals(u1))
 
-	s, err := expected.MarshalJSON()
-	require.NoError(t, err)
-
-	// UnmarshalJSON decodes hex-strings prefixed by 0x
-	assert.NoError(t, u2.UnmarshalJSON(s))
-	assert.True(t, expected.Equals(u1))
+	testserdes.MarshalUnmarshalJSON(t, &expected, &u2)
 
 	assert.Error(t, u2.UnmarshalJSON([]byte(`123`)))
 }

--- a/pkg/util/uint256_test.go
+++ b/pkg/util/uint256_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testserdes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,12 +20,7 @@ func TestUint256UnmarshalJSON(t *testing.T) {
 	require.NoError(t, u1.UnmarshalJSON([]byte(`"`+str+`"`)))
 	assert.True(t, expected.Equals(u1))
 
-	s, err := expected.MarshalJSON()
-	require.NoError(t, err)
-
-	// UnmarshalJSON decodes hex-strings prefixed by 0x
-	require.NoError(t, u2.UnmarshalJSON(s))
-	assert.True(t, expected.Equals(u1))
+	testserdes.MarshalUnmarshalJSON(t, &expected, &u2)
 
 	// UnmarshalJSON does not accepts numbers
 	assert.Error(t, u2.UnmarshalJSON([]byte("123")))
@@ -96,12 +91,6 @@ func TestUint256_Serializable(t *testing.T) {
 		17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
 	}
 
-	w := io.NewBufBinWriter()
-	a.EncodeBinary(w.BinWriter)
-	require.NoError(t, w.Err)
-
 	var b Uint256
-	r := io.NewBinReaderFromBuf(w.Bytes())
-	b.DecodeBinary(r)
-	require.Equal(t, a, b)
+	testserdes.EncodeDecodeBinary(t, &a, &b)
 }


### PR DESCRIPTION
Frequently one needs to check if struct serializes/deserializes
properly. This commit implements helpers for such cases including:
1. JSON
2. io.Serializable interface