### PR TITLE
storage: optimize (*MemCachedStore).Persist for memory-backed ps

### DIFF
--- a/pkg/core/storage/memcached_store_test.go
+++ b/pkg/core/storage/memcached_store_test.go
@@ -7,9 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMemCachedStorePersist(t *testing.T) {
-	// persistent Store
-	ps := NewMemoryStore()
+func testMemCachedStorePersist(t *testing.T, ps Store) {
 	// cached Store
 	ts := NewMemCachedStore(ps)
 	// persisting nothing should do nothing
@@ -92,6 +90,22 @@ func checkBatch(t *testing.T, ts *MemCachedStore, put []KeyValue, del []KeyValue
 	for i := range del {
 		assert.Contains(t, b.Deleted, del[i])
 	}
+}
+
+func TestMemCachedPersist(t *testing.T) {
+	t.Run("MemoryStore", func(t *testing.T) {
+		ps := NewMemoryStore()
+		testMemCachedStorePersist(t, ps)
+	})
+	t.Run("MemoryCachedStore", func(t *testing.T) {
+		ps1 := NewMemoryStore()
+		ps2 := NewMemCachedStore(ps1)
+		testMemCachedStorePersist(t, ps2)
+	})
+	t.Run("BoltDBStore", func(t *testing.T) {
+		ps := newBoltStoreForTesting(t)
+		testMemCachedStorePersist(t, ps)
+	})
 }
 
 func TestCachedGetFromPersistent(t *testing.T) {


### PR DESCRIPTION
Most of the time it's persisted into the MemoryStore or MemCachedStore, when
that's the case there is no real need to go through the Batch mechanism as it
incurs multiple copies of the data.

Importing 1.5M mainnet blocks with verification turned off, before:
real    12m39,484s
user    20m48,300s
sys     2m25,022s

After:
real    11m15,053s
user    18m2,755s
sys     2m4,162s

So it's around 10% improvement which looks good enough.