### PR TITLE
vm: make map serialization more compatible with C#

### DIFF
--- a/pkg/vm/serialization.go
+++ b/pkg/vm/serialization.go
@@ -74,8 +74,8 @@ func serializeItemTo(item StackItem, w *io.BinWriter, seen map[StackItem]bool) {
 		w.WriteBytes([]byte{byte(mapT)})
 		w.WriteVarUint(uint64(len(t.value)))
 		for k, v := range t.value {
-			serializeItemTo(v, w, seen)
 			serializeItemTo(makeStackItem(k), w, seen)
+			serializeItemTo(v, w, seen)
 		}
 	}
 }
@@ -128,8 +128,8 @@ func DecodeBinaryStackItem(r *io.BinReader) StackItem {
 		size := int(r.ReadVarUint())
 		m := NewMapItem()
 		for i := 0; i < size; i++ {
-			value := DecodeBinaryStackItem(r)
 			key := DecodeBinaryStackItem(r)
+			value := DecodeBinaryStackItem(r)
 			if r.Err != nil {
 				break
 			}

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -678,6 +678,20 @@ func TestSerializeMap(t *testing.T) {
 	require.Equal(t, item.value, vm.estack.Top().value.(*MapItem).value)
 }
 
+func TestSerializeMapCompat(t *testing.T) {
+	// Create a map, push key and value, add KV to map, serialize.
+	progHex := "c776036b65790576616c7565c468154e656f2e52756e74696d652e53657269616c697a65"
+	resHex := "820100036b6579000576616c7565"
+	prog, err := hex.DecodeString(progHex)
+	require.NoError(t, err)
+	res, err := hex.DecodeString(resHex)
+	require.NoError(t, err)
+
+	vm := load(prog)
+	runVM(t, vm)
+	assert.Equal(t, res, vm.estack.Pop().Bytes())
+}
+
 func TestSerializeInterop(t *testing.T) {
 	vm := load(getSerializeProg())
 	item := NewInteropItem("kek")


### PR DESCRIPTION
C# pushes value and key to the stack of non-serialized items, so key gets
serialized first followed by value. Fixes #806.

Notice though that neither IDictionary in C#, nor map in Go have elements
ordered, so we can easily get a difference in KV pairs order and it would be
impossible to fix.