### PR TITLE
docs: update wallet operations examples in cli documentation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -184,6 +184,6 @@ There is a small subset of commands:
 
 ## Wallet operations
 
-- `./bin/neo-go wallet create -p newWallet` to create new wallet in the path `newWallet`
-- `./bin/neo-go wallet open -p newWallet` to open created wallet in the path `newWallet`
-- `./bin/neo-go wallet create -p newWallet -a` to create new account
+- `./bin/neo-go wallet init -p newWallet` to create new wallet in the path `newWallet`
+- `./bin/neo-go wallet dump -p newWallet` to open created wallet in the path `newWallet`
+- `./bin/neo-go wallet init -p newWallet -a` to create new account


### PR DESCRIPTION
### Problem
In #589 `wallet open` command was renamed to `wallet dump`.
In #757 `wallet create` command was renamed to `wallet init`.


### Solution
Update documentation with correct command examples.
