### PR TITLE
compiler: calculate stack size more precisely

### DIFF
--- a/pkg/compiler/assign_test.go
+++ b/pkg/compiler/assign_test.go
@@ -3,6 +3,8 @@ package compiler_test
 import (
 	"math/big"
 	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/vm"
 )
 
 var assignTestCases = []testCase{
@@ -132,4 +134,19 @@ var assignTestCases = []testCase{
 
 func TestAssignments(t *testing.T) {
 	runTestCases(t, assignTestCases)
+}
+
+func TestManyAssignments(t *testing.T) {
+	src1 := `package foo
+	func Main() int {
+		a := 0
+	`
+	src2 := `return a
+	}`
+
+	for i := 0; i < vm.MaxArraySize; i++ {
+		src1 += "a += 1\n"
+	}
+
+	eval(t, src1+src2, big.NewInt(vm.MaxArraySize))
 }

--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"go/ast"
+	"go/token"
 )
 
 // A funcScope represents the scope within the function context.
@@ -76,7 +77,9 @@ func (c *funcScope) stackSize() int64 {
 	ast.Inspect(c.decl, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.AssignStmt:
-			size += len(n.Rhs)
+			if n.Tok == token.DEFINE {
+				size += len(n.Rhs)
+			}
 		case *ast.ReturnStmt, *ast.IfStmt:
 			size++
 		// This handles the inline GenDecl like "var x = 2"


### PR DESCRIPTION
When calculating number of local variables, only
defining assignments (i.e. via `:=`) must be taken into account.
