### PR TITLE
core: wrap cached dao properly, don't miss cached data

### DIFF
--- a/pkg/core/blockchainer.go
+++ b/pkg/core/blockchainer.go
@@ -5,7 +5,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/block"
 	"github.com/nspcc-dev/neo-go/pkg/core/mempool"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
-	"github.com/nspcc-dev/neo-go/pkg/core/storage"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -41,7 +40,7 @@ type Blockchainer interface {
 	GetScriptHashesForVerifying(*transaction.Transaction) ([]util.Uint160, error)
 	GetStorageItem(scripthash util.Uint160, key []byte) *state.StorageItem
 	GetStorageItems(hash util.Uint160) (map[string]*state.StorageItem, error)
-	GetTestVM() (*vm.VM, storage.Store)
+	GetTestVM() *vm.VM
 	GetTransaction(util.Uint256) (*transaction.Transaction, uint32, error)
 	GetUnspentCoinState(util.Uint256) *state.UnspentCoin
 	References(t *transaction.Transaction) ([]transaction.InOut, error)

--- a/pkg/core/cacheddao_test.go
+++ b/pkg/core/cacheddao_test.go
@@ -8,15 +8,16 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/internal/random"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCachedDaoAccounts(t *testing.T) {
 	store := storage.NewMemoryStore()
 	// Persistent DAO to check for backing storage.
-	pdao := newDao(store)
+	pdao := newSimpleDao(store)
 	// Cached DAO.
-	cdao := newCachedDao(store)
+	cdao := newCachedDao(pdao)
 
 	hash := random.Uint160()
 	_, err := cdao.GetAccountState(hash)
@@ -50,7 +51,8 @@ func TestCachedDaoAccounts(t *testing.T) {
 
 func TestCachedDaoContracts(t *testing.T) {
 	store := storage.NewMemoryStore()
-	dao := newCachedDao(store)
+	pdao := newSimpleDao(store)
+	dao := newCachedDao(pdao)
 
 	script := []byte{0xde, 0xad, 0xbe, 0xef}
 	sh := hash.Hash160(script)
@@ -69,7 +71,7 @@ func TestCachedDaoContracts(t *testing.T) {
 
 	_, err = dao.Persist()
 	require.Nil(t, err)
-	dao2 := newCachedDao(store)
+	dao2 := newCachedDao(pdao)
 	cs2, err = dao2.GetContractState(sh)
 	require.Nil(t, err)
 	require.Equal(t, cs, cs2)
@@ -80,4 +82,50 @@ func TestCachedDaoContracts(t *testing.T) {
 	require.Equal(t, cs, cs2)
 	_, err = dao.GetContractState(sh)
 	require.NotNil(t, err)
+}
+
+func TestCachedCachedDao(t *testing.T) {
+	store := storage.NewMemoryStore()
+	// Persistent DAO to check for backing storage.
+	pdao := newSimpleDao(store)
+	assert.NotEqual(t, store, pdao.store)
+	// Cached DAO.
+	cdao := newCachedDao(pdao)
+	cdaoDao := cdao.dao.(*simpleDao)
+	assert.NotEqual(t, store, cdaoDao.store)
+	assert.NotEqual(t, pdao.store, cdaoDao.store)
+
+	// Cached cached DAO.
+	ccdao := newCachedDao(cdao)
+	ccdaoDao := ccdao.dao.(*cachedDao)
+	intDao := ccdaoDao.dao.(*simpleDao)
+	assert.NotEqual(t, store, intDao.store)
+	assert.NotEqual(t, pdao.store, intDao.store)
+	assert.NotEqual(t, cdaoDao.store, intDao.store)
+
+	hash := random.Uint160()
+	key := []byte("qwerty")
+	si := &state.StorageItem{Value: []byte("poiuyt")}
+	require.NoError(t, ccdao.PutStorageItem(hash, key, si))
+	resi := ccdao.GetStorageItem(hash, key)
+	assert.Equal(t, si, resi)
+
+	resi = cdao.GetStorageItem(hash, key)
+	assert.Equal(t, (*state.StorageItem)(nil), resi)
+	resi = pdao.GetStorageItem(hash, key)
+	assert.Equal(t, (*state.StorageItem)(nil), resi)
+
+	cnt, err := ccdao.Persist()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, cnt)
+	resi = cdao.GetStorageItem(hash, key)
+	assert.Equal(t, si, resi)
+	resi = pdao.GetStorageItem(hash, key)
+	assert.Equal(t, (*state.StorageItem)(nil), resi)
+
+	cnt, err = cdao.Persist()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, cnt)
+	resi = pdao.GetStorageItem(hash, key)
+	assert.Equal(t, si, resi)
 }

--- a/pkg/core/dao_test.go
+++ b/pkg/core/dao_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestPutGetAndDecode(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	serializable := &TestSerializable{field: random.String(4)}
 	hash := []byte{1}
 	err := dao.Put(serializable, hash)
@@ -41,7 +41,7 @@ func (t *TestSerializable) DecodeBinary(reader *io.BinReader) {
 }
 
 func TestGetAccountStateOrNew_New(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	hash := random.Uint160()
 	createdAccount, err := dao.GetAccountStateOrNew(hash)
 	require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestGetAccountStateOrNew_New(t *testing.T) {
 }
 
 func TestPutAndGetAccountStateOrNew(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	hash := random.Uint160()
 	accountState := &state.Account{ScriptHash: hash}
 	err := dao.PutAccountState(accountState)
@@ -60,7 +60,7 @@ func TestPutAndGetAccountStateOrNew(t *testing.T) {
 }
 
 func TestPutAndGetAssetState(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	id := random.Uint256()
 	assetState := &state.Asset{ID: id, Owner: keys.PublicKey{}}
 	err := dao.PutAssetState(assetState)
@@ -71,7 +71,7 @@ func TestPutAndGetAssetState(t *testing.T) {
 }
 
 func TestPutAndGetContractState(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	contractState := &state.Contract{Script: []byte{}, ParamList: []smartcontract.ParamType{}}
 	hash := contractState.ScriptHash()
 	err := dao.PutContractState(contractState)
@@ -82,7 +82,7 @@ func TestPutAndGetContractState(t *testing.T) {
 }
 
 func TestDeleteContractState(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	contractState := &state.Contract{Script: []byte{}, ParamList: []smartcontract.ParamType{}}
 	hash := contractState.ScriptHash()
 	err := dao.PutContractState(contractState)
@@ -95,7 +95,7 @@ func TestDeleteContractState(t *testing.T) {
 }
 
 func TestGetUnspentCoinState_Err(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	hash := random.Uint256()
 	gotUnspentCoinState, err := dao.GetUnspentCoinState(hash)
 	require.Error(t, err)
@@ -103,7 +103,7 @@ func TestGetUnspentCoinState_Err(t *testing.T) {
 }
 
 func TestPutGetUnspentCoinState(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	hash := random.Uint256()
 	unspentCoinState := &state.UnspentCoin{Height: 42, States: []state.OutputState{}}
 	err := dao.PutUnspentCoinState(hash, unspentCoinState)
@@ -114,7 +114,7 @@ func TestPutGetUnspentCoinState(t *testing.T) {
 }
 
 func TestGetValidatorStateOrNew_New(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	publicKey := &keys.PublicKey{}
 	validatorState, err := dao.GetValidatorStateOrNew(publicKey)
 	require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestGetValidatorStateOrNew_New(t *testing.T) {
 }
 
 func TestPutGetValidatorState(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	publicKey := &keys.PublicKey{}
 	validatorState := &state.Validator{
 		PublicKey:  publicKey,
@@ -137,7 +137,7 @@ func TestPutGetValidatorState(t *testing.T) {
 }
 
 func TestDeleteValidatorState(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	publicKey := &keys.PublicKey{}
 	validatorState := &state.Validator{
 		PublicKey:  publicKey,
@@ -154,7 +154,7 @@ func TestDeleteValidatorState(t *testing.T) {
 }
 
 func TestGetValidators(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	publicKey := &keys.PublicKey{}
 	validatorState := &state.Validator{
 		PublicKey:  publicKey,
@@ -169,7 +169,7 @@ func TestGetValidators(t *testing.T) {
 }
 
 func TestPutGetAppExecResult(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	hash := random.Uint256()
 	appExecResult := &state.AppExecResult{
 		TxHash: hash,
@@ -184,7 +184,7 @@ func TestPutGetAppExecResult(t *testing.T) {
 }
 
 func TestPutGetStorageItem(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	hash := random.Uint160()
 	key := []byte{0}
 	storageItem := &state.StorageItem{Value: []uint8{}}
@@ -195,7 +195,7 @@ func TestPutGetStorageItem(t *testing.T) {
 }
 
 func TestDeleteStorageItem(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	hash := random.Uint160()
 	key := []byte{0}
 	storageItem := &state.StorageItem{Value: []uint8{}}
@@ -208,7 +208,7 @@ func TestDeleteStorageItem(t *testing.T) {
 }
 
 func TestGetBlock_NotExists(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	hash := random.Uint256()
 	block, _, err := dao.GetBlock(hash)
 	require.Error(t, err)
@@ -216,7 +216,7 @@ func TestGetBlock_NotExists(t *testing.T) {
 }
 
 func TestPutGetBlock(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	b := &block.Block{
 		Base: block.Base{
 			Script: transaction.Witness{
@@ -235,14 +235,14 @@ func TestPutGetBlock(t *testing.T) {
 }
 
 func TestGetVersion_NoVersion(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	version, err := dao.GetVersion()
 	require.Error(t, err)
 	require.Equal(t, "", version)
 }
 
 func TestGetVersion(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	err := dao.PutVersion("testVersion")
 	require.NoError(t, err)
 	version, err := dao.GetVersion()
@@ -251,14 +251,14 @@ func TestGetVersion(t *testing.T) {
 }
 
 func TestGetCurrentHeaderHeight_NoHeader(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	height, err := dao.GetCurrentBlockHeight()
 	require.Error(t, err)
 	require.Equal(t, uint32(0), height)
 }
 
 func TestGetCurrentHeaderHeight_Store(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	b := &block.Block{
 		Base: block.Base{
 			Script: transaction.Witness{
@@ -275,7 +275,7 @@ func TestGetCurrentHeaderHeight_Store(t *testing.T) {
 }
 
 func TestStoreAsTransaction(t *testing.T) {
-	dao := newDao(storage.NewMemoryStore())
+	dao := newSimpleDao(storage.NewMemoryStore())
 	tx := &transaction.Transaction{Type: transaction.IssueType, Data: &transaction.IssueTX{}}
 	hash := tx.Hash()
 	err := dao.StoreAsTransaction(tx, 0)

--- a/pkg/core/gas_price_test.go
+++ b/pkg/core/gas_price_test.go
@@ -15,7 +15,8 @@ import (
 func TestGetPrice(t *testing.T) {
 	bc := newTestChain(t)
 	defer bc.Close()
-	systemInterop := bc.newInteropContext(trigger.Application, storage.NewMemoryStore(), nil, nil)
+	sdao := newSimpleDao(storage.NewMemoryStore())
+	systemInterop := bc.newInteropContext(trigger.Application, sdao, nil, nil)
 
 	v := bc.spawnVMWithInterops(systemInterop)
 	v.SetPriceGetter(getPrice)

--- a/pkg/core/interop_neo_test.go
+++ b/pkg/core/interop_neo_test.go
@@ -123,7 +123,7 @@ func TestHeaderGetVersion_Negative(t *testing.T) {
 	block := newDumbBlock()
 	chain := newTestChain(t)
 	defer chain.Close()
-	context := chain.newInteropContext(trigger.Application, storage.NewMemoryStore(), block, nil)
+	context := chain.newInteropContext(trigger.Application, newSimpleDao(storage.NewMemoryStore()), block, nil)
 	v.Estack().PushVal(vm.NewBoolItem(false))
 
 	err := context.headerGetVersion(v)
@@ -219,7 +219,7 @@ func TestWitnessGetVerificationScript(t *testing.T) {
 	chain := newTestChain(t)
 	defer chain.Close()
 
-	context := chain.newInteropContext(trigger.Application, storage.NewMemoryStore(), nil, nil)
+	context := chain.newInteropContext(trigger.Application, newSimpleDao(storage.NewMemoryStore()), nil, nil)
 	v.Estack().PushVal(vm.NewInteropItem(&witness))
 	err := context.witnessGetVerificationScript(v)
 	require.NoError(t, err)
@@ -462,7 +462,7 @@ func createVMAndPushBlock(t *testing.T) (*vm.VM, *block.Block, *interopContext, 
 	v := vm.New()
 	block := newDumbBlock()
 	chain := newTestChain(t)
-	context := chain.newInteropContext(trigger.Application, storage.NewMemoryStore(), block, nil)
+	context := chain.newInteropContext(trigger.Application, newSimpleDao(storage.NewMemoryStore()), block, nil)
 	v.Estack().PushVal(vm.NewInteropItem(block))
 	return v, block, context, chain
 }
@@ -492,7 +492,7 @@ func createVMAndAssetState(t *testing.T) (*vm.VM, *state.Asset, *interopContext,
 	}
 
 	chain := newTestChain(t)
-	context := chain.newInteropContext(trigger.Application, storage.NewMemoryStore(), nil, nil)
+	context := chain.newInteropContext(trigger.Application, newSimpleDao(storage.NewMemoryStore()), nil, nil)
 	return v, assetState, context, chain
 }
 
@@ -511,7 +511,7 @@ func createVMAndContractState(t *testing.T) (*vm.VM, *state.Contract, *interopCo
 	}
 
 	chain := newTestChain(t)
-	context := chain.newInteropContext(trigger.Application, storage.NewMemoryStore(), nil, nil)
+	context := chain.newInteropContext(trigger.Application, newSimpleDao(storage.NewMemoryStore()), nil, nil)
 	return v, contractState, context, chain
 }
 
@@ -526,7 +526,7 @@ func createVMAndAccState(t *testing.T) (*vm.VM, *state.Account, *interopContext,
 
 	require.NoError(t, err)
 	chain := newTestChain(t)
-	context := chain.newInteropContext(trigger.Application, storage.NewMemoryStore(), nil, nil)
+	context := chain.newInteropContext(trigger.Application, newSimpleDao(storage.NewMemoryStore()), nil, nil)
 	return v, accountState, context, chain
 }
 
@@ -557,6 +557,6 @@ func createVMAndTX(t *testing.T) (*vm.VM, *transaction.Transaction, *interopCont
 	tx.Inputs = inputs
 	tx.Outputs = outputs
 	chain := newTestChain(t)
-	context := chain.newInteropContext(trigger.Application, storage.NewMemoryStore(), nil, tx)
+	context := chain.newInteropContext(trigger.Application, newSimpleDao(storage.NewMemoryStore()), nil, tx)
 	return v, tx, context, chain
 }

--- a/pkg/core/interops.go
+++ b/pkg/core/interops.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/core/block"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
-	"github.com/nspcc-dev/neo-go/pkg/core/storage"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/trigger"
 	"github.com/nspcc-dev/neo-go/pkg/vm"
@@ -29,8 +28,8 @@ type interopContext struct {
 	log           *zap.Logger
 }
 
-func newInteropContext(trigger trigger.Type, bc Blockchainer, s storage.Store, block *block.Block, tx *transaction.Transaction, log *zap.Logger) *interopContext {
-	dao := newCachedDao(s)
+func newInteropContext(trigger trigger.Type, bc Blockchainer, d dao, block *block.Block, tx *transaction.Transaction, log *zap.Logger) *interopContext {
+	dao := newCachedDao(d)
 	nes := make([]state.NotificationEvent, 0)
 	return &interopContext{bc, trigger, block, tx, dao, nes, log}
 }

--- a/pkg/core/interops_test.go
+++ b/pkg/core/interops_test.go
@@ -16,7 +16,7 @@ func testNonInterop(t *testing.T, value interface{}, f func(*interopContext, *vm
 	v.Estack().PushVal(value)
 	chain := newTestChain(t)
 	defer chain.Close()
-	context := chain.newInteropContext(trigger.Application, storage.NewMemoryStore(), nil, nil)
+	context := chain.newInteropContext(trigger.Application, newSimpleDao(storage.NewMemoryStore()), nil, nil)
 	require.Error(t, f(context, v))
 }
 

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/block"
 	"github.com/nspcc-dev/neo-go/pkg/core/mempool"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
-	"github.com/nspcc-dev/neo-go/pkg/core/storage"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/io"
@@ -109,7 +108,7 @@ func (chain testChain) GetScriptHashesForVerifying(*transaction.Transaction) ([]
 func (chain testChain) GetStorageItem(scripthash util.Uint160, key []byte) *state.StorageItem {
 	panic("TODO")
 }
-func (chain testChain) GetTestVM() (*vm.VM, storage.Store) {
+func (chain testChain) GetTestVM() *vm.VM {
 	panic("TODO")
 }
 func (chain testChain) GetStorageItems(hash util.Uint160) (map[string]*state.StorageItem, error) {

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -881,7 +881,7 @@ func (s *Server) invokescript(reqParams request.Params) (interface{}, error) {
 // runScriptInVM runs given script in a new test VM and returns the invocation
 // result.
 func (s *Server) runScriptInVM(script []byte) *result.Invoke {
-	vm, _ := s.chain.GetTestVM()
+	vm := s.chain.GetTestVM()
 	vm.SetGasLimit(s.config.MaxGasInvoke)
 	vm.LoadScript(script)
 	_ = vm.Run()


### PR DESCRIPTION
Fixes #817 where invoked contract missed updated account information because
it got it one layer below cachedDao used to process the block.
