### PR TITLE
core: bump DB version to make it differ from 2.0 branch

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -31,7 +31,7 @@ import (
 // Tuning parameters.
 const (
 	headerBatchCount = 2000
-	version          = "0.0.9"
+	version          = "0.1.0"
 
 	// This one comes from C# code and it's different from the constant used
 	// when creating an asset with Neo.Asset.Create interop call. It looks


### PR DESCRIPTION
Discussed in #781, but we may merge something else before that, so let's make an explicit PR just for that.