### PR TITLE
core: fix typo in TestECDSAVerify

### DIFF
--- a/pkg/core/interop_neo_test.go
+++ b/pkg/core/interop_neo_test.go
@@ -282,7 +282,7 @@ func TestECDSAVerify(t *testing.T) {
 
 	t.Run("invalid signature", func(t *testing.T) {
 		sign := priv.Sign(msg)
-		sign[0] ^= sign[0]
+		sign[0] = ^sign[0]
 		runCase(t, false, false, sign, priv.PublicKey().Bytes(), msg)
 	})
 


### PR DESCRIPTION
We need signature to always be invalid, thus invert it's first byte.
RN if it was always set to zero which worked 255/256 times.