### PR TITLE
core,test: move helper functions for testchain to the internal package

### DIFF
--- a/pkg/consensus/consensus_test.go
+++ b/pkg/consensus/consensus_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testchain"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
@@ -216,35 +217,7 @@ func TestExport(t *testing.T) {
 }
 
 func getTestValidator(i int) (*privateKey, *publicKey) {
-	var wif, password string
-
-	// Sorted by public key.
-	switch i {
-	case 0:
-		wif = "6PYXPEFeBxeDjqMiwRrSe81LnpL1cpw1WSwENJY1p4NtgSbfZPaUFy8Kkg"
-		password = "two"
-
-	case 1:
-		wif = "6PYWscJHQ76uctwuM7GRcAp6xfGjdYDKnbMtMnT6hcXxcNn7CywbQmvfSy"
-		password = "four"
-
-	case 2:
-		wif = "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN"
-		password = "one"
-
-	case 3:
-		wif = "6PYRHjZrvxYqrHLpXz1aP6dBnrFkkxQMCdYsJi7YDPoQnQddvRuTzKGxME"
-		password = "three"
-
-	default:
-		return nil, nil
-	}
-
-	key, err := keys.NEP2Decrypt(wif, password)
-	if err != nil {
-		return nil, nil
-	}
-
+	key := testchain.PrivateKey(i)
 	return &privateKey{PrivateKey: key}, &publicKey{PublicKey: key.PublicKey()}
 }
 
@@ -269,8 +242,7 @@ func (fs *feer) SystemFee(*transaction.Transaction) util.Fixed8  { return util.F
 
 func addSender(t *testing.T, txs ...*transaction.Transaction) {
 	// multisig address which possess all NEO
-	scriptHash, err := util.Uint160DecodeStringBE("d60ac443bb800fb08261e75fa5925d747d485861")
-	require.NoError(t, err)
+	scriptHash := testchain.MultisigScriptHash()
 	for _, tx := range txs {
 		tx.Sender = scriptHash
 	}

--- a/pkg/internal/testchain/address.go
+++ b/pkg/internal/testchain/address.go
@@ -1,0 +1,80 @@
+package testchain
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+// privNetKeys is a list of unencrypted WIFs sorted by public key.
+var privNetKeys = []string{
+	"KzfPUYDC9n2yf4fK5ro4C8KMcdeXtFuEnStycbZgX3GomiUsvX6W",
+	"KzgWE3u3EDp13XPXXuTKZxeJ3Gi8Bsm8f9ijY3ZsCKKRvZUo1Cdn",
+	"KxyjQ8eUa4FHt3Gvioyt1Wz29cTUrE4eTqX3yFSk1YFCsPL8uNsY",
+	"L2oEXKRAAMiPEZukwR5ho2S6SMeQLhcK9mF71ZnF7GvT8dU4Kkgz",
+}
+
+var (
+	// ids maps validators order by public key sorting to validators ID.
+	// which is an order of the validator in the StandByValidators list.
+	ids = []int{1, 3, 0, 2}
+	// orders maps to validators id to it's order by public key sorting.
+	orders = []int{2, 0, 3, 1}
+)
+
+// Size returns testchain initial validators amount.
+func Size() int {
+	return len(privNetKeys)
+}
+
+// IDToOrder returns node's order in privnet.
+func IDToOrder(id int) int {
+	return orders[id]
+}
+
+// WIF returns unencrypted wif of the specified validator.
+func WIF(i int) string {
+	return privNetKeys[i]
+}
+
+// PrivateKey returns private key of node #i.
+func PrivateKey(i int) *keys.PrivateKey {
+	wif := WIF(i)
+	priv, err := keys.NewPrivateKeyFromWIF(wif)
+	if err != nil {
+		panic(err)
+	}
+	return priv
+}
+
+// PrivateKeyByID returns private keys of a node with the specified id.
+func PrivateKeyByID(id int) *keys.PrivateKey {
+	return PrivateKey(IDToOrder(id))
+}
+
+// MultisigVerificationScript returns script hash of the consensus multisig address.
+func MultisigVerificationScript() []byte {
+	var pubs keys.PublicKeys
+	for i := range privNetKeys {
+		priv := PrivateKey(ids[i])
+		pubs = append(pubs, priv.PublicKey())
+	}
+
+	script, err := smartcontract.CreateMultiSigRedeemScript(3, pubs)
+	if err != nil {
+		panic(err)
+	}
+	return script
+}
+
+// MultisigScriptHash returns consensus address as Uint160.
+func MultisigScriptHash() util.Uint160 {
+	return hash.Hash160(MultisigVerificationScript())
+}
+
+// MultisigAddress return consensus address as string.
+func MultisigAddress() string {
+	return address.Uint160ToString(MultisigScriptHash())
+}

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
+	"github.com/nspcc-dev/neo-go/pkg/internal/testchain"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response"
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result"
@@ -86,7 +87,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 	"getaccountstate": {
 		{
 			name:   "positive",
-			params: `["AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6"]`,
+			params: `["` + testchain.MultisigAddress() + `"]`,
 			result: func(e *executor) interface{} { return &result.AccountState{} },
 			check: func(t *testing.T, e *executor, acc interface{}) {
 				res, ok := acc.(*result.AccountState)
@@ -160,12 +161,12 @@ var rpcTestCases = map[string][]rpcTestCase{
 		},
 		{
 			name:   "positive",
-			params: `["c4bba7ed4e624d038b844d6b6ff24518e7db0165"]`,
+			params: `["` + testchain.PrivateKeyByID(0).GetScriptHash().StringLE() + `"]`,
 			result: func(e *executor) interface{} { return &result.NEP5Balances{} },
 			check: func(t *testing.T, e *executor, acc interface{}) {
 				res, ok := acc.(*result.NEP5Balances)
 				require.True(t, ok)
-				require.Equal(t, "AQyx83BYr1PkyYhZhUAogaHdhkLVHn6htY", res.Address)
+				require.Equal(t, testchain.PrivateKeyByID(0).Address(), res.Address)
 				require.Equal(t, 1, len(res.Balances))
 				require.Equal(t, "8.77", res.Balances[0].Amount)
 				require.Equal(t, testContractHash, res.Balances[0].Asset.StringLE())
@@ -186,12 +187,12 @@ var rpcTestCases = map[string][]rpcTestCase{
 		},
 		{
 			name:   "positive",
-			params: `["AQyx83BYr1PkyYhZhUAogaHdhkLVHn6htY"]`,
+			params: `["` + testchain.PrivateKeyByID(0).Address() + `"]`,
 			result: func(e *executor) interface{} { return &result.NEP5Transfers{} },
 			check: func(t *testing.T, e *executor, acc interface{}) {
 				res, ok := acc.(*result.NEP5Transfers)
 				require.True(t, ok)
-				require.Equal(t, "AQyx83BYr1PkyYhZhUAogaHdhkLVHn6htY", res.Address)
+				require.Equal(t, testchain.PrivateKeyByID(0).Address(), res.Address)
 
 				assetHash, err := util.Uint160DecodeStringLE(testContractHash)
 				require.NoError(t, err)
@@ -204,7 +205,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 				require.Equal(t, 1, len(res.Sent))
 				require.Equal(t, "1.23", res.Sent[0].Amount)
 				require.Equal(t, assetHash, res.Sent[0].Asset)
-				require.Equal(t, "AdB6ayKfBRJZasiXX4JL5N2YtmxftNp1b3", res.Sent[0].Address)
+				require.Equal(t, testchain.PrivateKeyByID(1).Address(), res.Sent[0].Address)
 			},
 		},
 	},
@@ -515,7 +516,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 		},
 		{
 			name:   "normal address",
-			params: `["AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6"]`,
+			params: `["` + testchain.MultisigAddress() + `"]`,
 			result: func(*executor) interface{} {
 				// hash of the issueTx
 				h, _ := util.Uint256DecodeStringBE("4cccf8f1a4cfa9ebd9344c312f8220199ee9000f14cb951f677601d208aa5af0")
@@ -530,7 +531,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 							Unclaimed: amount,
 						},
 					},
-					Address:   "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
+					Address:   testchain.MultisigAddress(),
 					Unclaimed: amount,
 				}
 			},
@@ -612,7 +613,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 		},
 		{
 			name:   "positive",
-			params: `["AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6"]`,
+			params: `["` + testchain.MultisigAddress() + `"]`,
 			result: func(*executor) interface{} {
 				return &result.Unclaimed{}
 			},
@@ -628,7 +629,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 	"getunspents": {
 		{
 			name:   "positive",
-			params: `["AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6"]`,
+			params: `["` + testchain.MultisigAddress() + `"]`,
 			result: func(e *executor) interface{} { return &result.Unspents{} },
 			check: func(t *testing.T, e *executor, unsp interface{}) {
 				res, ok := unsp.(*result.Unspents)
@@ -973,7 +974,7 @@ func TestRPC(t *testing.T) {
 		assert.Equal(t, 0, txOut.N)
 		assert.Equal(t, "0xf5bc5a9ac7b85a47be381260a06b5a1e7a667ce8f7d7c8baa5cfc6465571377a", txOut.Asset)
 		assert.Equal(t, util.Fixed8FromInt64(100000000), txOut.Value)
-		assert.Equal(t, "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6", txOut.Address)
+		assert.Equal(t, testchain.MultisigAddress(), txOut.Address)
 	})
 
 	t.Run("getrawmempool", func(t *testing.T) {


### PR DESCRIPTION
Our test chain is used in core,rpc and (in future) interop packages.
It is better to have all related declarations in one place to avoid
code duplication.

This is a part of work towards moving `newTestChain` in a separate package.
