### PR TITLE
wallet: add test for regenerating test/docker wallets

### DIFF
--- a/.docker/wallets/wallet1.json
+++ b/.docker/wallets/wallet1.json
@@ -1,18 +1,10 @@
 {
-  "name": "wallet1",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
       "address": "AQyx83BYr1PkyYhZhUAogaHdhkLVHn6htY",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
         "script": "4c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc250680a906ad4",
         "parameters": [
@@ -23,14 +15,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
         "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
@@ -49,8 +40,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/.docker/wallets/wallet1_solo.json
+++ b/.docker/wallets/wallet1_solo.json
@@ -1,20 +1,12 @@
 {
-  "name": "wallet1",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
-      "address": "AKkkumHbBipZ46UMZJoFynJMXzSRnBvKcs",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
-      "key": "6PYLmjBYJ4wQTCEfqvnznGJwZeW9pfUcV5m5oreHxqryUgqKpTRAFt9L8Y",
+      "address": "AQyx83BYr1PkyYhZhUAogaHdhkLVHn6htY",
+      "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
-        "script": "2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2ac",
+        "script": "4c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc250680a906ad4",
         "parameters": [
           {
             "name": "parameter0",
@@ -23,16 +15,15 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
-      "key": "6PYLmjBYJ4wQTCEfqvnznGJwZeW9pfUcV5m5oreHxqryUgqKpTRAFt9L8Y",
+      "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
-        "script": "532102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd622102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc22103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee69954ae",
+        "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
           {
             "name": "parameter0",
@@ -49,16 +40,15 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
-      "address": "AKJbsdaKKhF8f922EpwKiZNbo8F2mocqHo",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
-      "key": "6PYLmjBYJ4wQTCEfqvnznGJwZeW9pfUcV5m5oreHxqryUgqKpTRAFt9L8Y",
+      "address": "Ab3TJfgpa94yDr1WPeXpYQiChTRohBJ6T5",
+      "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
-        "script": "514c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995150683073b3bb",
+        "script": "514c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc25150683073b3bb",
         "parameters": [
           {
             "name": "parameter0",
@@ -67,8 +57,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/.docker/wallets/wallet2.json
+++ b/.docker/wallets/wallet2.json
@@ -1,18 +1,10 @@
 {
-  "name": "wallet2",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
       "address": "AdB6ayKfBRJZasiXX4JL5N2YtmxftNp1b3",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYXPEFeBxeDjqMiwRrSe81LnpL1cpw1WSwENJY1p4NtgSbfZPaUFy8Kkg",
+      "label": "",
       "contract": {
         "script": "4c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e50680a906ad4",
         "parameters": [
@@ -23,14 +15,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYXPEFeBxeDjqMiwRrSe81LnpL1cpw1WSwENJY1p4NtgSbfZPaUFy8Kkg",
+      "label": "",
       "contract": {
         "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
@@ -49,8 +40,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/.docker/wallets/wallet3.json
+++ b/.docker/wallets/wallet3.json
@@ -1,18 +1,10 @@
 {
-  "name": "wallet3",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
       "address": "AbJTkhSMjJnm2CHZbCUe5j8w2xzjDbeWM8",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYRHjZrvxYqrHLpXz1aP6dBnrFkkxQMCdYsJi7YDPoQnQddvRuTzKGxME",
+      "label": "",
       "contract": {
         "script": "4c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee69950680a906ad4",
         "parameters": [
@@ -23,14 +15,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYRHjZrvxYqrHLpXz1aP6dBnrFkkxQMCdYsJi7YDPoQnQddvRuTzKGxME",
+      "label": "",
       "contract": {
         "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
@@ -49,8 +40,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/.docker/wallets/wallet4.json
+++ b/.docker/wallets/wallet4.json
@@ -1,18 +1,10 @@
 {
-  "name": "wallet4",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
       "address": "AT7C1Jno1CtJTYzA6MH8HpfYYso1RiES8q",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYWscJHQ76uctwuM7GRcAp6xfGjdYDKnbMtMnT6hcXxcNn7CywbQmvfSy",
+      "label": "",
       "contract": {
         "script": "4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd6250680a906ad4",
         "parameters": [
@@ -23,14 +15,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYWscJHQ76uctwuM7GRcAp6xfGjdYDKnbMtMnT6hcXxcNn7CywbQmvfSy",
+      "label": "",
       "contract": {
         "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
@@ -49,8 +40,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/pkg/consensus/testdata/wallet1.json
+++ b/pkg/consensus/testdata/wallet1.json
@@ -1,18 +1,10 @@
 {
-  "name": "wallet1",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
       "address": "AQyx83BYr1PkyYhZhUAogaHdhkLVHn6htY",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
         "script": "4c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc250680a906ad4",
         "parameters": [
@@ -23,14 +15,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
         "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
@@ -49,8 +40,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/pkg/consensus/testdata/wallet2.json
+++ b/pkg/consensus/testdata/wallet2.json
@@ -1,18 +1,10 @@
 {
-  "name": "wallet2",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
       "address": "AdB6ayKfBRJZasiXX4JL5N2YtmxftNp1b3",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYXPEFeBxeDjqMiwRrSe81LnpL1cpw1WSwENJY1p4NtgSbfZPaUFy8Kkg",
+      "label": "",
       "contract": {
         "script": "4c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e50680a906ad4",
         "parameters": [
@@ -23,14 +15,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYXPEFeBxeDjqMiwRrSe81LnpL1cpw1WSwENJY1p4NtgSbfZPaUFy8Kkg",
+      "label": "",
       "contract": {
         "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
@@ -49,8 +40,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/pkg/consensus/testdata/wallet3.json
+++ b/pkg/consensus/testdata/wallet3.json
@@ -1,18 +1,10 @@
 {
-  "name": "wallet3",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
       "address": "AbJTkhSMjJnm2CHZbCUe5j8w2xzjDbeWM8",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYRHjZrvxYqrHLpXz1aP6dBnrFkkxQMCdYsJi7YDPoQnQddvRuTzKGxME",
+      "label": "",
       "contract": {
         "script": "4c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee69950680a906ad4",
         "parameters": [
@@ -23,14 +15,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYRHjZrvxYqrHLpXz1aP6dBnrFkkxQMCdYsJi7YDPoQnQddvRuTzKGxME",
+      "label": "",
       "contract": {
         "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
@@ -49,8 +40,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/pkg/consensus/testdata/wallet4.json
+++ b/pkg/consensus/testdata/wallet4.json
@@ -1,18 +1,10 @@
 {
-  "name": "wallet4",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
       "address": "AT7C1Jno1CtJTYzA6MH8HpfYYso1RiES8q",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYWscJHQ76uctwuM7GRcAp6xfGjdYDKnbMtMnT6hcXxcNn7CywbQmvfSy",
+      "label": "",
       "contract": {
         "script": "4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd6250680a906ad4",
         "parameters": [
@@ -23,14 +15,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYWscJHQ76uctwuM7GRcAp6xfGjdYDKnbMtMnT6hcXxcNn7CywbQmvfSy",
+      "label": "",
       "contract": {
         "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
@@ -49,8 +40,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/pkg/wallet/regenerate_test.go
+++ b/pkg/wallet/regenerate_test.go
@@ -1,0 +1,125 @@
+package wallet
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/stretchr/testify/require"
+)
+
+const regenerate = false
+
+const dockerWalletDir = "../../.docker/wallets/"
+
+var (
+	// privNetKeys is a list of unencrypted WIFs sorted by wallet number.
+	privnetWIFs = []string{
+		"KxyjQ8eUa4FHt3Gvioyt1Wz29cTUrE4eTqX3yFSk1YFCsPL8uNsY",
+		"KzfPUYDC9n2yf4fK5ro4C8KMcdeXtFuEnStycbZgX3GomiUsvX6W",
+		"L2oEXKRAAMiPEZukwR5ho2S6SMeQLhcK9mF71ZnF7GvT8dU4Kkgz",
+		"KzgWE3u3EDp13XPXXuTKZxeJ3Gi8Bsm8f9ijY3ZsCKKRvZUo1Cdn",
+	}
+
+	passwords = []string{"one", "two", "three", "four"}
+)
+
+func getKeys(t *testing.T) []*keys.PublicKey {
+	var pubs []*keys.PublicKey
+
+	for i := range privnetWIFs {
+		priv, err := keys.NewPrivateKeyFromWIF(privnetWIFs[i])
+		require.NoError(t, err)
+		pubs = append(pubs, priv.PublicKey())
+	}
+	return pubs
+}
+
+func getAccount(t *testing.T, wif, pass string) *Account {
+	acc, err := NewAccountFromWIF(wif)
+	require.NoError(t, err)
+	require.NoError(t, acc.Encrypt(pass))
+	return acc
+}
+
+func TestRegenerateSoloWallet(t *testing.T) {
+	if !regenerate {
+		return
+	}
+	walletPath := path.Join(dockerWalletDir, "wallet1_solo.json")
+	wif := privnetWIFs[0]
+	acc1 := getAccount(t, wif, "one")
+	acc2 := getAccount(t, wif, "one")
+	require.NoError(t, acc2.ConvertMultisig(3, getKeys(t)))
+
+	acc3 := getAccount(t, wif, "one")
+	require.NoError(t, acc3.ConvertMultisig(1, keys.PublicKeys{getKeys(t)[0]}))
+
+	w, err := NewWallet(walletPath)
+	require.NoError(t, err)
+	w.AddAccount(acc1)
+	w.AddAccount(acc2)
+	w.AddAccount(acc3)
+	require.NoError(t, w.savePretty())
+	w.Close()
+}
+
+func regenerateWallets(t *testing.T, dir string) {
+	pubs := getKeys(t)
+	for i := range privnetWIFs {
+		acc1 := getAccount(t, privnetWIFs[i], passwords[i])
+		acc2 := getAccount(t, privnetWIFs[i], passwords[i])
+		require.NoError(t, acc2.ConvertMultisig(3, pubs))
+
+		w, err := NewWallet(path.Join(dir, fmt.Sprintf("wallet%d.json", i+1)))
+		require.NoError(t, err)
+		w.AddAccount(acc1)
+		w.AddAccount(acc2)
+		require.NoError(t, w.savePretty())
+		w.Close()
+	}
+}
+
+func TestRegeneratePrivnetWallets(t *testing.T) {
+	if !regenerate {
+		return
+	}
+	dirs := []string{
+		dockerWalletDir,
+		"../consensus/testdata",
+	}
+	for i := range dirs {
+		regenerateWallets(t, dirs[i])
+	}
+}
+
+func TestRegenerateWalletTestdata(t *testing.T) {
+	if !regenerate {
+		return
+	}
+	const walletDir = "./testdata/"
+
+	acc1 := getAccount(t, privnetWIFs[0], "one")
+	acc2 := getAccount(t, privnetWIFs[0], "one")
+	pubs := getKeys(t)
+	require.NoError(t, acc2.ConvertMultisig(3, pubs))
+
+	acc3 := getAccount(t, privnetWIFs[1], "two")
+	acc3.Default = true
+
+	w, err := NewWallet(path.Join(walletDir, "wallet1.json"))
+	require.NoError(t, err)
+	w.AddAccount(acc1)
+	w.AddAccount(acc2)
+	require.NoError(t, w.savePretty())
+	w.Close()
+
+	w, err = NewWallet(path.Join(walletDir, "wallet2.json"))
+	require.NoError(t, err)
+	w.AddAccount(acc1)
+	w.AddAccount(acc2)
+	w.AddAccount(acc3)
+	require.NoError(t, w.savePretty())
+	w.Close()
+}

--- a/pkg/wallet/testdata/wallet1.json
+++ b/pkg/wallet/testdata/wallet1.json
@@ -1,18 +1,10 @@
 {
-  "name": "wallet1",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
       "address": "AQyx83BYr1PkyYhZhUAogaHdhkLVHn6htY",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
         "script": "4c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc250680a906ad4",
         "parameters": [
@@ -23,14 +15,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
         "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
@@ -49,8 +40,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/pkg/wallet/testdata/wallet2.json
+++ b/pkg/wallet/testdata/wallet2.json
@@ -1,18 +1,10 @@
 {
-  "name": "wallet2",
   "version": "1.0",
-  "scrypt": {
-    "n": 16384,
-    "r": 8,
-    "p": 8
-  },
   "accounts": [
     {
       "address": "AQyx83BYr1PkyYhZhUAogaHdhkLVHn6htY",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
         "script": "4c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc250680a906ad4",
         "parameters": [
@@ -23,14 +15,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AbHd9dXYUryuCvMgXRUfdR6zC2CJixS6Q6",
-      "label": null,
-      "isDefault": false,
-      "lock": false,
       "key": "6PYKYQKRs758NBX4q5k6fSmduZDfEfQyoXMovQU5myKm2h5ArXuYpuMEaN",
+      "label": "",
       "contract": {
         "script": "534c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e4c2102a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd624c2102b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc24c2103d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee6995450683073b3bb",
         "parameters": [
@@ -49,14 +40,13 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": false
     },
     {
       "address": "AdB6ayKfBRJZasiXX4JL5N2YtmxftNp1b3",
-      "label": null,
-      "isDefault": true,
-      "lock": false,
       "key": "6PYXPEFeBxeDjqMiwRrSe81LnpL1cpw1WSwENJY1p4NtgSbfZPaUFy8Kkg",
+      "label": "",
       "contract": {
         "script": "4c2102103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e50680a906ad4",
         "parameters": [
@@ -67,8 +57,16 @@
         ],
         "deployed": false
       },
-      "extra": null
+      "lock": false,
+      "isDefault": true
     }
   ],
-  "extra": null
+  "scrypt": {
+    "n": 16384,
+    "r": 8,
+    "p": 8
+  },
+  "extra": {
+    "Tokens": null
+  }
 }

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -142,12 +142,29 @@ func (w *Wallet) Path() string {
 // that is responsible for saving the data. This can
 // be a buffer, file, etc..
 func (w *Wallet) Save() error {
+	if err := w.rewind(); err != nil {
+		return err
+	}
+	return json.NewEncoder(w.rw).Encode(w)
+}
+
+// savePretty saves wallet in a beautiful JSON.
+func (w *Wallet) savePretty() error {
+	if err := w.rewind(); err != nil {
+		return err
+	}
+	enc := json.NewEncoder(w.rw)
+	enc.SetIndent("", "  ")
+	return enc.Encode(w)
+}
+
+func (w *Wallet) rewind() error {
 	if s, ok := w.rw.(io.Seeker); ok {
 		if _, err := s.Seek(0, 0); err != nil {
 			return err
 		}
 	}
-	return json.NewEncoder(w.rw).Encode(w)
+	return nil
 }
 
 // JSON outputs a pretty JSON representation of the wallet.


### PR DESCRIPTION
When changing accounts or VM, it is useful to be able to
regenerate all wallets easy and fast.