### PR TITLE
compiler: add ability to generate .abi.json file

### DIFF
--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -45,7 +45,7 @@ func TestCompiler(t *testing.T) {
 				err = os.MkdirAll(exampleSavePath, os.ModePerm)
 				require.NoError(t, err)
 				outfile := exampleSavePath + "/test.avm"
-				_, err = compiler.CompileAndSave(exampleCompilePath+"/"+infos[0].Name(), &compiler.Options{Outfile: outfile})
+				_, err = compiler.CompileAndSave(exampleCompilePath+"/"+infos[0].Name(), nil, &compiler.Options{Outfile: outfile})
 				require.NoError(t, err)
 				defer func() {
 					err := os.RemoveAll(exampleSavePath)

--- a/pkg/compiler/debug.go
+++ b/pkg/compiler/debug.go
@@ -72,8 +72,8 @@ type DebugRange struct {
 
 // DebugParam represents variables's name and type.
 type DebugParam struct {
-	Name string
-	Type string
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 func (c *codegen) saveSequencePoint(n ast.Node) {


### PR DESCRIPTION
A part of integration with NEO Blockchain Toolkit (see #902). To be
able to deploy smart-contract compiled with neo-go compiler via NEO
Express, we have to generate additional .abi.json file. This file
contains the following information:
 - hash of the compiled contract
 - smart-contract metadata (title, description, version, author,
email, has-storage, has-dynamic-invoke, is-payable)
 - smart-contract entry point
 - functions
 - events

However, this .abi.json file is slightly different from the one,
described in manifest.go, so we have to add auxilaury stractures for
json marshalling. The .abi.json format used by NEO-Express is described
[here](https://github.com/neo-project/neo-devpack-dotnet/blob/master/src/Neo.Compiler.MSIL/FuncExport.cs#L66).