### PR TITLE
compiler: add ability to generate .abi.json file

### DIFF
--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -505,11 +505,11 @@ func testInvokeScript(ctx *cli.Context) error {
 // ProjectConfig contains project metadata.
 type ProjectConfig struct {
 	Version  uint
-	Contract request.ContractDetails `yaml:"project"`
+	Contract smartcontract.ContractDetails `yaml:"project"`
 }
 
-func parseContractDetails() request.ContractDetails {
-	details := request.ContractDetails{}
+func parseContractDetails() smartcontract.ContractDetails {
+	details := smartcontract.ContractDetails{}
 	reader := bufio.NewReader(os.Stdin)
 
 	fmt.Print("Author: ")

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"golang.org/x/tools/go/loader"
 )
 
@@ -26,6 +27,12 @@ type Options struct {
 
 	// The name of the output for debug info.
 	DebugInfo string
+
+	// The name of the output for application binary interface info.
+	ABIInfo string
+
+	// Contract metadata.
+	ContractDetails *smartcontract.ContractDetails
 }
 
 type buildInfo struct {
@@ -105,5 +112,16 @@ func CompileAndSave(src string, o *Options) ([]byte, error) {
 	if err != nil {
 		return b, err
 	}
-	return b, ioutil.WriteFile(o.DebugInfo, data, os.ModePerm)
+	if err := ioutil.WriteFile(o.DebugInfo, data, os.ModePerm); err != nil {
+		return b, err
+	}
+	if o.ABIInfo == "" {
+		return b, err
+	}
+	abi := di.convertToABI(b, o.ContractDetails)
+	abiData, err := json.Marshal(abi)
+	if err != nil {
+		return b, err
+	}
+	return b, ioutil.WriteFile(o.ABIInfo, abiData, os.ModePerm)
 }

--- a/pkg/compiler/debug.go
+++ b/pkg/compiler/debug.go
@@ -8,6 +8,10 @@ import (
 	"go/types"
 	"strconv"
 	"strings"
+
+	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/util"
 )
 
 // DebugInfo represents smart-contract debug information.
@@ -72,8 +76,42 @@ type DebugRange struct {
 
 // DebugParam represents variables's name and type.
 type DebugParam struct {
-	Name string
-	Type string
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// ABI represents ABI contract info in compatible with NEO Blockchain Toolkit format
+type ABI struct {
+	Hash       util.Uint160 `json:"hash"`
+	Metadata   Metadata     `json:"metadata"`
+	EntryPoint string       `json:"entrypoint"`
+	Functions  []Method     `json:"functions"`
+	Events     []Event      `json:"events"`
+}
+
+// Metadata represents ABI contract metadata
+type Metadata struct {
+	Author               string `json:"author"`
+	Email                string `json:"email"`
+	Version              string `json:"version"`
+	Title                string `json:"title"`
+	Description          string `json:"description"`
+	HasStorage           bool   `json:"has-storage"`
+	HasDynamicInvocation bool   `json:"has-dynamic-invoke"`
+	IsPayable            bool   `json:"is-payable"`
+}
+
+// Method represents ABI method's metadata.
+type Method struct {
+	Name       string       `json:"name"`
+	Parameters []DebugParam `json:"parameters"`
+	ReturnType string       `json:"returntype"`
+}
+
+// Event represents ABI event's metadata.
+type Event struct {
+	Name       string       `json:"name"`
+	Parameters []DebugParam `json:"parameters"`
 }
 
 func (c *codegen) saveSequencePoint(n ast.Node) {
@@ -259,4 +297,41 @@ func parsePairJSON(data []byte, sep string) (string, string, error) {
 		return "", "", errors.New("invalid range format")
 	}
 	return ss[0], ss[1], nil
+}
+
+func (di *DebugInfo) convertToABI(contract []byte, cd *smartcontract.ContractDetails) ABI {
+	methods := make([]Method, 0)
+	for _, method := range di.Methods {
+		if method.Name.Name == di.EntryPoint {
+			methods = append(methods, Method{
+				Name:       method.Name.Name,
+				Parameters: method.Parameters,
+				ReturnType: cd.ReturnType.String(),
+			})
+			break
+		}
+	}
+	events := make([]Event, len(di.Events))
+	for i, event := range di.Events {
+		events[i] = Event{
+			Name:       event.Name,
+			Parameters: event.Parameters,
+		}
+	}
+	return ABI{
+		Hash: hash.Hash160(contract),
+		Metadata: Metadata{
+			Author:               cd.Author,
+			Email:                cd.Email,
+			Version:              cd.Version,
+			Title:                cd.ProjectName,
+			Description:          cd.Description,
+			HasStorage:           cd.HasStorage,
+			HasDynamicInvocation: cd.HasDynamicInvocation,
+			IsPayable:            cd.IsPayable,
+		},
+		EntryPoint: di.EntryPoint,
+		Functions:  methods,
+		Events:     events,
+	}
 }

--- a/pkg/compiler/debug.go
+++ b/pkg/compiler/debug.go
@@ -112,7 +112,7 @@ func (c *codegen) registerDebugVariable(name string, expr ast.Expr) {
 func (c *codegen) methodInfoFromScope(name string, scope *funcScope) *MethodDebugInfo {
 	ps := scope.decl.Type.Params
 	params := make([]DebugParam, 0, ps.NumFields())
-	for i := range params {
+	for i := range ps.List {
 		for j := range ps.List[i].Names {
 			params = append(params, DebugParam{
 				Name: ps.List[i].Names[j].Name,

--- a/pkg/compiler/debug_test.go
+++ b/pkg/compiler/debug_test.go
@@ -28,6 +28,9 @@ func methodInt(a string) int {
 	}
 	return 3
 }
+func methodConcat(a, b string, c string) string{
+	return a + b + c
+}
 func methodString() string { return "" }
 func methodByteArray() []byte { return nil }
 func methodArray() []bool { return nil }
@@ -48,6 +51,7 @@ func methodStruct() struct{} { return struct{}{} }
 	t.Run("return types", func(t *testing.T) {
 		returnTypes := map[string]string{
 			"methodInt":    "Integer",
+			"methodConcat": "String",
 			"methodString": "String", "methodByteArray": "ByteArray",
 			"methodArray": "Array", "methodStruct": "Struct",
 			"Main": "Boolean",
@@ -66,6 +70,39 @@ func methodStruct() struct{} { return struct{}{} }
 			v, ok := vars[d.Methods[i].Name.Name]
 			if ok {
 				require.Equal(t, v, d.Methods[i].Variables)
+			}
+		}
+	})
+
+	t.Run("param types", func(t *testing.T) {
+		paramTypes := map[string][]DebugParam{
+			"methodInt": {{
+				Name: "a",
+				Type: "String",
+			}},
+			"methodConcat": {
+				{
+					Name: "a",
+					Type: "String",
+				},
+				{
+					Name: "b",
+					Type: "String",
+				},
+				{
+					Name: "c",
+					Type: "String",
+				},
+			},
+			"Main": {{
+				Name: "op",
+				Type: "String",
+			}},
+		}
+		for i := range d.Methods {
+			v, ok := paramTypes[d.Methods[i].Name.Name]
+			if ok {
+				require.Equal(t, v, d.Methods[i].Parameters)
 			}
 		}
 	})

--- a/pkg/rpc/request/txBuilder.go
+++ b/pkg/rpc/request/txBuilder.go
@@ -78,7 +78,7 @@ func AddInputsAndUnspentsToTx(tx *transaction.Transaction, addr string, assetID 
 
 // DetailsToSCProperties extract the fields needed from ContractDetails
 // and converts them to smartcontract.PropertyState.
-func DetailsToSCProperties(contract *ContractDetails) smartcontract.PropertyState {
+func DetailsToSCProperties(contract *smartcontract.ContractDetails) smartcontract.PropertyState {
 	var props smartcontract.PropertyState
 	if contract.HasStorage {
 		props |= smartcontract.HasStorage
@@ -94,7 +94,7 @@ func DetailsToSCProperties(contract *ContractDetails) smartcontract.PropertyStat
 
 // CreateDeploymentScript returns a script that deploys given smart contract
 // with its metadata.
-func CreateDeploymentScript(avm []byte, contract *ContractDetails) ([]byte, error) {
+func CreateDeploymentScript(avm []byte, contract *smartcontract.ContractDetails) ([]byte, error) {
 	script := io.NewBufBinWriter()
 	emit.Bytes(script.BinWriter, []byte(contract.Description))
 	emit.Bytes(script.BinWriter, []byte(contract.Email))

--- a/pkg/smartcontract/contract_details.go
+++ b/pkg/smartcontract/contract_details.go
@@ -1,6 +1,4 @@
-package request
-
-import "github.com/nspcc-dev/neo-go/pkg/smartcontract"
+package smartcontract
 
 // ContractDetails contains contract metadata.
 type ContractDetails struct {
@@ -12,6 +10,6 @@ type ContractDetails struct {
 	HasStorage           bool
 	HasDynamicInvocation bool
 	IsPayable            bool
-	ReturnType           smartcontract.ParamType
-	Parameters           []smartcontract.ParamType
+	ReturnType           ParamType
+	Parameters           []ParamType
 }


### PR DESCRIPTION
Ported from #916.

A part of integration with NEO Blockchain Toolkit (see #902). To be
able to deploy smart-contract compiled with neo-go compiler via NEO
Express, we have to generate additional .abi.json file. This file
contains the following information:

    hash of the compiled contract
    smart-contract metadata (title, description, version, author,
    email, has-storage, has-dynamic-invoke, is-payable)
    smart-contract entry point
    functions
    events

However, this .abi.json file is slightly different from the one,
described in manifest.go, so we have to add auxilaury stractures for
json marshalling. The .abi.json format used by NEO-Express is described
[here](https://github.com/neo-project/neo-devpack-dotnet/blob/master/src/Neo.Compiler.MSIL/FuncExport.cs#L66).