### PR TITLE
Fix RPC submitblock test

### DIFF
--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -860,8 +860,9 @@ func testRPCProtocol(t *testing.T, doRPCCall func(string, string, *testing.T) []
 
 	t.Run("submit", func(t *testing.T) {
 		rpc := `{"jsonrpc": "2.0", "id": 1, "method": "submitblock", "params": ["%s"]}`
-		t.Run("empty", func(t *testing.T) {
+		t.Run("invalid signature", func(t *testing.T) {
 			s := newBlock(t, chain, 1)
+			s.Script.VerificationScript[8] ^= 0xff
 			body := doRPCCall(fmt.Sprintf(rpc, encodeBlock(t, s)), httpSrv.URL, t)
 			checkErrGetResult(t, body, true)
 		})

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -1091,6 +1091,7 @@ func checkErrGetResult(t *testing.T, body []byte, expectingFail bool) json.RawMe
 	err := json.Unmarshal(body, &resp)
 	require.Nil(t, err)
 	if expectingFail {
+		require.NotNil(t, resp.Error)
 		assert.NotEqual(t, 0, resp.Error.Code)
 		assert.NotEqual(t, "", resp.Error.Message)
 	} else {


### PR DESCRIPTION
### Problem

Tests failing after #925 merge (which worked before the merge because they missed #898 changes).

### Solution

Fix it.