### PR TITLE
Cache storage operations across same block tx executions

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1147,7 +1147,16 @@ func (bc *Blockchain) GetStorageItem(scripthash util.Uint160, key []byte) *state
 
 // GetStorageItems returns all storage items for a given scripthash.
 func (bc *Blockchain) GetStorageItems(hash util.Uint160) (map[string]*state.StorageItem, error) {
-	return bc.dao.GetStorageItems(hash)
+	siMap, err := bc.dao.GetStorageItems(hash)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]*state.StorageItem)
+	for i := range siMap {
+		val := siMap[i].StorageItem
+		m[string(siMap[i].Key)] = &val
+	}
+	return m, nil
 }
 
 // GetBlock returns a Block by the given hash.

--- a/pkg/core/dao/storage_item.go
+++ b/pkg/core/dao/storage_item.go
@@ -1,0 +1,57 @@
+package dao
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/core/state"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+type (
+	itemState int
+
+	trackedItem struct {
+		state.StorageItem
+		State itemState
+	}
+
+	itemCache struct {
+		st   map[util.Uint160]map[string]*trackedItem
+		keys map[util.Uint160][]string
+	}
+)
+
+const (
+	getOp itemState = 1 << iota
+	delOp
+	addOp
+	putOp
+)
+
+func newItemCache() *itemCache {
+	return &itemCache{
+		make(map[util.Uint160]map[string]*trackedItem),
+		make(map[util.Uint160][]string),
+	}
+}
+
+func (c *itemCache) put(h util.Uint160, key []byte, op itemState, item *state.StorageItem) {
+	m := c.getItems(h)
+	m[string(key)] = &trackedItem{
+		StorageItem: *item,
+		State:       op,
+	}
+	c.keys[h] = append(c.keys[h], string(key))
+	c.st[h] = m
+}
+
+func (c *itemCache) getItem(h util.Uint160, key []byte) *trackedItem {
+	m := c.getItems(h)
+	return m[string(key)]
+}
+
+func (c *itemCache) getItems(h util.Uint160) map[string]*trackedItem {
+	m, ok := c.st[h]
+	if !ok {
+		return make(map[string]*trackedItem)
+	}
+	return m
+}

--- a/pkg/core/interop_system.go
+++ b/pkg/core/interop_system.go
@@ -561,8 +561,8 @@ func (ic *interopContext) contractDestroy(v *vm.VM) error {
 		if err != nil {
 			return err
 		}
-		for k := range siMap {
-			_ = ic.dao.DeleteStorageItem(hash, []byte(k))
+		for i := range siMap {
+			_ = ic.dao.DeleteStorageItem(hash, siMap[i].Key)
 		}
 	}
 	return nil


### PR DESCRIPTION
The order of `Storage.Find` is the following:
1. Iterate through items not contained in cache.
2. Iterate through cache.

Closes #822  .