### PR TITLE
compiler: support implicit type in function arguments

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -251,9 +251,10 @@ func (c *codegen) convertFuncDecl(file ast.Node, decl *ast.FuncDecl) {
 
 	// Load the arguments in scope.
 	for _, arg := range decl.Type.Params.List {
-		name := arg.Names[0].Name // for now.
-		l := c.scope.newLocal(name)
-		c.emitStoreLocal(l)
+		for _, id := range arg.Names {
+			l := c.scope.newLocal(id.Name)
+			c.emitStoreLocal(l)
+		}
 	}
 	// Load in all the global variables in to the scope of the function.
 	// This is not necessary for syscalls.

--- a/pkg/compiler/function_call_test.go
+++ b/pkg/compiler/function_call_test.go
@@ -158,3 +158,14 @@ func TestFunctionWithVoidReturnBranch(t *testing.T) {
 		eval(t, src, big.NewInt(2))
 	})
 }
+
+func TestFunctionWithMultipleArgumentNames(t *testing.T) {
+	src := `package foo
+	func Main() int {
+		return add(1, 2)
+	}
+	func add(a, b int) int {
+		return a + b
+	}`
+	eval(t, src, big.NewInt(3))
+}


### PR DESCRIPTION
Port of #935 to `master`.

Go supports declaring multiple arguments of the same type without
duplicating type name. Now we support this too.