### PR TITLE
examples: Use "or" operator in transfer check of NEP5 token

### DIFF
--- a/examples/token/nep5/nep5.go
+++ b/examples/token/nep5/nep5.go
@@ -58,7 +58,7 @@ func (t Token) Transfer(ctx storage.Context, from []byte, to []byte, amount int)
 
 // CanTransfer returns the amount it can transfer
 func (t Token) CanTransfer(ctx storage.Context, from []byte, to []byte, amount int) int {
-	if len(to) != 20 && !IsUsableAddress(from) {
+	if len(to) != 20 || !IsUsableAddress(from) {
 		return -1
 	}
 


### PR DESCRIPTION
### Problem

`CanTransfer` function checks if `to` and `from` values are correct script hashes. If one of these values is correct and one incorrect, then function returns false positive result. It uses `and` operator which requires both `to` and `from` script hashes to be incorrect to fail transaction.

### Solution

Instead transaction must fail if at least one argument is incorrect, so it should be `or` operator.