### PR TITLE
compiler: set default values for complex struct fields (2.x)

### DIFF
--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -44,8 +44,9 @@ func typeAndValueForField(fld *types.Var) (types.TypeAndValue, error) {
 		default:
 			return types.TypeAndValue{}, fmt.Errorf("could not initialize struct field %s to zero, type: %s", fld.Name(), t)
 		}
+	default:
+		return types.TypeAndValue{Type: t}, nil
 	}
-	return types.TypeAndValue{}, nil
 }
 
 // countGlobals counts the global variables in the program to add

--- a/pkg/compiler/debug.go
+++ b/pkg/compiler/debug.go
@@ -183,7 +183,11 @@ func (c *codegen) scReturnTypeFromScope(scope *funcScope) string {
 }
 
 func (c *codegen) scTypeFromExpr(typ ast.Expr) string {
-	switch t := c.typeInfo.Types[typ].Type.(type) {
+	return c.scTypeFromGo(c.typeInfo.Types[typ].Type)
+}
+
+func (c *codegen) scTypeFromGo(typ types.Type) string {
+	switch t := typ.(type) {
 	case *types.Basic:
 		info := t.Info()
 		switch {

--- a/pkg/compiler/struct_test.go
+++ b/pkg/compiler/struct_test.go
@@ -1,6 +1,7 @@
 package compiler_test
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -365,4 +366,26 @@ var structTestCases = []testCase{
 
 func TestStructs(t *testing.T) {
 	runTestCases(t, structTestCases)
+}
+
+func TestStructCompare(t *testing.T) {
+	srcTmpl := `package testcase
+	type T struct { f int }
+	func Main() int {
+		a := T{f: %d}
+		b := T{f: %d}
+		if a != b {
+			return 2
+		}
+		return 1
+	}`
+	t.Run("Equal", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, 4, 4)
+		eval(t, src, big.NewInt(1))
+	})
+	t.Run("NotEqual", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, 4, 5)
+		eval(t, src, big.NewInt(2))
+	})
+
 }

--- a/pkg/compiler/struct_test.go
+++ b/pkg/compiler/struct_test.go
@@ -338,6 +338,29 @@ var structTestCases = []testCase{
 		}`,
 		big.NewInt(2),
 	},
+	{
+		"uninitialized struct fields",
+		`package foo
+		type Foo struct {
+			i int
+			m map[string]int
+			b []byte
+			a []int
+			s struct { ii int }
+		}
+		func NewFoo() Foo { return Foo{} }
+		func Main() int {
+			foo := NewFoo()
+			if foo.i != 0 { return 1 }
+			if len(foo.m) != 0 { return 1 }
+			if len(foo.b) != 0 { return 1 }
+			if len(foo.a) != 0 { return 1 }
+			s := foo.s
+			if s.ii != 0 { return 1 }
+			return 2
+		}`,
+		big.NewInt(2),
+	},
 }
 
 func TestStructs(t *testing.T) {


### PR DESCRIPTION
Closes #949 .

There is no way we can distinguish `[]int(nil)` from `[]int{}` without substantial effort. And even then array is a reference type so it's instance is equal only to itself in NeoVM.
There is a simple workaround for checking if slice is empty: `len(arr) == 0`.

1. Emit error on comparison with `nil`
2. Fix type dispatch during `!=` processing.