### PR TITLE
compiler: support using OP= with struct fields and slice elements

### DIFF
--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -34,6 +34,16 @@ var sliceTestCases = []testCase{
 		big.NewInt(42),
 	},
 	{
+		"increase slice element with +=",
+		`package foo
+		func Main() int {
+			a := []int{1, 2, 3}
+			a[1] += 40
+			return a[1]
+		}`,
+		big.NewInt(42),
+	},
+	{
 		"complex test",
 		`
 		package foo

--- a/pkg/compiler/struct_test.go
+++ b/pkg/compiler/struct_test.go
@@ -135,6 +135,17 @@ var structTestCases = []testCase{
 		big.NewInt(14),
 	},
 	{
+		"increase struct field with +=",
+		`package foo
+		type token struct { x int }
+		func Main() int {
+		t := token{x: 2}
+		t.x += 3
+		return t.x
+		}`,
+		big.NewInt(5),
+	},
+	{
 		"assign a struct field to a struct field",
 		`
 		package foo


### PR DESCRIPTION
Support using "in-place" assignment operations with struct fields and slice elements.

Closes #953.