### PR TITLE
rpc/client: handle client creation error in new wsclient

### DIFF
--- a/pkg/rpc/client/wsclient.go
+++ b/pkg/rpc/client/wsclient.go
@@ -71,6 +71,10 @@ const (
 // connection). You need to use websocket URL for it like `ws://1.2.3.4/ws`.
 func NewWS(ctx context.Context, endpoint string, opts Options) (*WSClient, error) {
 	cl, err := New(ctx, endpoint, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	cl.cli = nil
 
 	dialer := websocket.Dialer{HandshakeTimeout: opts.DialTimeout}

--- a/pkg/rpc/client/wsclient_test.go
+++ b/pkg/rpc/client/wsclient_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -246,4 +247,18 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			wsc.Close()
 		})
 	}
+}
+
+func TestNewWS(t *testing.T) {
+	srv := initTestServer(t, "")
+	defer srv.Close()
+
+	t.Run("good", func(t *testing.T) {
+		_, err := NewWS(context.TODO(), httpURLtoWS(srv.URL), Options{})
+		require.NoError(t, err)
+	})
+	t.Run("bad URL", func(t *testing.T) {
+		_, err := NewWS(context.TODO(), strings.Trim(srv.URL, "http://"), Options{})
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
### Problem

`NewWS()` does not check error when new client is created. It can cause panic at `cl.cli = nil` expression.

### Solution

Check error when new client is created.