### PR TITLE
compiler: refactor typeinfo functions

### DIFF
--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -70,16 +70,16 @@ func (c *codegen) traverseGlobals(f ast.Node) {
 
 // countGlobals counts the global variables in the program to add
 // them with the stack size of the function.
-func countGlobals(f ast.Node) (i int64) {
+func countGlobals(f ast.Node) (i int) {
 	ast.Inspect(f, func(node ast.Node) bool {
-		switch node.(type) {
+		switch n := node.(type) {
 		// Skip all function declarations.
 		case *ast.FuncDecl:
 			return false
 		// After skipping all funcDecls we are sure that each value spec
 		// is a global declared variable or constant.
 		case *ast.ValueSpec:
-			i++
+			i += len(n.Names)
 		}
 		return true
 	})

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -205,62 +205,10 @@ func isBuiltin(expr ast.Expr) bool {
 	return false
 }
 
-func (c *codegen) isCompoundArrayType(t ast.Expr) bool {
-	switch s := t.(type) {
-	case *ast.ArrayType:
-		return true
-	case *ast.Ident:
-		arr, ok := c.typeInfo.Types[s].Type.Underlying().(*types.Slice)
-		return ok && !isByte(arr.Elem())
-	}
-	return false
-}
-
-func isByte(t types.Type) bool {
-	e, ok := t.(*types.Basic)
-	return ok && e.Kind() == types.Byte
-}
-
-func (c *codegen) isStructType(t ast.Expr) (int, bool) {
-	switch s := t.(type) {
-	case *ast.StructType:
-		return s.Fields.NumFields(), true
-	case *ast.Ident:
-		st, ok := c.typeInfo.Types[s].Type.Underlying().(*types.Struct)
-		if ok {
-			return st.NumFields(), true
-		}
-	}
-	return 0, false
-}
-
-func isByteArray(lit *ast.CompositeLit, tInfo *types.Info) bool {
-	if len(lit.Elts) == 0 {
-		if typ, ok := lit.Type.(*ast.ArrayType); ok {
-			if name, ok := typ.Elt.(*ast.Ident); ok {
-				return name.Name == "byte" || name.Name == "uint8"
-			}
-		}
-
-		return false
-	}
-
-	typ := tInfo.Types[lit.Elts[0]].Type.Underlying()
-	return isByte(typ)
-}
-
 func isSyscall(fun *funcScope) bool {
 	if fun.selector == nil {
 		return false
 	}
 	_, ok := syscalls[fun.selector.Name][fun.name]
 	return ok
-}
-
-func isByteArrayType(t types.Type) bool {
-	return t.String() == "[]byte"
-}
-
-func isStringType(t types.Type) bool {
-	return t.String() == "string"
 }

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -86,32 +86,10 @@ func countGlobals(f ast.Node) (i int64) {
 	return
 }
 
-// isIdentBool looks if the given ident is a boolean.
-func isIdentBool(ident *ast.Ident) bool {
-	return ident.Name == "true" || ident.Name == "false"
-}
-
 // isExprNil looks if the given expression is a `nil`.
 func isExprNil(e ast.Expr) bool {
 	v, ok := e.(*ast.Ident)
 	return ok && v.Name == "nil"
-}
-
-// makeBoolFromIdent creates a bool type from an *ast.Ident.
-func makeBoolFromIdent(ident *ast.Ident, tinfo *types.Info) (types.TypeAndValue, error) {
-	var b bool
-	switch ident.Name {
-	case "true":
-		b = true
-	case "false":
-		b = false
-	default:
-		return types.TypeAndValue{}, fmt.Errorf("givent identifier cannot be converted to a boolean => %s", ident.Name)
-	}
-	return types.TypeAndValue{
-		Type:  tinfo.ObjectOf(ident).Type(),
-		Value: constant.MakeBool(b),
-	}, nil
 }
 
 // resolveEntryPoint returns the function declaration of the entrypoint and the corresponding file.

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -610,14 +610,7 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 		return nil
 
 	case *ast.Ident:
-		if isIdentBool(n) {
-			value, err := makeBoolFromIdent(n, c.typeInfo)
-			if err != nil {
-				c.prog.Err = err
-				return nil
-			}
-			c.emitLoadConst(value)
-		} else if tv := c.typeAndValueOf(n); tv.Value != nil {
+		if tv := c.typeAndValueOf(n); tv.Value != nil {
 			c.emitLoadConst(tv)
 		} else {
 			c.emitLoadVar(n.Name)

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -233,6 +233,8 @@ func (c *codegen) emitDefault(t types.Type) {
 	case *types.Slice:
 		if isCompoundSlice(t) {
 			emit.Opcode(c.prog.BinWriter, opcode.NEWARRAY0)
+		} else {
+			emit.Bytes(c.prog.BinWriter, []byte{})
 		}
 	case *types.Struct:
 		emit.Int(c.prog.BinWriter, int64(t.NumFields()))

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -207,6 +207,10 @@ func (c *codegen) emitLoadVar(name string) {
 
 // emitStoreVar stores top value from the evaluation stack in the specified variable.
 func (c *codegen) emitStoreVar(name string) {
+	if name == "_" {
+		emit.Opcode(c.prog.BinWriter, opcode.DROP)
+		return
+	}
 	t, i := c.getVarIndex(name)
 	_, base := getBaseOpcode(t)
 	if i < 7 {
@@ -401,12 +405,7 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 					if i == 0 || !multiRet {
 						ast.Walk(c, n.Rhs[i])
 					}
-
-					if t.Name == "_" {
-						emit.Opcode(c.prog.BinWriter, opcode.DROP)
-					} else {
-						c.emitStoreVar(t.Name)
-					}
+					c.emitStoreVar(t.Name)
 				}
 
 			case *ast.SelectorExpr:

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -304,15 +304,8 @@ func (c *codegen) convertFuncDecl(file ast.Node, decl *ast.FuncDecl) {
 	// to support other types.
 	if decl.Recv != nil {
 		for _, arg := range decl.Recv.List {
-			ident := arg.Names[0]
-			// Currently only method receives for struct types is supported.
-			_, ok := c.typeInfo.Defs[ident].Type().Underlying().(*types.Struct)
-			if !ok {
-				c.prog.Err = fmt.Errorf("method receives for non-struct types is not yet supported")
-				return
-			}
 			// only create an argument here, it will be stored via INITSLOT
-			c.scope.newVariable(varArgument, ident.Name)
+			c.scope.newVariable(varArgument, arg.Names[0].Name)
 		}
 	}
 

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -900,20 +900,18 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 		c.currentSwitch = label
 
 		ast.Walk(c, n.X)
+		emit.Syscall(c.prog.BinWriter, "Neo.Iterator.Create")
 
-		emit.Opcode(c.prog.BinWriter, opcode.SIZE)
-		emit.Opcode(c.prog.BinWriter, opcode.PUSH0)
-
-		c.pushStackLabel(label, 2)
+		c.pushStackLabel(label, 1)
 		c.setLabel(start)
 
-		emit.Opcode(c.prog.BinWriter, opcode.OVER)
-		emit.Opcode(c.prog.BinWriter, opcode.OVER)
-		emit.Opcode(c.prog.BinWriter, opcode.LTE) // finish if len <= i
-		emit.Jmp(c.prog.BinWriter, opcode.JMPIFL, end)
+		emit.Opcode(c.prog.BinWriter, opcode.DUP)
+		emit.Syscall(c.prog.BinWriter, "Neo.Enumerator.Next")
+		emit.Jmp(c.prog.BinWriter, opcode.JMPIFNOTL, end)
 
 		if n.Key != nil {
 			emit.Opcode(c.prog.BinWriter, opcode.DUP)
+			emit.Syscall(c.prog.BinWriter, "Neo.Iterator.Key")
 			c.emitStoreVar(n.Key.(*ast.Ident).Name)
 		}
 
@@ -921,7 +919,6 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 
 		c.setLabel(post)
 
-		emit.Opcode(c.prog.BinWriter, opcode.INC)
 		emit.Jmp(c.prog.BinWriter, opcode.JMPL, start)
 
 		c.setLabel(end)

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -883,13 +883,6 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 		return nil
 
 	case *ast.RangeStmt:
-		// currently only simple for-range loops are supported
-		// for i := range ...
-		if n.Value != nil {
-			c.prog.Err = errors.New("range loops with value variable are not supported")
-			return nil
-		}
-
 		start, label := c.generateLabel(labelStart)
 		end := c.newNamedLabel(labelEnd, label)
 		post := c.newNamedLabel(labelPost, label)
@@ -913,6 +906,11 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 			emit.Opcode(c.prog.BinWriter, opcode.DUP)
 			emit.Syscall(c.prog.BinWriter, "Neo.Iterator.Key")
 			c.emitStoreVar(n.Key.(*ast.Ident).Name)
+		}
+		if n.Value != nil {
+			emit.Opcode(c.prog.BinWriter, opcode.DUP)
+			emit.Syscall(c.prog.BinWriter, "Neo.Enumerator.Value")
+			c.emitStoreVar(n.Value.(*ast.Ident).Name)
 		}
 
 		ast.Walk(c, n.Body)

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -360,27 +360,19 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 					}
 					c.registerDebugVariable(id.Name, t.Type)
 				}
-				if len(t.Values) != 0 {
-					for i, val := range t.Values {
-						ast.Walk(c, val)
-						c.emitStoreVar(t.Names[i].Name)
-					}
-				} else {
-					typ := c.typeOf(t.Type)
-					if isCompoundSlice(typ) {
+				for i := range t.Names {
+					if len(t.Values) != 0 {
+						ast.Walk(c, t.Values[i])
+					} else if typ := c.typeOf(t.Type); isCompoundSlice(typ) {
 						emit.Opcode(c.prog.BinWriter, opcode.PUSH0)
 						emit.Opcode(c.prog.BinWriter, opcode.NEWARRAY)
-						c.emitStoreVar(t.Names[0].Name)
 					} else if s, ok := typ.Underlying().(*types.Struct); ok {
 						emit.Int(c.prog.BinWriter, int64(s.NumFields()))
 						emit.Opcode(c.prog.BinWriter, opcode.NEWSTRUCT)
-						c.emitStoreVar(t.Names[0].Name)
 					} else {
-						for _, id := range t.Names {
-							c.emitDefault(t.Type)
-							c.emitStoreVar(id.Name)
-						}
+						c.emitDefault(t.Type)
 					}
+					c.emitStoreVar(t.Names[i].Name)
 				}
 			}
 		}

--- a/pkg/compiler/debug.go
+++ b/pkg/compiler/debug.go
@@ -191,7 +191,11 @@ func (c *codegen) scReturnTypeFromScope(scope *funcScope) string {
 }
 
 func (c *codegen) scTypeFromExpr(typ ast.Expr) string {
-	switch t := c.typeInfo.Types[typ].Type.(type) {
+	t := c.typeOf(typ)
+	if c.typeOf(typ) == nil {
+		return "Any"
+	}
+	switch t := t.Underlying().(type) {
 	case *types.Basic:
 		info := t.Info()
 		switch {
@@ -209,7 +213,7 @@ func (c *codegen) scTypeFromExpr(typ ast.Expr) string {
 	case *types.Struct:
 		return "Struct"
 	case *types.Slice:
-		if isByteArrayType(t) {
+		if isByte(t.Elem()) {
 			return "ByteArray"
 		}
 		return "Array"

--- a/pkg/compiler/for_test.go
+++ b/pkg/compiler/for_test.go
@@ -3,13 +3,9 @@ package compiler_test
 import (
 	"fmt"
 	"math/big"
-	"strings"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/compiler"
-
 	"github.com/nspcc-dev/neo-go/pkg/vm"
-	"github.com/stretchr/testify/require"
 )
 
 func TestEntryPointWithMethod(t *testing.T) {
@@ -707,20 +703,20 @@ func TestForLoopRangeNoVariable(t *testing.T) {
 	eval(t, src, big.NewInt(3))
 }
 
-func TestForLoopRangeCompilerError(t *testing.T) {
+func TestForLoopRangeValue(t *testing.T) {
 	src := `
 	package foo
-	func f(a int) int { return 0 }
+	func f(a int) int { return a }
 	func Main() int {
-		arr := []int{1, 2, 3}
+		var sum int
+		arr := []int{1, 9, 4}
 		for _, v := range arr {
-			f(v)
+			sum += f(v)
 		}
-		return 0
+		return sum
 	}`
 
-	_, err := compiler.Compile(strings.NewReader(src))
-	require.Error(t, err)
+	eval(t, src, big.NewInt(14))
 }
 
 func TestForLoopComplexConditions(t *testing.T) {

--- a/pkg/compiler/for_test.go
+++ b/pkg/compiler/for_test.go
@@ -719,6 +719,24 @@ func TestForLoopRangeValue(t *testing.T) {
 	eval(t, src, big.NewInt(14))
 }
 
+func TestForLoopRangeMap(t *testing.T) {
+	src := `package foo
+	func Main() int {
+		m := map[int]int{
+			1: 13,
+			11: 17,
+		}
+		var sum int
+		for i, v := range m {
+			sum += i
+			sum += v
+		}
+		return sum
+	}`
+
+	eval(t, src, big.NewInt(42))
+}
+
 func TestForLoopComplexConditions(t *testing.T) {
 	src := `
 	package foo

--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -104,6 +104,15 @@ func (c *funcScope) countLocals() int {
 		// This handles the inline GenDecl like "var x = 2"
 		case *ast.ValueSpec:
 			size += len(n.Names)
+		case *ast.RangeStmt:
+			if n.Tok == token.DEFINE {
+				if n.Key != nil {
+					size++
+				}
+				if n.Value != nil {
+					size++
+				}
+			}
 		}
 		return true
 	})

--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -102,13 +102,8 @@ func (c *funcScope) countLocals() int {
 		case *ast.ReturnStmt, *ast.IfStmt:
 			size++
 		// This handles the inline GenDecl like "var x = 2"
-		case *ast.GenDecl:
-			switch t := n.Specs[0].(type) {
-			case *ast.ValueSpec:
-				if len(t.Values) > 0 {
-					size++
-				}
-			}
+		case *ast.ValueSpec:
+			size += len(n.Names)
 		}
 		return true
 	})

--- a/pkg/compiler/global_test.go
+++ b/pkg/compiler/global_test.go
@@ -19,3 +19,27 @@ func TestChangeGlobal(t *testing.T) {
 
 	eval(t, src, big.NewInt(42))
 }
+
+func TestMultiDeclaration(t *testing.T) {
+	src := `package foo
+	var a, b, c int
+	func Main() int {
+		a = 1
+		b = 2
+		c = 3
+		return a + b + c
+	}`
+	eval(t, src, big.NewInt(6))
+}
+
+func TestMultiDeclarationLocal(t *testing.T) {
+	src := `package foo
+	func Main() int {
+		var a, b, c int
+		a = 1
+		b = 2
+		c = 3
+		return a + b + c
+	}`
+	eval(t, src, big.NewInt(6))
+}

--- a/pkg/compiler/global_test.go
+++ b/pkg/compiler/global_test.go
@@ -43,3 +43,15 @@ func TestMultiDeclarationLocal(t *testing.T) {
 	}`
 	eval(t, src, big.NewInt(6))
 }
+
+func TestMultiDeclarationLocalCompound(t *testing.T) {
+	src := `package foo
+	func Main() int {
+		var a, b, c []int
+		a = append(a, 1)
+		b = append(b, 2)
+		c = append(c, 3)
+		return a[0] + b[0] + c[0]
+	}`
+	eval(t, src, big.NewInt(6))
+}

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -131,6 +131,17 @@ var sliceTestCases = []testCase{
 		[]byte{2, 3},
 	},
 	{
+		"declare byte slice",
+		`package foo
+		func Main() []byte {
+			var a []byte
+			a = append(a, 1)
+			a = append(a, 2)
+			return a
+		}`,
+		[]byte{1, 2},
+	},
+	{
 		"declare compound slice",
 		`package foo
 		func Main() []string {

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -34,6 +34,16 @@ var sliceTestCases = []testCase{
 		big.NewInt(42),
 	},
 	{
+		"increase slice element with +=",
+		`package foo
+		func Main() int {
+			a := []int{1, 2, 3}
+			a[1] += 40
+			return a[1]
+		}`,
+		big.NewInt(42),
+	},
+	{
 		"complex test",
 		`
 		package foo

--- a/pkg/compiler/struct_test.go
+++ b/pkg/compiler/struct_test.go
@@ -135,6 +135,17 @@ var structTestCases = []testCase{
 		big.NewInt(14),
 	},
 	{
+		"increase struct field with +=",
+		`package foo
+		type token struct { x int }
+		func Main() int {
+		t := token{x: 2}
+		t.x += 3
+		return t.x
+		}`,
+		big.NewInt(5),
+	},
+	{
 		"assign a struct field to a struct field",
 		`
 		package foo

--- a/pkg/compiler/type_test.go
+++ b/pkg/compiler/type_test.go
@@ -1,6 +1,9 @@
 package compiler_test
 
-import "testing"
+import (
+	"math/big"
+	"testing"
+)
 
 func TestCustomType(t *testing.T) {
 	src := `
@@ -21,4 +24,16 @@ func TestCustomType(t *testing.T) {
 		}
 	`
 	eval(t, src, []byte("some short string"))
+}
+
+func TestCustomTypeMethods(t *testing.T) {
+	src := `package foo
+	type bar int
+	func (b bar) add(a bar) bar { return a + b }
+	func Main() bar {
+		var b bar
+		b = 10
+		return b.add(32)
+	}`
+	eval(t, src, big.NewInt(42))
 }

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -1,0 +1,44 @@
+package compiler
+
+import (
+	"go/ast"
+	"go/types"
+)
+
+func (c *codegen) typeAndValueOf(e ast.Expr) types.TypeAndValue {
+	return c.typeInfo.Types[e]
+}
+
+func (c *codegen) typeOf(e ast.Expr) types.Type {
+	return c.typeAndValueOf(e).Type
+}
+
+func isBasicTypeOfKind(typ types.Type, ks ...types.BasicKind) bool {
+	if t, ok := typ.Underlying().(*types.Basic); ok {
+		k := t.Kind()
+		for i := range ks {
+			if k == ks[i] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isByte(typ types.Type) bool {
+	return isBasicTypeOfKind(typ, types.Uint8, types.Int8)
+}
+
+func isString(typ types.Type) bool {
+	return isBasicTypeOfKind(typ, types.String)
+}
+
+func isCompoundSlice(typ types.Type) bool {
+	t, ok := typ.Underlying().(*types.Slice)
+	return ok && !isByte(t.Elem())
+}
+
+func isByteSlice(typ types.Type) bool {
+	t, ok := typ.Underlying().(*types.Slice)
+	return ok && isByte(t.Elem())
+}


### PR DESCRIPTION
1. Make type info processing more unified and clear.
2. Simplify some processing of index expressions, reuse code.
3. Emit default values in a generic way.
4. Support for-range loops with value variable. Reimplement `range` via `Iterator`.
5. Support for-range over maps.
6. Port of #954.