### PR TITLE
vm: allow to convert Map item to bool

### DIFF
--- a/pkg/vm/stack.go
+++ b/pkg/vm/stack.go
@@ -96,7 +96,7 @@ func (e *Element) TryBool() (bool, error) {
 		return t.value.Int64() != 0, nil
 	case *BoolItem:
 		return t.value, nil
-	case *ArrayItem, *StructItem:
+	case *ArrayItem, *StructItem, *MapItem:
 		return true, nil
 	case *ByteArrayItem:
 		for _, b := range t.value {


### PR DESCRIPTION
Closes #966.
Logs were pretty helpful.
```2020-05-21T17:45:51.808+0300    WARN    contract invocation failed      {"tx": "71c43cc32ae5336622d7105d1c96387c8cca6c948beac29edfef46712ba5ffeb", "block": 3960417, "error": "error encountered at instruction 14802 (JMPIFNOT): can't convert to bool: Map"}```