### PR TITLE
Clean build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1-alpine as builder
 
 RUN set -x \
-    && apk add --no-cache git \
+    && apk add --no-cache git make \
     && mkdir -p /tmp
 
 COPY . /neo-go
@@ -12,14 +12,7 @@ WORKDIR /neo-go
 ARG REPO=repository
 ARG VERSION=dev
 
-# https://github.com/golang/go/wiki/Modules#how-do-i-use-vendoring-with-modules-is-vendoring-going-away
-# go build -mod=vendor
-RUN set -x \
-    && export GOGC=off \
-    && export GO111MODULE=on \
-    && export CGO_ENABLED=0 \
-    && export LDFLAGS="-X ${REPO}/config.Version=${VERSION}" \
-    && go build -v -mod=vendor -ldflags "${LDFLAGS}" -o /go/bin/neo-go ./cli
+RUN make
 
 # Executable image
 FROM alpine
@@ -33,7 +26,7 @@ COPY --from=builder /neo-go/config /config
 COPY --from=builder /neo-go/.docker/6000-privnet-blocks.acc.gz /6000-privnet-blocks.acc.gz
 COPY --from=builder /neo-go/.docker/1600-privnet-blocks-single.acc.gz /1600-privnet-blocks-single.acc.gz
 COPY --from=builder /neo-go/.docker/privnet-entrypoint.sh /usr/bin/privnet-entrypoint.sh
-COPY --from=builder /go/bin/neo-go /usr/bin/neo-go
+COPY --from=builder /neo-go/bin/neo-go /usr/bin/neo-go
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT ["/usr/bin/privnet-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ image-push:
 check-version:
 	git fetch && (! git rev-list ${VERSION})
 
+version:
+	@echo ${VERSION}
+
 deps:
 	@go mod tidy -v
 	@go mod vendor


### PR DESCRIPTION
### Problem

A NeoGo build in docker is useful for test purposes.

### Solution

Current Dockerfile is designed to work on developer's laptop only. The PR makes build in docker clean and independent of host filesystem, what allows to include NeoGo instance in test installations.
