### PR TITLE
vm,dao: return storage iterator from DAO in Storage.Find interop

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1147,7 +1147,7 @@ func (bc *Blockchain) GetStorageItem(scripthash util.Uint160, key []byte) *state
 
 // GetStorageItems returns all storage items for a given scripthash.
 func (bc *Blockchain) GetStorageItems(hash util.Uint160) (map[string]*state.StorageItem, error) {
-	siMap, err := bc.dao.GetStorageItems(hash)
+	siMap, err := bc.dao.GetStorageItems(hash, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/core/dao/cacheddao.go
+++ b/pkg/core/dao/cacheddao.go
@@ -321,7 +321,7 @@ type StorageIteratorFunc func() ([]byte, []byte, error)
 // GetStorageItemsIterator returns iterator over all storage items.
 // Function returned can be called until first error.
 func (cd *Cached) GetStorageItemsIterator(hash util.Uint160, prefix []byte) (StorageIteratorFunc, error) {
-	items, err := cd.DAO.GetStorageItems(hash)
+	items, err := cd.DAO.GetStorageItems(hash, prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +352,7 @@ func (cd *Cached) GetStorageItemsIterator(hash util.Uint160, prefix []byte) (Sto
 		index++
 		for ; index < len(items); index++ {
 			_, ok := cache[string(items[index].Key)]
-			if !ok && bytes.HasPrefix(items[index].Key, prefix) {
+			if !ok {
 				return items[index].Key, items[index].Value, nil
 			}
 		}
@@ -362,8 +362,8 @@ func (cd *Cached) GetStorageItemsIterator(hash util.Uint160, prefix []byte) (Sto
 }
 
 // GetStorageItems returns all storage items for a given scripthash.
-func (cd *Cached) GetStorageItems(hash util.Uint160) ([]StorageItemWithKey, error) {
-	items, err := cd.DAO.GetStorageItems(hash)
+func (cd *Cached) GetStorageItems(hash util.Uint160, prefix []byte) ([]StorageItemWithKey, error) {
+	items, err := cd.DAO.GetStorageItems(hash, prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -35,7 +35,7 @@ type DAO interface {
 	GetNEP5Balances(acc util.Uint160) (*state.NEP5Balances, error)
 	GetNEP5TransferLog(acc util.Uint160, index uint32) (*state.NEP5TransferLog, error)
 	GetStorageItem(scripthash util.Uint160, key []byte) *state.StorageItem
-	GetStorageItems(hash util.Uint160) ([]StorageItemWithKey, error)
+	GetStorageItems(hash util.Uint160, prefix []byte) ([]StorageItemWithKey, error)
 	GetTransaction(hash util.Uint256) (*transaction.Transaction, uint32, error)
 	GetUnspentCoinState(hash util.Uint256) (*state.UnspentCoin, error)
 	GetValidatorState(publicKey *keys.PublicKey) (*state.Validator, error)
@@ -442,7 +442,7 @@ type StorageItemWithKey struct {
 }
 
 // GetStorageItems returns all storage items for a given scripthash.
-func (dao *Simple) GetStorageItems(hash util.Uint160) ([]StorageItemWithKey, error) {
+func (dao *Simple) GetStorageItems(hash util.Uint160, prefix []byte) ([]StorageItemWithKey, error) {
 	var res []StorageItemWithKey
 	var err error
 
@@ -462,7 +462,7 @@ func (dao *Simple) GetStorageItems(hash util.Uint160) ([]StorageItemWithKey, err
 		s.Key = k[21:]
 		res = append(res, s)
 	}
-	dao.Store.Seek(storage.AppendPrefix(storage.STStorage, hash.BytesLE()), saveToMap)
+	dao.Store.Seek(makeStorageItemKey(hash, prefix), saveToMap)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/core/interop_neo.go
+++ b/pkg/core/interop_neo.go
@@ -582,7 +582,7 @@ func (ic *interopContext) contractMigrate(v *vm.VM) error {
 		}
 		if contract.HasStorage() {
 			hash := getContextScriptHash(v, 0)
-			siMap, err := ic.dao.GetStorageItems(hash)
+			siMap, err := ic.dao.GetStorageItems(hash, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/core/interop_neo.go
+++ b/pkg/core/interop_neo.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -463,22 +462,12 @@ func (ic *interopContext) storageFind(v *vm.VM) error {
 		return err
 	}
 	pref := v.Estack().Pop().Bytes()
-	siMap, err := ic.dao.GetStorageItems(stc.ScriptHash)
+	next, err := ic.dao.GetStorageItemsIterator(stc.ScriptHash, pref)
 	if err != nil {
 		return err
 	}
-
-	filteredMap := vm.NewMapItem()
-	for i := range siMap {
-		k := siMap[i].Key
-		if bytes.HasPrefix(k, pref) {
-			filteredMap.Add(vm.NewByteArrayItem(siMap[i].Key),
-				vm.NewByteArrayItem(siMap[i].Value))
-		}
-	}
-
-	item := vm.NewMapIterator(filteredMap)
-	v.Estack().PushVal(item)
+	item := newStorageIterator(next)
+	v.Estack().PushVal(vm.NewInteropItem(item))
 
 	return nil
 }

--- a/pkg/core/interop_system.go
+++ b/pkg/core/interop_system.go
@@ -561,7 +561,7 @@ func (ic *interopContext) contractDestroy(v *vm.VM) error {
 		return err
 	}
 	if cs.HasStorage() {
-		siMap, err := ic.dao.GetStorageItems(hash)
+		siMap, err := ic.dao.GetStorageItems(hash, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/core/storage_find.go
+++ b/pkg/core/storage_find.go
@@ -11,6 +11,8 @@ type storageWrapper struct {
 	finished   bool
 }
 
+var _ vm.Iterator = (*storageWrapper)(nil)
+
 // newStorageIterator returns new storage iterator from the `next()` callback.
 func newStorageIterator(next dao.StorageIteratorFunc) *storageWrapper {
 	return &storageWrapper{
@@ -18,7 +20,7 @@ func newStorageIterator(next dao.StorageIteratorFunc) *storageWrapper {
 	}
 }
 
-// Next implements iterator interface.
+// Next implements vm.Iterator interface.
 func (s *storageWrapper) Next() bool {
 	if s.finished {
 		return false
@@ -33,12 +35,12 @@ func (s *storageWrapper) Next() bool {
 	return true
 }
 
-// Value implements iterator interface.
+// Value implements vm.Iterator interface.
 func (s *storageWrapper) Value() vm.StackItem {
 	return s.value
 }
 
-// Key implements iterator interface.
+// Key implements vm.Iterator interface.
 func (s *storageWrapper) Key() vm.StackItem {
 	return s.key
 }

--- a/pkg/core/storage_find.go
+++ b/pkg/core/storage_find.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/core/dao"
+	"github.com/nspcc-dev/neo-go/pkg/vm"
+)
+
+type storageWrapper struct {
+	next       dao.StorageIteratorFunc
+	key, value vm.StackItem
+	finished   bool
+}
+
+// newStorageIterator returns new storage iterator from the `next()` callback.
+func newStorageIterator(next dao.StorageIteratorFunc) *storageWrapper {
+	return &storageWrapper{
+		next: next,
+	}
+}
+
+// Next implements iterator interface.
+func (s *storageWrapper) Next() bool {
+	if s.finished {
+		return false
+	}
+	key, value, err := s.next()
+	if err != nil {
+		s.finished = true
+		return false
+	}
+	s.key = vm.NewByteArrayItem(key)
+	s.value = vm.NewByteArrayItem(value)
+	return true
+}
+
+// Value implements iterator interface.
+func (s *storageWrapper) Value() vm.StackItem {
+	return s.value
+}
+
+// Key implements iterator interface.
+func (s *storageWrapper) Key() vm.StackItem {
+	return s.key
+}

--- a/pkg/vm/interop.go
+++ b/pkg/vm/interop.go
@@ -205,9 +205,9 @@ func NewMapIterator(m *MapItem) *InteropItem {
 // IteratorConcat handles syscall Neo.Iterator.Concat.
 func IteratorConcat(v *VM) error {
 	iop1 := v.Estack().Pop().Interop()
-	iter1 := iop1.value.(iterator)
+	iter1 := iop1.value.(Iterator)
 	iop2 := v.Estack().Pop().Interop()
-	iter2 := iop2.value.(iterator)
+	iter2 := iop2.value.(Iterator)
 
 	v.Estack().Push(&Element{value: NewInteropItem(
 		&concatIter{
@@ -222,7 +222,7 @@ func IteratorConcat(v *VM) error {
 // IteratorKey handles syscall Neo.Iterator.Key.
 func IteratorKey(v *VM) error {
 	iop := v.estack.Pop().Interop()
-	iter := iop.value.(iterator)
+	iter := iop.value.(Iterator)
 	v.Estack().Push(&Element{value: iter.Key()})
 
 	return nil
@@ -231,7 +231,7 @@ func IteratorKey(v *VM) error {
 // IteratorKeys handles syscall Neo.Iterator.Keys.
 func IteratorKeys(v *VM) error {
 	iop := v.estack.Pop().Interop()
-	iter := iop.value.(iterator)
+	iter := iop.value.(Iterator)
 	v.Estack().Push(&Element{value: NewInteropItem(
 		&keysWrapper{iter},
 	)})
@@ -242,7 +242,7 @@ func IteratorKeys(v *VM) error {
 // IteratorValues handles syscall Neo.Iterator.Values.
 func IteratorValues(v *VM) error {
 	iop := v.estack.Pop().Interop()
-	iter := iop.value.(iterator)
+	iter := iop.value.(Iterator)
 	v.Estack().Push(&Element{value: NewInteropItem(
 		&valuesWrapper{iter},
 	)})

--- a/pkg/vm/interop_iterators.go
+++ b/pkg/vm/interop_iterators.go
@@ -18,7 +18,8 @@ type (
 )
 
 type (
-	iterator interface {
+	// Iterator defined public interface for VM's iterator type.
+	Iterator interface {
 		enumerator
 		Key() StackItem
 	}
@@ -29,16 +30,16 @@ type (
 	}
 
 	concatIter struct {
-		current iterator
-		second  iterator
+		current Iterator
+		second  Iterator
 	}
 
 	keysWrapper struct {
-		iter iterator
+		iter Iterator
 	}
 
 	valuesWrapper struct {
-		iter iterator
+		iter Iterator
 	}
 )
 


### PR DESCRIPTION
Fix #988 .

Reproduce behavior of the reference realization:
- if item was Put in cache after it was encountered during
  Storage.Find, it must appear twice
- checking if item is in cache must be performed in real-time
  during `Iterator.Next()`

Need too retest #822 .