### PR TITLE
core: sort results of Storage.Find interop and NEO.getRegisterValidators

### DIFF
--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -3,6 +3,7 @@ package native
 import (
 	"math/big"
 	"sort"
+	"strings"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/blockchainer"
 	"github.com/nspcc-dev/neo-go/pkg/core/dao"
@@ -344,6 +345,7 @@ func (n *NEO) getRegisteredValidators(d dao.DAO) ([]keyWithVotes, error) {
 		}
 		arr = append(arr, keyWithVotes{key, &votes.Balance})
 	}
+	sort.Slice(arr, func(i, j int) bool { return strings.Compare(arr[i].Key, arr[j].Key) == -1 })
 	return arr, nil
 }
 


### PR DESCRIPTION
Closes #909
We need to match elements order with C# implementation.

Perhaps, we don't even need to change return value of `dao.GetStorageItems(WithKey)` as Storage.Find and NEO.getRegisteredVelidators are the only places where we have to keep elements sorted.