### PR TITLE
consensus: update dbft to include CountFailed and RecoveryMessage changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/gorilla/websocket v1.4.2
 	github.com/mr-tron/base58 v1.1.2
-	github.com/nspcc-dev/dbft v0.0.0-20200303183127-36d3da79c682
+	github.com/nspcc-dev/dbft v0.0.0-20200531081613-7a39e7b757ac
 	github.com/nspcc-dev/rfc6979 v0.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/nspcc-dev/dbft v0.0.0-20200117124306-478e5cfbf03a h1:ajvxgEe9qY4vvoSm
 github.com/nspcc-dev/dbft v0.0.0-20200117124306-478e5cfbf03a/go.mod h1:/YFK+XOxxg0Bfm6P92lY5eDSLYfp06XOdL8KAVgXjVk=
 github.com/nspcc-dev/dbft v0.0.0-20200219114139-199d286ed6c1 h1:yEx9WznS+rjE0jl0dLujCxuZSIb+UTjF+005TJu/nNI=
 github.com/nspcc-dev/dbft v0.0.0-20200219114139-199d286ed6c1/go.mod h1:O0qtn62prQSqizzoagHmuuKoz8QMkU3SzBoKdEvm3aQ=
-github.com/nspcc-dev/dbft v0.0.0-20200303183127-36d3da79c682 h1:63OWUolW4GcjJR7cThq8hLnMLTwL+sjO3Qf4fo4sx8w=
-github.com/nspcc-dev/dbft v0.0.0-20200303183127-36d3da79c682/go.mod h1:1FYQXSbb6/9HQIkoF8XO7W/S8N7AZRkBsgwbcXRvk0E=
+github.com/nspcc-dev/dbft v0.0.0-20200531081613-7a39e7b757ac h1:cXPgsp4avJ7cR1nPRdpFRHmWoMSRZ41FSvlNjpsyTiA=
+github.com/nspcc-dev/dbft v0.0.0-20200531081613-7a39e7b757ac/go.mod h1:1FYQXSbb6/9HQIkoF8XO7W/S8N7AZRkBsgwbcXRvk0E=
 github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:pPYwPZ2ks+uMnlRLUyXOpLieaDQSEaf4NM3zHVbRjmg=
 github.com/nspcc-dev/neofs-crypto v0.2.0 h1:ftN+59WqxSWz/RCgXYOfhmltOOqU+udsNQSvN6wkFck=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=

--- a/pkg/consensus/block.go
+++ b/pkg/consensus/block.go
@@ -58,44 +58,23 @@ func (n *neoBlock) SetTransactions(txes []block.Transaction) {
 // Version implements block.Block interface.
 func (n *neoBlock) Version() uint32 { return n.Block.Version }
 
-// SetVersion implements block.Block interface.
-func (n *neoBlock) SetVersion(v uint32) { n.Block.Version = v }
-
 // PrevHash implements block.Block interface.
 func (n *neoBlock) PrevHash() util.Uint256 { return n.Block.PrevHash }
-
-// SetPrevHash implements block.Block interface.
-func (n *neoBlock) SetPrevHash(h util.Uint256) { n.Block.PrevHash = h }
 
 // MerkleRoot implements block.Block interface.
 func (n *neoBlock) MerkleRoot() util.Uint256 { return n.Block.MerkleRoot }
 
-// SetMerkleRoot implements block.Block interface.
-func (n *neoBlock) SetMerkleRoot(r util.Uint256) { n.Block.MerkleRoot = r }
-
 // Timestamp implements block.Block interface.
-func (n *neoBlock) Timestamp() uint32 { return n.Block.Timestamp }
-
-// SetTimestamp implements block.Block interface.
-func (n *neoBlock) SetTimestamp(ts uint32) { n.Block.Timestamp = ts }
+func (n *neoBlock) Timestamp() uint64 { return uint64(n.Block.Timestamp) * 1000000000 }
 
 // Index implements block.Block interface.
 func (n *neoBlock) Index() uint32 { return n.Block.Index }
 
-// SetIndex implements block.Block interface.
-func (n *neoBlock) SetIndex(i uint32) { n.Block.Index = i }
-
 // ConsensusData implements block.Block interface.
 func (n *neoBlock) ConsensusData() uint64 { return n.Block.ConsensusData }
 
-// SetConsensusData implements block.Block interface.
-func (n *neoBlock) SetConsensusData(nonce uint64) { n.Block.ConsensusData = nonce }
-
 // NextConsensus implements block.Block interface.
 func (n *neoBlock) NextConsensus() util.Uint160 { return n.Block.NextConsensus }
-
-// SetNextConsensus implements block.Block interface.
-func (n *neoBlock) SetNextConsensus(h util.Uint160) { n.Block.NextConsensus = h }
 
 // Signature implements block.Block interface.
 func (n *neoBlock) Signature() []byte { return n.signature }

--- a/pkg/consensus/block_test.go
+++ b/pkg/consensus/block_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nspcc-dev/dbft/block"
 	"github.com/nspcc-dev/dbft/crypto"
+	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/require"
 )
@@ -21,28 +22,29 @@ func TestNeoBlock_Sign(t *testing.T) {
 func TestNeoBlock_Setters(t *testing.T) {
 	b := new(neoBlock)
 
-	b.SetVersion(1)
+	b.Block.Version = 1
 	require.EqualValues(t, 1, b.Version())
 
-	b.SetIndex(12)
+	b.Block.Index = 12
 	require.EqualValues(t, 12, b.Index())
 
-	b.SetTimestamp(777)
-	require.EqualValues(t, 777, b.Timestamp())
+	b.Block.Timestamp = 777
+	require.EqualValues(t, 777*1000000000, b.Timestamp()) // Nanoseconds.
 
-	b.SetConsensusData(456)
+	b.Block.ConsensusData = 456
 	require.EqualValues(t, 456, b.ConsensusData())
 
-	b.SetMerkleRoot(util.Uint256{1, 2, 3, 4})
+	b.Block.MerkleRoot = util.Uint256{1, 2, 3, 4}
 	require.Equal(t, util.Uint256{1, 2, 3, 4}, b.MerkleRoot())
 
-	b.SetNextConsensus(util.Uint160{9, 2})
+	b.Block.NextConsensus = util.Uint160{9, 2}
 	require.Equal(t, util.Uint160{9, 2}, b.NextConsensus())
 
-	b.SetPrevHash(util.Uint256{9, 8, 7})
+	b.Block.PrevHash = util.Uint256{9, 8, 7}
 	require.Equal(t, util.Uint256{9, 8, 7}, b.PrevHash())
 
-	txx := []block.Transaction{newMinerTx(123)}
-	b.SetTransactions(txx)
+	tx := newMinerTx(123)
+	txx := []block.Transaction{tx}
+	b.Block.Transactions = []*transaction.Transaction{tx}
 	require.Equal(t, txx, b.Transactions())
 }

--- a/pkg/consensus/prepare_request.go
+++ b/pkg/consensus/prepare_request.go
@@ -37,10 +37,10 @@ func (p *prepareRequest) DecodeBinary(r *io.BinReader) {
 }
 
 // Timestamp implements payload.PrepareRequest interface.
-func (p *prepareRequest) Timestamp() uint32 { return p.timestamp }
+func (p *prepareRequest) Timestamp() uint64 { return uint64(p.timestamp) * 1000000000 }
 
 // SetTimestamp implements payload.PrepareRequest interface.
-func (p *prepareRequest) SetTimestamp(ts uint32) { p.timestamp = ts }
+func (p *prepareRequest) SetTimestamp(ts uint64) { p.timestamp = uint32(ts / 1000000000) }
 
 // Nonce implements payload.PrepareRequest interface.
 func (p *prepareRequest) Nonce() uint64 { return p.nonce }

--- a/pkg/consensus/prepare_request_test.go
+++ b/pkg/consensus/prepare_request_test.go
@@ -11,8 +11,8 @@ import (
 func TestPrepareRequest_Setters(t *testing.T) {
 	var p prepareRequest
 
-	p.SetTimestamp(123)
-	require.EqualValues(t, 123, p.Timestamp())
+	p.SetTimestamp(123 * 1000000000) // Nanoseconds.
+	require.EqualValues(t, 123*1000000000, p.Timestamp())
 
 	p.SetNextConsensus(util.Uint160{5, 6, 7})
 	require.Equal(t, util.Uint160{5, 6, 7}, p.NextConsensus())


### PR DESCRIPTION
dbft interface changed a little also because of Neo 3 changes, but it still is
compatible with Neo 2.

Merging to neox-2.x first and then to master-2.x