### PR TITLE
compiler: process interop together with package

### DIFF
--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 )
 
 // A funcScope represents the scope within the function context.
@@ -17,6 +18,9 @@ type funcScope struct {
 
 	// The declaration of the function in the AST. Nil if this scope is not a function.
 	decl *ast.FuncDecl
+
+	// Package where the function is defined.
+	pkg *types.Package
 
 	// Program label of the scope
 	label uint16

--- a/pkg/compiler/testdata/block/block.go
+++ b/pkg/compiler/testdata/block/block.go
@@ -1,0 +1,9 @@
+package block
+
+// Block is opaque type.
+type Block struct{}
+
+// GetTransactionCount is a mirror of `GetTransactionCount` interop.
+func GetTransactionCount(b Block) int {
+	return 42
+}

--- a/pkg/compiler/testdata/util/equals.go
+++ b/pkg/compiler/testdata/util/equals.go
@@ -1,0 +1,6 @@
+package util
+
+// Equals is a mirror of `Equals` builtin.
+func Equals(a, b interface{}) bool {
+	return true
+}


### PR DESCRIPTION
Closes #913 .
Provide package info in the `funcScope` to check if function is defined
insided an interop package. As a good side-effect bytecode for builtins from `util`
is no longer emitted.

Related #941.