### PR TITLE
Implement System.Json.* interops

### DIFF
--- a/pkg/compiler/assign_test.go
+++ b/pkg/compiler/assign_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/nspcc-dev/neo-go/pkg/vm"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
 var assignTestCases = []testCase{
@@ -144,9 +144,9 @@ func TestManyAssignments(t *testing.T) {
 	src2 := `return a
 	}`
 
-	for i := 0; i < vm.MaxArraySize; i++ {
+	for i := 0; i < stackitem.MaxArraySize; i++ {
 		src1 += "a += 1\n"
 	}
 
-	eval(t, src1+src2, big.NewInt(vm.MaxArraySize))
+	eval(t, src1+src2, big.NewInt(stackitem.MaxArraySize))
 }

--- a/pkg/compiler/syscall.go
+++ b/pkg/compiler/syscall.go
@@ -10,6 +10,10 @@ var syscalls = map[string]map[string]string{
 		"Next":   "System.Enumerator.Next",
 		"Value":  "System.Enumerator.Value",
 	},
+	"json": {
+		"Serialize":   "System.Json.Serialize",
+		"Deserialize": "System.Json.Deserialize",
+	},
 	"storage": {
 		"ConvertContextToReadOnly": "System.Storage.AsReadOnly",
 		"Delete":                   "System.Storage.Delete",

--- a/pkg/core/interop/json/json.go
+++ b/pkg/core/interop/json/json.go
@@ -1,0 +1,29 @@
+package json
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/core/interop"
+	"github.com/nspcc-dev/neo-go/pkg/vm"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+)
+
+// Serialize handles System.JSON.Serialize syscall.
+func Serialize(_ *interop.Context, v *vm.VM) error {
+	item := v.Estack().Pop().Item()
+	data, err := stackitem.ToJSON(item)
+	if err != nil {
+		return err
+	}
+	v.Estack().PushVal(data)
+	return nil
+}
+
+// Deserialize handles System.JSON.Deserialize syscall.
+func Deserialize(_ *interop.Context, v *vm.VM) error {
+	data := v.Estack().Pop().Bytes()
+	item, err := stackitem.FromJSON(data)
+	if err != nil {
+		return err
+	}
+	v.Estack().PushVal(item)
+	return nil
+}

--- a/pkg/core/interop/json/json_test.go
+++ b/pkg/core/interop/json/json_test.go
@@ -1,0 +1,68 @@
+package json
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/vm"
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	serializeID   = emit.InteropNameToID([]byte("System.Json.Serialize"))
+	deserializeID = emit.InteropNameToID([]byte("System.Json.Deserialize"))
+)
+
+func getInterop(id uint32) *vm.InteropFuncPrice {
+	switch id {
+	case serializeID:
+		return &vm.InteropFuncPrice{
+			Func: func(v *vm.VM) error { return Serialize(nil, v) },
+		}
+	case deserializeID:
+		return &vm.InteropFuncPrice{
+			Func: func(v *vm.VM) error { return Deserialize(nil, v) },
+		}
+	default:
+		return nil
+	}
+}
+
+func getTestFunc(id uint32, arg interface{}, result interface{}) func(t *testing.T) {
+	prog := make([]byte, 5)
+	prog[0] = byte(opcode.SYSCALL)
+	binary.LittleEndian.PutUint32(prog[1:], id)
+
+	return func(t *testing.T) {
+		v := vm.New()
+		v.RegisterInteropGetter(getInterop)
+		v.LoadScript(prog)
+		v.Estack().PushVal(arg)
+		if result == nil {
+			require.Error(t, v.Run())
+			return
+		}
+		require.NoError(t, v.Run())
+		require.Equal(t, stackitem.Make(result), v.Estack().Pop().Item())
+	}
+}
+
+func TestSerialize(t *testing.T) {
+	t.Run("Serialize", func(t *testing.T) {
+		t.Run("Good", getTestFunc(serializeID, 42, []byte("42")))
+		t.Run("Bad", func(t *testing.T) {
+			arr := stackitem.NewArray([]stackitem.Item{
+				stackitem.NewByteArray(make([]byte, stackitem.MaxSize/2)),
+				stackitem.NewByteArray(make([]byte, stackitem.MaxSize/2)),
+			})
+			getTestFunc(serializeID, arr, nil)(t)
+		})
+	})
+	t.Run("Deserialize", func(t *testing.T) {
+		t.Run("Good", getTestFunc(deserializeID, []byte("42"), 42))
+		t.Run("Bad", getTestFunc(deserializeID, []byte("{]"), nil))
+	})
+}

--- a/pkg/core/interops.go
+++ b/pkg/core/interops.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/interop/crypto"
 	"github.com/nspcc-dev/neo-go/pkg/core/interop/enumerator"
 	"github.com/nspcc-dev/neo-go/pkg/core/interop/iterator"
+	"github.com/nspcc-dev/neo-go/pkg/core/interop/json"
 	"github.com/nspcc-dev/neo-go/pkg/core/interop/runtime"
 	"github.com/nspcc-dev/neo-go/pkg/core/native"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
@@ -105,6 +106,8 @@ var systemInterops = []interop.Function{
 	{Name: "System.Iterator.Key", Func: iterator.Key, Price: 400},
 	{Name: "System.Iterator.Keys", Func: iterator.Keys, Price: 400},
 	{Name: "System.Iterator.Values", Func: iterator.Values, Price: 400},
+	{Name: "System.Json.Deserialize", Func: json.Deserialize, Price: 500000},
+	{Name: "System.Json.Serialize", Func: json.Serialize, Price: 100000},
 	{Name: "System.Runtime.CheckWitness", Func: runtime.CheckWitness, Price: 200, RequiredFlags: smartcontract.AllowStates},
 	{Name: "System.Runtime.GetTime", Func: runtimeGetTime, Price: 1,
 		AllowedTriggers: trigger.Application, RequiredFlags: smartcontract.AllowStates},

--- a/pkg/interop/json/json.go
+++ b/pkg/interop/json/json.go
@@ -1,0 +1,28 @@
+/*
+Package json provides various JSON serialization/deserialization routines.
+*/
+package json
+
+// ToJSON serializes value to json. It uses `System.Json.Serialize` syscall.
+// Serialization format is the following:
+// []byte -> base64 string
+// bool -> json boolean
+// nil -> Null
+// string -> base64 encoded sequence of underlying bytes
+// (u)int* -> integer, only value in -2^53..2^53 are allowed
+// []interface{} -> json array
+// map[type1]type2 -> json object with string keys marshaled as strings (not base64).
+func ToJSON(item interface{}) []byte {
+	return nil
+}
+
+// FromJSON deserializes value from json. It uses `System.Json.Deserialize` syscall.
+// It performs deserialization as follows:
+// strings -> []byte (string) from base64
+// integers -> (u)int* types
+// null -> interface{}(nil)
+// arrays -> []interface{}
+// maps -> map[string]interface{}
+func FromJSON(data []byte) interface{} {
+	return nil
+}

--- a/pkg/vm/context.go
+++ b/pkg/vm/context.go
@@ -97,7 +97,7 @@ func (c *Context) Next() (opcode.Opcode, []byte, error) {
 			err = errNoInstParam
 		} else {
 			var n = binary.LittleEndian.Uint32(c.prog[c.nextip : c.nextip+4])
-			if n > MaxItemSize {
+			if n > stackitem.MaxSize {
 				return instr, nil, errors.New("parameter is too big")
 			}
 			numtoread = int(n)

--- a/pkg/vm/contract_checks.go
+++ b/pkg/vm/contract_checks.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/encoding/bigint"
 	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
 var (
@@ -21,14 +22,14 @@ func getNumOfThingsFromInstr(instr opcode.Opcode, param []byte) (int, bool) {
 		nthings = int(instr-opcode.PUSH1) + 1
 	case instr <= opcode.PUSHINT256:
 		n := bigint.FromBytes(param)
-		if !n.IsInt64() || n.Int64() > MaxArraySize {
+		if !n.IsInt64() || n.Int64() > stackitem.MaxArraySize {
 			return 0, false
 		}
 		nthings = int(n.Int64())
 	default:
 		return 0, false
 	}
-	if nthings < 1 || nthings > MaxArraySize {
+	if nthings < 1 || nthings > stackitem.MaxArraySize {
 		return 0, false
 	}
 	return nthings, true
@@ -69,7 +70,7 @@ func ParseMultiSigContract(script []byte) (int, [][]byte, bool) {
 		}
 		pubs = append(pubs, param)
 		nkeys++
-		if nkeys > MaxArraySize {
+		if nkeys > stackitem.MaxArraySize {
 			return nsigs, nil, false
 		}
 	}

--- a/pkg/vm/interop.go
+++ b/pkg/vm/interop.go
@@ -93,7 +93,7 @@ func RuntimeSerialize(vm *VM) error {
 	data, err := stackitem.SerializeItem(item.value)
 	if err != nil {
 		return err
-	} else if len(data) > MaxItemSize {
+	} else if len(data) > stackitem.MaxSize {
 		return errors.New("too big item")
 	}
 

--- a/pkg/vm/stackitem/item.go
+++ b/pkg/vm/stackitem/item.go
@@ -18,6 +18,12 @@ import (
 // MaxBigIntegerSizeBits is the maximum size of BigInt item in bits.
 const MaxBigIntegerSizeBits = 32 * 8
 
+// MaxArraySize is the maximum array size allowed in the VM.
+const MaxArraySize = 1024
+
+// MaxSize is the maximum item size allowed in the VM.
+const MaxSize = 1024 * 1024
+
 // Item represents the "real" value that is pushed on the stack.
 type Item interface {
 	fmt.Stringer

--- a/pkg/vm/stackitem/json.go
+++ b/pkg/vm/stackitem/json.go
@@ -1,0 +1,202 @@
+package stackitem
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	gio "io"
+	"math"
+	"math/big"
+
+	"github.com/nspcc-dev/neo-go/pkg/io"
+)
+
+// decoder is a wrapper around json.Decoder helping to mimic C# json decoder behaviour.
+type decoder struct {
+	json.Decoder
+
+	depth int
+}
+
+// MaxAllowedInteger is the maximum integer allowed to be encoded.
+const MaxAllowedInteger = 2<<53 - 1
+
+// maxJSONDepth is a maximum allowed depth-level of decoded JSON.
+const maxJSONDepth = 10
+
+// ToJSON encodes Item to JSON.
+// It behaves as following:
+//   ByteArray -> base64 string
+//   BigInteger -> number
+//   Bool -> bool
+//   Null -> null
+//   Array, Struct -> array
+//   Map -> map with keys as UTF-8 bytes
+func ToJSON(item Item) ([]byte, error) {
+	buf := io.NewBufBinWriter()
+	toJSON(buf, item)
+	if buf.Err != nil {
+		return nil, buf.Err
+	}
+	return buf.Bytes(), nil
+}
+
+func toJSON(buf *io.BufBinWriter, item Item) {
+	w := buf.BinWriter
+	if w.Err != nil {
+		return
+	} else if buf.Len() > MaxSize {
+		w.Err = errors.New("item is too big")
+	}
+	switch it := item.(type) {
+	case *Array, *Struct:
+		w.WriteB('[')
+		items := it.Value().([]Item)
+		for i, v := range items {
+			toJSON(buf, v)
+			if i < len(items)-1 {
+				w.WriteB(',')
+			}
+		}
+		w.WriteB(']')
+	case *Map:
+		w.WriteB('{')
+		for i := range it.value {
+			bs, _ := it.value[i].Key.TryBytes() // map key can always be converted to []byte
+			w.WriteB('"')
+			w.WriteBytes(bs)
+			w.WriteBytes([]byte(`":`))
+			toJSON(buf, it.value[i].Value)
+			if i < len(it.value)-1 {
+				w.WriteB(',')
+			}
+		}
+		w.WriteB('}')
+	case *BigInteger:
+		if it.value.CmpAbs(big.NewInt(MaxAllowedInteger)) == 1 {
+			w.Err = errors.New("too big integer")
+			return
+		}
+		w.WriteBytes([]byte(it.value.String()))
+	case *ByteArray:
+		w.WriteB('"')
+		val := it.Value().([]byte)
+		b := make([]byte, base64.StdEncoding.EncodedLen(len(val)))
+		base64.StdEncoding.Encode(b, val)
+		w.WriteBytes(b)
+		w.WriteB('"')
+	case *Bool:
+		if it.value {
+			w.WriteBytes([]byte("true"))
+		} else {
+			w.WriteBytes([]byte("false"))
+		}
+	case Null:
+		w.WriteBytes([]byte("null"))
+	default:
+		w.Err = fmt.Errorf("invalid item: %s", it.String())
+		return
+	}
+	if w.Err == nil && buf.Len() > MaxSize {
+		w.Err = errors.New("item is too big")
+	}
+}
+
+// FromJSON decodes Item from JSON.
+// It behaves as following:
+//   string -> ByteArray from base64
+//   number -> BigInteger
+//   bool -> Bool
+//   null -> Null
+//   array -> Array
+//   map -> Map, keys are UTF-8
+func FromJSON(data []byte) (Item, error) {
+	d := decoder{Decoder: *json.NewDecoder(bytes.NewReader(data))}
+	if item, err := d.decode(); err != nil {
+		return nil, err
+	} else if _, err := d.Token(); err != gio.EOF {
+		return nil, errors.New("unexpected items")
+	} else {
+		return item, nil
+	}
+}
+
+func (d *decoder) decode() (Item, error) {
+	tok, err := d.Token()
+	if err != nil {
+		return nil, err
+	}
+	switch t := tok.(type) {
+	case json.Delim:
+		switch t {
+		case json.Delim('{'), json.Delim('['):
+			if d.depth == maxJSONDepth {
+				return nil, errors.New("JSON depth limit exceeded")
+			}
+			d.depth++
+			var item Item
+			if t == json.Delim('{') {
+				item, err = d.decodeMap()
+			} else {
+				item, err = d.decodeArray()
+			}
+			d.depth--
+			return item, err
+		default:
+			// no error above means corresponding closing token
+			// was encountered for map or array respectively
+			return nil, nil
+		}
+	case string:
+		b, err := base64.StdEncoding.DecodeString(t)
+		if err != nil {
+			return nil, err
+		}
+		return NewByteArray(b), nil
+	case float64:
+		if math.Floor(t) != t {
+			return nil, fmt.Errorf("real value is not allowed: %v", t)
+		}
+		return NewBigInteger(big.NewInt(int64(t))), nil
+	case bool:
+		return NewBool(t), nil
+	default:
+		// it can be only `nil`
+		return Null{}, nil
+	}
+}
+
+func (d *decoder) decodeArray() (*Array, error) {
+	items := []Item{}
+	for {
+		item, err := d.decode()
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			return NewArray(items), nil
+		}
+		items = append(items, item)
+	}
+}
+
+func (d *decoder) decodeMap() (*Map, error) {
+	m := NewMap()
+	for {
+		key, err := d.Token()
+		if err != nil {
+			return nil, err
+		}
+		k, ok := key.(string)
+		if !ok {
+			return m, nil
+		}
+		val, err := d.decode()
+		if err != nil {
+			return nil, err
+		}
+		m.Add(NewByteArray([]byte(k)), val)
+	}
+}

--- a/pkg/vm/stackitem/json_test.go
+++ b/pkg/vm/stackitem/json_test.go
@@ -1,0 +1,105 @@
+package stackitem
+
+import (
+	"encoding/base64"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func getTestDecodeFunc(js string, expected ...interface{}) func(t *testing.T) {
+	return func(t *testing.T) {
+		actual, err := FromJSON([]byte(js))
+		if expected[0] == nil {
+			require.Error(t, err)
+			return
+		}
+		require.NoError(t, err)
+		require.Equal(t, Make(expected[0]), actual)
+
+		if len(expected) == 1 {
+			encoded, err := ToJSON(actual)
+			require.NoError(t, err)
+			require.Equal(t, js, string(encoded))
+		}
+	}
+}
+
+func TestFromToJSON(t *testing.T) {
+	var testBase64 = base64.StdEncoding.EncodeToString([]byte("test"))
+	t.Run("ByteString", func(t *testing.T) {
+		t.Run("Empty", getTestDecodeFunc(`""`, []byte{}))
+		t.Run("Base64", getTestDecodeFunc(`"`+testBase64+`"`, "test"))
+	})
+	t.Run("BigInteger", func(t *testing.T) {
+		t.Run("ZeroFloat", getTestDecodeFunc(`12.000`, 12, nil))
+		t.Run("NonZeroFloat", getTestDecodeFunc(`12.01`, nil))
+		t.Run("Negative", getTestDecodeFunc(`-4`, -4))
+		t.Run("Positive", getTestDecodeFunc(`123`, 123))
+	})
+	t.Run("Bool", func(t *testing.T) {
+		t.Run("True", getTestDecodeFunc(`true`, true))
+		t.Run("False", getTestDecodeFunc(`false`, false))
+	})
+	t.Run("Null", getTestDecodeFunc(`null`, Null{}))
+	t.Run("Array", func(t *testing.T) {
+		t.Run("Empty", getTestDecodeFunc(`[]`, NewArray([]Item{})))
+		t.Run("Simple", getTestDecodeFunc((`[1,"`+testBase64+`",true,null]`),
+			NewArray([]Item{NewBigInteger(big.NewInt(1)), NewByteArray([]byte("test")), NewBool(true), Null{}})))
+		t.Run("Nested", getTestDecodeFunc(`[[],[{},null]]`,
+			NewArray([]Item{NewArray([]Item{}), NewArray([]Item{NewMap(), Null{}})})))
+	})
+	t.Run("Map", func(t *testing.T) {
+		small := NewMap()
+		small.Add(NewByteArray([]byte("a")), NewBigInteger(big.NewInt(3)))
+		large := NewMap()
+		large.Add(NewByteArray([]byte("3")), small)
+		large.Add(NewByteArray([]byte("arr")), NewArray([]Item{NewByteArray([]byte("test"))}))
+		t.Run("Empty", getTestDecodeFunc(`{}`, NewMap()))
+		t.Run("Small", getTestDecodeFunc(`{"a":3}`, small))
+		t.Run("Big", getTestDecodeFunc(`{"3":{"a":3},"arr":["`+testBase64+`"]}`, large))
+	})
+	t.Run("Invalid", func(t *testing.T) {
+		t.Run("Empty", getTestDecodeFunc(``, nil))
+		t.Run("InvalidString", getTestDecodeFunc(`"not a base64"`, nil))
+		t.Run("InvalidArray", getTestDecodeFunc(`[}`, nil))
+		t.Run("InvalidMap", getTestDecodeFunc(`{]`, nil))
+		t.Run("InvalidMapValue", getTestDecodeFunc(`{"a":{]}`, nil))
+		t.Run("AfterArray", getTestDecodeFunc(`[]XX`, nil))
+		t.Run("EncodeBigInteger", func(t *testing.T) {
+			item := NewBigInteger(big.NewInt(MaxAllowedInteger + 1))
+			_, err := ToJSON(item)
+			require.Error(t, err)
+		})
+		t.Run("EncodeInvalidItemType", func(t *testing.T) {
+			item := NewPointer(1, []byte{1, 2, 3})
+			_, err := ToJSON(item)
+			require.Error(t, err)
+		})
+		t.Run("BigByteArray", func(t *testing.T) {
+			l := base64.StdEncoding.DecodedLen(MaxSize + 8)
+			require.True(t, l < MaxSize) // check if test makes sense
+			item := NewByteArray(make([]byte, l))
+			_, err := ToJSON(item)
+			require.Error(t, err)
+		})
+		t.Run("BigNestedArray", getTestDecodeFunc(`[[[[[[[[[[[]]]]]]]]]]]`, nil))
+		t.Run("EncodeRecursive", func(t *testing.T) {
+			// add this item to speed up test a bit
+			item := NewByteArray(make([]byte, MaxSize/100))
+			t.Run("Array", func(t *testing.T) {
+				arr := NewArray([]Item{item})
+				arr.Append(arr)
+				_, err := ToJSON(arr)
+				require.Error(t, err)
+			})
+			t.Run("Map", func(t *testing.T) {
+				m := NewMap()
+				m.Add(item, m)
+				_, err := ToJSON(m)
+				require.Error(t, err)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Closes #1030.

There is a separate `ToJSON` function (instead of `MarshalJSON`) because it is more convenient.
Interops have some restrictions, for example marshaled integer must not exceed `2^53` while in `Integer` items marshaled in RPC can be 32-bytes wide.