### PR TITLE
Allow to restrict slice size in `io.ReadVarBytes()`

### DIFF
--- a/pkg/consensus/recovery_message.go
+++ b/pkg/consensus/recovery_message.go
@@ -97,7 +97,7 @@ func (p *changeViewCompact) DecodeBinary(r *io.BinReader) {
 	p.ValidatorIndex = r.ReadU16LE()
 	p.OriginalViewNumber = r.ReadB()
 	p.Timestamp = r.ReadU32LE()
-	p.InvocationScript = r.ReadVarBytes()
+	p.InvocationScript = r.ReadVarBytes(1024)
 }
 
 // EncodeBinary implements io.Serializable interface.
@@ -114,7 +114,7 @@ func (p *commitCompact) DecodeBinary(r *io.BinReader) {
 	p.ValidatorIndex = r.ReadU16LE()
 	r.ReadBytes(p.Signature[:])
 	r.ReadBytes(p.StateSignature[:])
-	p.InvocationScript = r.ReadVarBytes()
+	p.InvocationScript = r.ReadVarBytes(1024)
 }
 
 // EncodeBinary implements io.Serializable interface.
@@ -129,7 +129,7 @@ func (p *commitCompact) EncodeBinary(w *io.BinWriter) {
 // DecodeBinary implements io.Serializable interface.
 func (p *preparationCompact) DecodeBinary(r *io.BinReader) {
 	p.ValidatorIndex = r.ReadU16LE()
-	p.InvocationScript = r.ReadVarBytes()
+	p.InvocationScript = r.ReadVarBytes(1024)
 }
 
 // EncodeBinary implements io.Serializable interface.

--- a/pkg/io/binaryReader.go
+++ b/pkg/io/binaryReader.go
@@ -168,8 +168,16 @@ func (r *BinReader) ReadVarUint() uint64 {
 
 // ReadVarBytes reads the next set of bytes from the underlying reader.
 // ReadVarUInt() is used to determine how large that slice is
-func (r *BinReader) ReadVarBytes() []byte {
+func (r *BinReader) ReadVarBytes(maxSize ...int) []byte {
 	n := r.ReadVarUint()
+	ms := maxArraySize
+	if len(maxSize) != 0 {
+		ms = maxSize[0]
+	}
+	if n > uint64(ms) {
+		r.Err = fmt.Errorf("byte-slice is too big (%d)", n)
+		return nil
+	}
 	b := make([]byte, n)
 	r.ReadBytes(b)
 	return b

--- a/pkg/io/binaryrw_test.go
+++ b/pkg/io/binaryrw_test.go
@@ -143,6 +143,35 @@ func TestBufBinWriter_Len(t *testing.T) {
 	require.Equal(t, 1, bw.Len())
 }
 
+func TestBinReader_ReadVarBytes(t *testing.T) {
+	buf := make([]byte, 11)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	w := NewBufBinWriter()
+	w.WriteVarBytes(buf)
+	require.NoError(t, w.Err)
+	data := w.Bytes()
+
+	t.Run("NoArguments", func(t *testing.T) {
+		r := NewBinReaderFromBuf(data)
+		actual := r.ReadVarBytes()
+		require.NoError(t, r.Err)
+		require.Equal(t, buf, actual)
+	})
+	t.Run("Good", func(t *testing.T) {
+		r := NewBinReaderFromBuf(data)
+		actual := r.ReadVarBytes(11)
+		require.NoError(t, r.Err)
+		require.Equal(t, buf, actual)
+	})
+	t.Run("Bad", func(t *testing.T) {
+		r := NewBinReaderFromBuf(data)
+		r.ReadVarBytes(10)
+		require.Error(t, r.Err)
+	})
+}
+
 func TestWriterErrHandling(t *testing.T) {
 	var badio = &badRW{}
 	bw := NewBinWriterFromIO(badio)


### PR DESCRIPTION
```
Jun 12 06:29:45 nodoka neo-go[2976]: panic: runtime error: makeslice: len out of range
Jun 12 06:29:45 nodoka neo-go[2976]: goroutine 645 [running]:
Jun 12 06:29:45 nodoka neo-go[2976]: github.com/nspcc-dev/neo-go/pkg/io.(*BinReader).ReadVarBytes(0xc033febd00, 0xc03174d380, 0xc033942184, 0x40)
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/io/binaryReader.go:173 +0x4e
Jun 12 06:29:45 nodoka neo-go[2976]: github.com/nspcc-dev/neo-go/pkg/consensus.(*commitCompact).DecodeBinary(0xc033942180, 0xc033febd00)
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/consensus/recovery_message.go:115 +0x6d
Jun 12 06:29:45 nodoka neo-go[2976]: github.com/nspcc-dev/neo-go/pkg/io.(*BinReader).ReadArray(0xc033febd00, 0xc3eb40, 0xc033942020, 0x0, 0x0, 0x0)
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/io/binaryReader.go:141 +0x22f
Jun 12 06:29:45 nodoka neo-go[2976]: github.com/nspcc-dev/neo-go/pkg/consensus.(*recoveryMessage).DecodeBinary(0xc033942000, 0xc033febd00)
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/consensus/recovery_message.go:70 +0x12d
Jun 12 06:29:45 nodoka neo-go[2976]: github.com/nspcc-dev/neo-go/pkg/consensus.(*message).DecodeBinary(0xc00f3a76a0, 0xc033febd00)
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/consensus/payload.go:299 +0x157
Jun 12 06:29:45 nodoka neo-go[2976]: github.com/nspcc-dev/neo-go/pkg/consensus.(*Payload).decodeData(0xc033feb880, 0x102aea0, 0xc033feb880)
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/consensus/payload.go:326 +0x1b1
Jun 12 06:29:45 nodoka neo-go[2976]: github.com/nspcc-dev/neo-go/pkg/consensus.(*service).OnPayload(0xc0000ecb40, 0xc033feb880)
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/consensus/consensus.go:296 +0x3ea
Jun 12 06:29:45 nodoka neo-go[2976]: github.com/nspcc-dev/neo-go/pkg/network.(*Server).handleConsensusCmd(...)
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/network/server.go:644
Jun 12 06:29:45 nodoka neo-go[2976]: github.com/nspcc-dev/neo-go/pkg/network.(*Server).handleMessage(0xc0000ba160, 0x104e300, 0xc0000ecd80, 0xc03174c600, 0x0, 0x0)
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/network/server.go:763 +0xd3e
Jun 12 06:29:45 nodoka neo-go[2976]: github.com/nspcc-dev/neo-go/pkg/network.(*TCPPeer).handleConn(0xc0000ecd80)
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/network/tcp_peer.go:160 +0x294
Jun 12 06:29:45 nodoka neo-go[2976]: created by github.com/nspcc-dev/neo-go/pkg/network.(*TCPTransport).Dial
Jun 12 06:29:45 nodoka neo-go[2976]: #011/home/rik/dev/neo-go2/pkg/network/tcp_transport.go:38 +0x1ad
```