### PR TITLE
docker: fix shell condition check in entrypoint script

### DIFF
--- a/.docker/privnet-entrypoint.sh
+++ b/.docker/privnet-entrypoint.sh
@@ -2,7 +2,7 @@
 
 BIN=/usr/bin/neo-go
 
-if [ -z "$ACC"]; then
+if [ -z "$ACC" ]; then
   ACC=/6000-privnet-blocks.acc.gz
 fi
 


### PR DESCRIPTION
### Problem

When I run neo-go in docker image I see these line in logs:

```
sh: missing ]
```

Shell requires to have white space before `]` symbol in condition check. Now condition is not checked and 6k-block dump is not restored. 

### Solution

Fix entry point script. 