### PR TITLE
Enable state root exchange base on config

### DIFF
--- a/config/protocol.testnet.yml
+++ b/config/protocol.testnet.yml
@@ -2,6 +2,8 @@ ProtocolConfiguration:
   Magic: 1953787457
   AddressVersion: 23
   SecondsPerBlock: 15
+  EnableStateRoot: true
+  StateRootEnableIndex: 4380100
   LowPriorityThreshold: 0.000
   MemPoolSize: 50000
   StandbyValidators:

--- a/config/protocol.unit_testnet.yml
+++ b/config/protocol.unit_testnet.yml
@@ -2,6 +2,7 @@ ProtocolConfiguration:
   Magic: 56753
   AddressVersion: 23
   SecondsPerBlock: 15
+  EnableStateRoot: true
   LowPriorityThreshold: 0.000
   MemPoolSize: 50000
   StandbyValidators:

--- a/pkg/config/protocol_config.go
+++ b/pkg/config/protocol_config.go
@@ -36,11 +36,13 @@ type (
 		MaxFreeTransactionsPerBlock int `yaml:"MaxFreeTransactionsPerBlock"`
 		MemPoolSize                 int `yaml:"MemPoolSize"`
 		// SaveStorageBatch enables storage batch saving before every persist.
-		SaveStorageBatch  bool      `yaml:"SaveStorageBatch"`
-		SecondsPerBlock   int       `yaml:"SecondsPerBlock"`
-		SeedList          []string  `yaml:"SeedList"`
-		StandbyValidators []string  `yaml:"StandbyValidators"`
-		SystemFee         SystemFee `yaml:"SystemFee"`
+		SaveStorageBatch  bool     `yaml:"SaveStorageBatch"`
+		SecondsPerBlock   int      `yaml:"SecondsPerBlock"`
+		SeedList          []string `yaml:"SeedList"`
+		StandbyValidators []string `yaml:"StandbyValidators"`
+		// StateRootEnableIndex specifies starting height for state root calculations and exchange.
+		StateRootEnableIndex uint32    `yaml:"StateRootEnableIndex"`
+		SystemFee            SystemFee `yaml:"SystemFee"`
 		// Whether to verify received blocks.
 		VerifyBlocks bool `yaml:"VerifyBlocks"`
 		// Whether to verify transactions in received blocks.

--- a/pkg/config/protocol_config.go
+++ b/pkg/config/protocol_config.go
@@ -20,6 +20,8 @@ const (
 type (
 	ProtocolConfiguration struct {
 		AddressVersion byte `yaml:"AddressVersion"`
+		// EnableStateRoot specifies if exchange of state roots should be enabled.
+		EnableStateRoot bool `yaml:"EnableStateRoot"`
 		// FeePerExtraByte sets the expected per-byte fee for
 		// transactions exceeding the MaxFreeTransactionSize.
 		FeePerExtraByte float64 `yaml:"FeePerExtraByte"`

--- a/pkg/consensus/commit.go
+++ b/pkg/consensus/commit.go
@@ -9,6 +9,8 @@ import (
 type commit struct {
 	signature [signatureSize]byte
 	stateSig  [signatureSize]byte
+
+	stateRootEnabled bool
 }
 
 // signatureSize is an rfc6989 signature size in bytes
@@ -20,13 +22,17 @@ var _ payload.Commit = (*commit)(nil)
 // EncodeBinary implements io.Serializable interface.
 func (c *commit) EncodeBinary(w *io.BinWriter) {
 	w.WriteBytes(c.signature[:])
-	w.WriteBytes(c.stateSig[:])
+	if c.stateRootEnabled {
+		w.WriteBytes(c.stateSig[:])
+	}
 }
 
 // DecodeBinary implements io.Serializable interface.
 func (c *commit) DecodeBinary(r *io.BinReader) {
 	r.ReadBytes(c.signature[:])
-	r.ReadBytes(c.stateSig[:])
+	if c.stateRootEnabled {
+		r.ReadBytes(c.stateSig[:])
+	}
 }
 
 // Signature implements payload.Commit interface.

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -138,7 +138,7 @@ func NewService(cfg Config) (Service, error) {
 		dbft.WithGetValidators(srv.getValidators),
 		dbft.WithGetConsensusAddress(srv.getConsensusAddress),
 
-		dbft.WithNewConsensusPayload(func() payload.ConsensusPayload { p := new(Payload); p.message = &message{}; return p }),
+		dbft.WithNewConsensusPayload(srv.newPayload),
 		dbft.WithNewPrepareRequest(srv.newPrepareRequest),
 		dbft.WithNewPrepareResponse(func() payload.PrepareResponse { return new(prepareResponse) }),
 		dbft.WithNewChangeView(func() payload.ChangeView { return new(changeView) }),
@@ -211,6 +211,12 @@ func (s *service) eventLoop() {
 				s.dbft.InitializeConsensus(0)
 			}
 		}
+	}
+}
+
+func (s *service) newPayload() payload.ConsensusPayload {
+	return &Payload{
+		message: new(message),
 	}
 }
 

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -216,35 +216,49 @@ func (s *service) eventLoop() {
 
 func (s *service) newPayload() payload.ConsensusPayload {
 	return &Payload{
-		message: new(message),
+		message: &message{
+			stateRootEnabled: s.stateRootEnabled(),
+		},
 	}
+}
+
+// stateRootEnabled checks if state root feature is enabled on current height.
+// It should be called only from dbft callbacks and is not protected by any mutex.
+func (s *service) stateRootEnabled() bool {
+	return s.Chain.GetConfig().EnableStateRoot
 }
 
 func (s *service) newPrepareRequest() payload.PrepareRequest {
-	sr, err := s.Chain.GetStateRoot(s.Chain.BlockHeight())
-	if err != nil {
+	if !s.stateRootEnabled() {
 		return new(prepareRequest)
 	}
-	return &prepareRequest{
-		proposalStateRoot: sr.MPTRootBase,
+	sr, err := s.Chain.GetStateRoot(s.Chain.BlockHeight())
+	if err == nil {
+		return &prepareRequest{
+			stateRootEnabled:  true,
+			proposalStateRoot: sr.MPTRootBase,
+		}
 	}
+	return &prepareRequest{stateRootEnabled: true}
 }
 
 func (s *service) newCommit() payload.Commit {
+	if !s.stateRootEnabled() {
+		return new(commit)
+	}
+	c := &commit{stateRootEnabled: true}
 	for _, p := range s.dbft.Context.PreparationPayloads {
 		if p != nil && p.ViewNumber() == s.dbft.ViewNumber && p.Type() == payload.PrepareRequestType {
 			pr := p.GetPrepareRequest().(*prepareRequest)
 			data := pr.proposalStateRoot.GetSignedPart()
 			sign, err := s.dbft.Priv.Sign(data)
 			if err == nil {
-				var c commit
 				copy(c.stateSig[:], sign)
-				return &c
 			}
 			break
 		}
 	}
-	return new(commit)
+	return c
 }
 
 func (s *service) validatePayload(p *Payload) bool {
@@ -299,8 +313,8 @@ func (s *service) OnPayload(cp *Payload) {
 
 	// decode payload data into message
 	if cp.message == nil {
-		if err := cp.decodeData(); err != nil {
-			log.Debug("can't decode payload data")
+		if err := cp.decodeData(s.stateRootEnabled()); err != nil {
+			log.Debug("can't decode payload data", zap.Error(err))
 			return
 		}
 	}
@@ -378,6 +392,9 @@ func (s *service) verifyBlock(b block.Block) bool {
 }
 
 func (s *service) verifyRequest(p payload.ConsensusPayload) error {
+	if !s.stateRootEnabled() {
+		return nil
+	}
 	r, err := s.Chain.GetStateRoot(s.dbft.BlockIndex - 1)
 	if err != nil {
 		return fmt.Errorf("can't get local state root: %v", err)

--- a/pkg/consensus/payload.go
+++ b/pkg/consensus/payload.go
@@ -319,7 +319,7 @@ func (t messageType) String() string {
 	}
 }
 
-// decode data of payload into it's message
+// decodeData decodes data of payload into it's message.
 func (p *Payload) decodeData() error {
 	m := new(message)
 	br := io.NewBinReaderFromBuf(p.data)

--- a/pkg/consensus/payload.go
+++ b/pkg/consensus/payload.go
@@ -22,6 +22,8 @@ type (
 		Type       messageType
 		ViewNumber byte
 
+		stateRootEnabled bool
+
 		payload io.Serializable
 	}
 
@@ -283,15 +285,21 @@ func (m *message) DecodeBinary(r *io.BinReader) {
 		cv.newViewNumber = m.ViewNumber + 1
 		m.payload = cv
 	case prepareRequestType:
-		m.payload = new(prepareRequest)
+		m.payload = &prepareRequest{
+			stateRootEnabled: m.stateRootEnabled,
+		}
 	case prepareResponseType:
 		m.payload = new(prepareResponse)
 	case commitType:
-		m.payload = new(commit)
+		m.payload = &commit{
+			stateRootEnabled: m.stateRootEnabled,
+		}
 	case recoveryRequestType:
 		m.payload = new(recoveryRequest)
 	case recoveryMessageType:
-		m.payload = new(recoveryMessage)
+		m.payload = &recoveryMessage{
+			stateRootEnabled: m.stateRootEnabled,
+		}
 	default:
 		r.Err = errors.Errorf("invalid type: 0x%02x", byte(m.Type))
 		return
@@ -320,8 +328,8 @@ func (t messageType) String() string {
 }
 
 // decodeData decodes data of payload into it's message.
-func (p *Payload) decodeData() error {
-	m := new(message)
+func (p *Payload) decodeData(stateRootEnabled bool) error {
+	m := &message{stateRootEnabled: stateRootEnabled}
 	br := io.NewBinReaderFromBuf(p.data)
 	m.DecodeBinary(br)
 	if br.Err != nil {

--- a/pkg/consensus/prepare_request.go
+++ b/pkg/consensus/prepare_request.go
@@ -16,6 +16,8 @@ type prepareRequest struct {
 	minerTx           transaction.Transaction
 	nextConsensus     util.Uint160
 	proposalStateRoot state.MPTRootBase
+
+	stateRootEnabled bool
 }
 
 var _ payload.PrepareRequest = (*prepareRequest)(nil)
@@ -27,7 +29,9 @@ func (p *prepareRequest) EncodeBinary(w *io.BinWriter) {
 	w.WriteBytes(p.nextConsensus[:])
 	w.WriteArray(p.transactionHashes)
 	p.minerTx.EncodeBinary(w)
-	p.proposalStateRoot.EncodeBinary(w)
+	if p.stateRootEnabled {
+		p.proposalStateRoot.EncodeBinary(w)
+	}
 }
 
 // DecodeBinary implements io.Serializable interface.
@@ -37,7 +41,9 @@ func (p *prepareRequest) DecodeBinary(r *io.BinReader) {
 	r.ReadBytes(p.nextConsensus[:])
 	r.ReadArray(&p.transactionHashes)
 	p.minerTx.DecodeBinary(r)
-	p.proposalStateRoot.DecodeBinary(r)
+	if p.stateRootEnabled {
+		p.proposalStateRoot.DecodeBinary(r)
+	}
 }
 
 // Timestamp implements payload.PrepareRequest interface.

--- a/pkg/consensus/recovery_message.go
+++ b/pkg/consensus/recovery_message.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"github.com/nspcc-dev/dbft/crypto"
 	"github.com/nspcc-dev/dbft/payload"
+	"github.com/nspcc-dev/neo-go/pkg/core/state"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/pkg/errors"
@@ -16,6 +17,8 @@ type (
 		commitPayloads      []*commitCompact
 		changeViewPayloads  []*changeViewCompact
 		prepareRequest      *message
+
+		stateRootEnabled bool
 	}
 
 	changeViewCompact struct {
@@ -31,6 +34,8 @@ type (
 		Signature        [signatureSize]byte
 		StateSignature   [signatureSize]byte
 		InvocationScript []byte
+
+		stateRootEnabled bool
 	}
 
 	preparationCompact struct {
@@ -47,7 +52,7 @@ func (m *recoveryMessage) DecodeBinary(r *io.BinReader) {
 
 	var hasReq = r.ReadBool()
 	if hasReq {
-		m.prepareRequest = new(message)
+		m.prepareRequest = &message{stateRootEnabled: m.stateRootEnabled}
 		m.prepareRequest.DecodeBinary(r)
 		if r.Err == nil && m.prepareRequest.Type != prepareRequestType {
 			r.Err = errors.New("recovery message PrepareRequest has wrong type")
@@ -68,7 +73,16 @@ func (m *recoveryMessage) DecodeBinary(r *io.BinReader) {
 	}
 
 	r.ReadArray(&m.preparationPayloads)
-	r.ReadArray(&m.commitPayloads)
+	lu := r.ReadVarUint()
+	if lu > state.MaxValidatorsVoted {
+		r.Err = errors.New("too many preparation payloads")
+		return
+	}
+	m.commitPayloads = make([]*commitCompact, lu)
+	for i := uint64(0); i < lu; i++ {
+		m.commitPayloads[i] = &commitCompact{stateRootEnabled: m.stateRootEnabled}
+		m.commitPayloads[i].DecodeBinary(r)
+	}
 }
 
 // EncodeBinary implements io.Serializable interface.
@@ -113,7 +127,9 @@ func (p *commitCompact) DecodeBinary(r *io.BinReader) {
 	p.ViewNumber = r.ReadB()
 	p.ValidatorIndex = r.ReadU16LE()
 	r.ReadBytes(p.Signature[:])
-	r.ReadBytes(p.StateSignature[:])
+	if p.stateRootEnabled {
+		r.ReadBytes(p.StateSignature[:])
+	}
 	p.InvocationScript = r.ReadVarBytes(1024)
 }
 
@@ -122,7 +138,9 @@ func (p *commitCompact) EncodeBinary(w *io.BinWriter) {
 	w.WriteB(p.ViewNumber)
 	w.WriteU16LE(p.ValidatorIndex)
 	w.WriteBytes(p.Signature[:])
-	w.WriteBytes(p.StateSignature[:])
+	if p.stateRootEnabled {
+		w.WriteBytes(p.StateSignature[:])
+	}
 	w.WriteVarBytes(p.InvocationScript)
 }
 
@@ -146,6 +164,8 @@ func (m *recoveryMessage) AddPayload(p payload.ConsensusPayload) {
 			Type:       prepareRequestType,
 			ViewNumber: p.ViewNumber(),
 			payload:    p.GetPrepareRequest().(*prepareRequest),
+
+			stateRootEnabled: m.stateRootEnabled,
 		}
 		h := p.Hash()
 		m.preparationHash = &h
@@ -172,6 +192,7 @@ func (m *recoveryMessage) AddPayload(p payload.ConsensusPayload) {
 		})
 	case payload.CommitType:
 		m.commitPayloads = append(m.commitPayloads, &commitCompact{
+			stateRootEnabled: m.stateRootEnabled,
 			ValidatorIndex:   p.ValidatorIndex(),
 			ViewNumber:       p.ViewNumber(),
 			Signature:        p.GetCommit().(*commit).signature,
@@ -254,7 +275,12 @@ func (m *recoveryMessage) GetCommits(p payload.ConsensusPayload, validators []cr
 	ps := make([]payload.ConsensusPayload, len(m.commitPayloads))
 
 	for i, c := range m.commitPayloads {
-		cc := fromPayload(commitType, p.(*Payload), &commit{signature: c.Signature, stateSig: c.StateSignature})
+		cc := fromPayload(commitType, p.(*Payload), &commit{
+			signature: c.Signature,
+			stateSig:  c.StateSignature,
+
+			stateRootEnabled: m.stateRootEnabled,
+		})
 		cc.SetValidatorIndex(c.ValidatorIndex)
 		cc.Witness.InvocationScript = c.InvocationScript
 		cc.Witness.VerificationScript = getVerificationScript(c.ValidatorIndex, validators)
@@ -294,6 +320,8 @@ func fromPayload(t messageType, recovery *Payload, p io.Serializable) *Payload {
 			Type:       t,
 			ViewNumber: recovery.message.ViewNumber,
 			payload:    p,
+
+			stateRootEnabled: recovery.stateRootEnabled,
 		},
 		version:  recovery.Version(),
 		prevHash: recovery.PrevHash(),

--- a/pkg/core/interops.go
+++ b/pkg/core/interops.go
@@ -52,6 +52,9 @@ func (ic *interopContext) SpawnVM() *vm.VM {
 	})
 	vm.RegisterInteropGetter(ic.getSystemInterop)
 	vm.RegisterInteropGetter(ic.getNeoInterop)
+	if ic.bc != nil && ic.bc.GetConfig().EnableStateRoot {
+		vm.RegisterInteropGetter(ic.getNeoxInterop)
+	}
 	return vm
 }
 
@@ -75,6 +78,12 @@ func (ic *interopContext) getSystemInterop(id uint32) *vm.InteropFuncPrice {
 // namespaces for a given id in the current context.
 func (ic *interopContext) getNeoInterop(id uint32) *vm.InteropFuncPrice {
 	return ic.getInteropFromSlice(id, neoInterops)
+}
+
+// getNeoxInterop returns matching interop function from the NeoX extension
+// for a given id in the current context.
+func (ic *interopContext) getNeoxInterop(id uint32) *vm.InteropFuncPrice {
+	return ic.getInteropFromSlice(id, neoxInterops)
 }
 
 // getInteropFromSlice returns matching interop function from the given slice of
@@ -166,8 +175,6 @@ var neoInterops = []interopedFunction{
 	{Name: "Neo.Contract.GetStorageContext", Func: (*interopContext).contractGetStorageContext, Price: 1},
 	{Name: "Neo.Contract.IsPayable", Func: (*interopContext).contractIsPayable, Price: 1},
 	{Name: "Neo.Contract.Migrate", Func: (*interopContext).contractMigrate, Price: 0},
-	{Name: "Neo.Cryptography.Secp256k1Recover", Func: (*interopContext).secp256k1Recover, Price: 100},
-	{Name: "Neo.Cryptography.Secp256r1Recover", Func: (*interopContext).secp256r1Recover, Price: 100},
 	{Name: "Neo.Enumerator.Concat", Func: (*interopContext).enumeratorConcat, Price: 1},
 	{Name: "Neo.Enumerator.Create", Func: (*interopContext).enumeratorCreate, Price: 1},
 	{Name: "Neo.Enumerator.Next", Func: (*interopContext).enumeratorNext, Price: 1},
@@ -278,6 +285,11 @@ var neoInterops = []interopedFunction{
 	{Name: "AntShares.Transaction.GetType", Func: (*interopContext).txGetType, Price: 1},
 }
 
+var neoxInterops = []interopedFunction{
+	{Name: "Neo.Cryptography.Secp256k1Recover", Func: (*interopContext).secp256k1Recover, Price: 100},
+	{Name: "Neo.Cryptography.Secp256r1Recover", Func: (*interopContext).secp256r1Recover, Price: 100},
+}
+
 // initIDinInteropsSlice initializes IDs from names in one given
 // interopedFunction slice and then sorts it.
 func initIDinInteropsSlice(iops []interopedFunction) {
@@ -293,4 +305,5 @@ func initIDinInteropsSlice(iops []interopedFunction) {
 func init() {
 	initIDinInteropsSlice(systemInterops)
 	initIDinInteropsSlice(neoInterops)
+	initIDinInteropsSlice(neoxInterops)
 }

--- a/pkg/io/binaryReader.go
+++ b/pkg/io/binaryReader.go
@@ -8,9 +8,9 @@ import (
 	"reflect"
 )
 
-// maxArraySize is a maximums size of an array which can be decoded.
+// MaxArraySize is the maximum size of an array which can be decoded.
 // It is taken from https://github.com/neo-project/neo/blob/master/neo/IO/Helper.cs#L130
-const maxArraySize = 0x1000000
+const MaxArraySize = 0x1000000
 
 // BinReader is a convenient wrapper around a io.Reader and err object.
 // Used to simplify error handling when reading into a struct with many fields.
@@ -110,7 +110,7 @@ func (r *BinReader) ReadArray(t interface{}, maxSize ...int) {
 	elemType := sliceType.Elem()
 	isPtr := elemType.Kind() == reflect.Ptr
 
-	ms := maxArraySize
+	ms := MaxArraySize
 	if len(maxSize) != 0 {
 		ms = maxSize[0]
 	}
@@ -170,7 +170,7 @@ func (r *BinReader) ReadVarUint() uint64 {
 // ReadVarUInt() is used to determine how large that slice is
 func (r *BinReader) ReadVarBytes(maxSize ...int) []byte {
 	n := r.ReadVarUint()
-	ms := maxArraySize
+	ms := MaxArraySize
 	if len(maxSize) != 0 {
 		ms = maxSize[0]
 	}

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -602,6 +602,9 @@ func (s *Server) handleGetHeadersCmd(p Peer, gh *payload.GetBlocks) error {
 
 // handleGetRootsCmd processees `getroots` request.
 func (s *Server) handleGetRootsCmd(p Peer, gr *payload.GetStateRoots) error {
+	if !s.chain.GetConfig().EnableStateRoot {
+		return nil
+	}
 	count := gr.Count
 	if count > payload.MaxStateRootsAllowed {
 		count = payload.MaxStateRootsAllowed
@@ -621,6 +624,9 @@ func (s *Server) handleGetRootsCmd(p Peer, gr *payload.GetStateRoots) error {
 
 // handleStateRootsCmd processees `roots` request.
 func (s *Server) handleRootsCmd(p Peer, rs *payload.StateRoots) error {
+	if !s.chain.GetConfig().EnableStateRoot {
+		return nil
+	}
 	h := s.chain.StateHeight()
 	for i := range rs.Roots {
 		if rs.Roots[i].Index <= h {
@@ -652,6 +658,9 @@ func (s *Server) requestStateRoot(p Peer) error {
 
 // handleStateRootCmd processees `stateroot` request.
 func (s *Server) handleStateRootCmd(r *state.MPTRoot) error {
+	if !s.chain.GetConfig().EnableStateRoot {
+		return nil
+	}
 	// we ignore error, because there is nothing wrong if we already have this state root
 	err := s.chain.AddStateRoot(r)
 	if err == nil && !s.stateCache.Has(r.Hash()) {

--- a/pkg/network/tcp_peer.go
+++ b/pkg/network/tcp_peer.go
@@ -251,7 +251,7 @@ func (p *TCPPeer) StartProtocol() {
 			if p.LastBlockIndex() > p.server.chain.BlockHeight() {
 				err = p.server.requestBlocks(p)
 			}
-			if err == nil {
+			if err == nil && p.server.chain.GetConfig().EnableStateRoot {
 				err = p.server.requestStateRoot(p)
 			}
 			if err == nil {


### PR DESCRIPTION
Closes #1085 (merge will follow).
There were 3 ways to handle multiple wire formats for consensus messages:
1. Using global variables
2. Renaming `EncodeBinary` to `EncodeGeneric(BinWriter, config)`
3. Providing context directly to `BinWriter`.
I have chosen 3rd, because 2nd is rather verbose, and 1st can lead to problems, though it is a final version and maybe we can afford having global.