### PR TITLE
consensus: update dbft library (neox-2.x)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/gorilla/websocket v1.4.2
 	github.com/mr-tron/base58 v1.1.2
-	github.com/nspcc-dev/dbft v0.0.0-20200610194044-e2dbc098ab46
+	github.com/nspcc-dev/dbft v0.0.0-20200623100921-5a182c20965e
 	github.com/nspcc-dev/rfc6979 v0.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/nspcc-dev/dbft v0.0.0-20200117124306-478e5cfbf03a h1:ajvxgEe9qY4vvoSm
 github.com/nspcc-dev/dbft v0.0.0-20200117124306-478e5cfbf03a/go.mod h1:/YFK+XOxxg0Bfm6P92lY5eDSLYfp06XOdL8KAVgXjVk=
 github.com/nspcc-dev/dbft v0.0.0-20200219114139-199d286ed6c1 h1:yEx9WznS+rjE0jl0dLujCxuZSIb+UTjF+005TJu/nNI=
 github.com/nspcc-dev/dbft v0.0.0-20200219114139-199d286ed6c1/go.mod h1:O0qtn62prQSqizzoagHmuuKoz8QMkU3SzBoKdEvm3aQ=
-github.com/nspcc-dev/dbft v0.0.0-20200610194044-e2dbc098ab46 h1:3MTsGNIWSi0FZm3hmj9//iaDRNHqBZzgfBbPEagh2eY=
-github.com/nspcc-dev/dbft v0.0.0-20200610194044-e2dbc098ab46/go.mod h1:1FYQXSbb6/9HQIkoF8XO7W/S8N7AZRkBsgwbcXRvk0E=
+github.com/nspcc-dev/dbft v0.0.0-20200623100921-5a182c20965e h1:QOT9slflIkEKb5wY0ZUC0dCmCgoqGlhOAh9+xWMIxfg=
+github.com/nspcc-dev/dbft v0.0.0-20200623100921-5a182c20965e/go.mod h1:1FYQXSbb6/9HQIkoF8XO7W/S8N7AZRkBsgwbcXRvk0E=
 github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:pPYwPZ2ks+uMnlRLUyXOpLieaDQSEaf4NM3zHVbRjmg=
 github.com/nspcc-dev/neofs-crypto v0.2.0 h1:ftN+59WqxSWz/RCgXYOfhmltOOqU+udsNQSvN6wkFck=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -123,7 +123,6 @@ func NewService(cfg Config) (Service, error) {
 		dbft.WithLogger(srv.log),
 		dbft.WithSecondsPerBlock(cfg.TimePerBlock),
 		dbft.WithGetKeyPair(srv.getKeyPair),
-		dbft.WithTxPerBlock(10000),
 		dbft.WithRequestTx(cfg.RequestTx),
 		dbft.WithGetTx(srv.getTx),
 		dbft.WithGetVerified(srv.getVerifiedTx),
@@ -460,7 +459,7 @@ func (s *service) getBlock(h util.Uint256) block.Block {
 	return &neoBlock{Block: *b}
 }
 
-func (s *service) getVerifiedTx(count int) []block.Transaction {
+func (s *service) getVerifiedTx() []block.Transaction {
 	pool := s.Config.Chain.GetMemPool()
 
 	var txx []mempool.TxWithFee

--- a/pkg/consensus/consensus_test.go
+++ b/pkg/consensus/consensus_test.go
@@ -26,7 +26,7 @@ func TestNewService(t *testing.T) {
 	require.NoError(t, srv.Chain.PoolTx(tx))
 
 	var txx []block.Transaction
-	require.NotPanics(t, func() { txx = srv.getVerifiedTx(1) })
+	require.NotPanics(t, func() { txx = srv.getVerifiedTx() })
 	require.Len(t, txx, 2)
 	require.Equal(t, tx, txx[1])
 	srv.Chain.Close()
@@ -59,7 +59,7 @@ func TestService_GetVerified(t *testing.T) {
 	srv.dbft.ViewNumber = 1
 
 	t.Run("new transactions will be proposed in case of failure", func(t *testing.T) {
-		txx := srv.getVerifiedTx(10)
+		txx := srv.getVerifiedTx()
 		require.Equal(t, 2, len(txx), "there is only 1 tx in mempool")
 		require.Equal(t, txs[3], txx[1])
 	})
@@ -69,7 +69,7 @@ func TestService_GetVerified(t *testing.T) {
 			require.NoError(t, srv.Chain.PoolTx(tx))
 		}
 
-		txx := srv.getVerifiedTx(10)
+		txx := srv.getVerifiedTx()
 		require.Contains(t, txx, txs[0])
 		require.Contains(t, txx, txs[1])
 		require.NotContains(t, txx, txs[2])


### PR DESCRIPTION
Pick up the following changes:
 * recovery message sending fix
 * tx re-requests on sendRecoveryRequest
 * proposed block checks fix
 * timeout calculation fix for InitializeConsensus
 * removal of TxPerBlock which is irrelevant for neo-go (policying is done by
   the node, not dbft library)
