### PR TITLE
Support type conversions

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -991,6 +991,8 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 	// not the assertion type.
 	case *ast.TypeAssertExpr:
 		ast.Walk(c, n.X)
+		typ := toNeoType(c.typeOf(n.Type))
+		emit.Instruction(c.prog.BinWriter, opcode.CONVERT, []byte{byte(typ)})
 		return nil
 	}
 	return c

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -712,6 +712,7 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 			name      string
 			numArgs   = len(n.Args)
 			isBuiltin bool
+			isFunc    bool
 		)
 
 		switch fun := n.Fun.(type) {
@@ -720,6 +721,10 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 			isBuiltin = isGoBuiltin(fun.Name)
 			if !ok && !isBuiltin {
 				name = fun.Name
+			}
+			// distinguish lambda invocations from type conversions
+			if fun.Obj != nil && fun.Obj.Kind == ast.Var {
+				isFunc = true
 			}
 		case *ast.SelectorExpr:
 			// If this is a method call we need to walk the AST to load the struct locally.
@@ -767,9 +772,11 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 			// We can be sure builtins are of type *ast.Ident.
 			c.convertBuiltin(n)
 		case name != "":
-			// Function was not found thus is can be only an invocation of func-typed variable.
-			c.emitLoadVar(name)
-			emit.Opcode(c.prog.BinWriter, opcode.CALLA)
+			// Function was not found thus is can be only an invocation of func-typed variable or type conversion.
+			if isFunc {
+				c.emitLoadVar(name)
+				emit.Opcode(c.prog.BinWriter, opcode.CALLA)
+			}
 		case isSyscall(f):
 			c.convertSyscall(n, f.selector.Name, f.name)
 		default:

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -773,7 +773,11 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 			c.convertBuiltin(n)
 		case name != "":
 			// Function was not found thus is can be only an invocation of func-typed variable or type conversion.
-			if isFunc {
+			// We care only about string conversions because all others are effectively no-op in NeoVM.
+			// E.g. one cannot write `bool(int(a))`, only `int32(int(a))`.
+			if isString(c.typeOf(n.Fun)) {
+				c.emitConvert(stackitem.ByteArrayT)
+			} else if isFunc {
 				c.emitLoadVar(name)
 				emit.Opcode(c.prog.BinWriter, opcode.CALLA)
 			}

--- a/pkg/compiler/convert_test.go
+++ b/pkg/compiler/convert_test.go
@@ -72,3 +72,17 @@ func TestTypeAssertion(t *testing.T) {
 	}`
 	eval(t, src, big.NewInt(1))
 }
+
+func TestTypeConversion(t *testing.T) {
+	src := `package foo
+	type myInt int
+	func Main() int32 {
+		var a int32 = 41
+		b := myInt(a)
+		incMy := func(x myInt) myInt { return x + 1 }
+		c := incMy(b)
+		return int32(c)
+	}`
+
+	eval(t, src, big.NewInt(42))
+}

--- a/pkg/compiler/convert_test.go
+++ b/pkg/compiler/convert_test.go
@@ -61,3 +61,14 @@ func TestConvert(t *testing.T) {
 		})
 	}
 }
+
+func TestTypeAssertion(t *testing.T) {
+	src := `package foo
+	func Main() int {
+		a := []byte{1}
+		var u interface{}
+		u = a
+		return u.(int)
+	}`
+	eval(t, src, big.NewInt(1))
+}

--- a/pkg/compiler/convert_test.go
+++ b/pkg/compiler/convert_test.go
@@ -86,3 +86,15 @@ func TestTypeConversion(t *testing.T) {
 
 	eval(t, src, big.NewInt(42))
 }
+
+func TestTypeConversionString(t *testing.T) {
+	src := `package foo
+	type mystr string
+	func Main() mystr {
+		b := []byte{'l', 'a', 'm', 'a', 'o'}
+		s := mystr(b)
+		b[0] = 'u'
+		return s
+	}`
+	eval(t, src, []byte("lamao"))
+}


### PR DESCRIPTION
Close #960 .
Close #1092 .

1. Do not fail for `int(...)` conversions.
2. Convert to `ByteString` for `[]byte -> string` conversions.
3. Emit proper conversions for type assertions.