### PR TITLE
cli: update wallet path argument name in cli context

### DIFF
--- a/cli/wallet/multisig.go
+++ b/cli/wallet/multisig.go
@@ -35,7 +35,7 @@ func newMultisigCommands() []cli.Command {
 }
 
 func signMultisig(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}

--- a/cli/wallet/nep5.go
+++ b/cli/wallet/nep5.go
@@ -115,7 +115,7 @@ func newNEP5Commands() []cli.Command {
 }
 
 func getNEP5Balance(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -214,7 +214,7 @@ func getMatchingTokenAux(get func(i int) *wallet.Token, n int, name string) (*wa
 }
 
 func importNEP5Token(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -262,7 +262,7 @@ func printTokenInfo(tok *wallet.Token) {
 }
 
 func printNEP5Info(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -287,7 +287,7 @@ func printNEP5Info(ctx *cli.Context) error {
 }
 
 func removeNEP5Token(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -315,7 +315,7 @@ func removeNEP5Token(ctx *cli.Context) error {
 }
 
 func transferNEP5(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}

--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -191,7 +191,7 @@ func NewCommands() []cli.Command {
 }
 
 func claimGas(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -237,7 +237,7 @@ func claimGas(ctx *cli.Context) error {
 }
 
 func convertWallet(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -281,7 +281,7 @@ func convertWallet(ctx *cli.Context) error {
 }
 
 func addAccount(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -296,7 +296,7 @@ func addAccount(ctx *cli.Context) error {
 }
 
 func exportKeys(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -354,7 +354,7 @@ loop:
 }
 
 func importMultisig(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -393,7 +393,7 @@ func importMultisig(ctx *cli.Context) error {
 }
 
 func importWallet(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -422,7 +422,7 @@ func importWallet(ctx *cli.Context) error {
 }
 
 func removeAccount(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -468,7 +468,7 @@ func askForConsent() bool {
 }
 
 func dumpWallet(ctx *cli.Context) error {
-	wall, err := openWallet(ctx.String("path"))
+	wall, err := openWallet(ctx.String("wallet"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -490,7 +490,7 @@ func dumpWallet(ctx *cli.Context) error {
 }
 
 func createWallet(ctx *cli.Context) error {
-	path := ctx.String("path")
+	path := ctx.String("wallet")
 	if len(path) == 0 {
 		return cli.NewExitError(errNoPath, 1)
 	}


### PR DESCRIPTION
### Problem

In #1104 wallet path argument has changed from `--path` to `--wallet` but cli application still getting wallet path with `ctx.String("path")` instead of `ctx.String("wallet")`.

### Solution

Replace `ctx.String("path")` with `ctx.String("wallet")` in cli wallet commands.
