### PR TITLE
consensus: prevent `invalid message` panic

### DIFF
--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -283,7 +283,7 @@ func (s *service) OnPayload(cp *Payload) {
 	}
 
 	// decode payload data into message
-	if cp.message == nil {
+	if cp.message.payload == nil {
 		if err := cp.decodeData(); err != nil {
 			log.Debug("can't decode payload data")
 			return


### PR DESCRIPTION
After 5c2f69bd2cff98382b4b458462d488e1945f3f37 there's an `invalid
message` panic when trying to run 4-nodes private network:

```
=> Try to restore blocks before running node
2020-06-30T08:59:39.696Z	INFO	no storage version found! creating genesis block
2020-06-30T08:59:39.696Z	INFO	service is running	{"service": "Prometheus", "endpoint": ":20001"}
2020-06-30T08:59:39.696Z	INFO	service hasn't started since it's disabled	{"service": "Pprof"}

    _   ____________        __________
   / | / / ____/ __ \      / ____/ __ \
  /  |/ / __/ / / / /_____/ / __/ / / /
 / /|  / /___/ /_/ /_____/ /_/ / /_/ /
/_/ |_/_____/\____/      \____/\____/
2020-06-30T08:59:39.696Z	INFO	starting rpc-server	{"endpoint": ":30333"}
2020-06-30T08:59:39.696Z	INFO	node started	{"blockHeight": 0, "headerHeight": 0}

/NEO-GO:/

2020-06-30T08:59:39.697Z	INFO	new peer connected	{"addr": "172.200.0.1:20333", "peerCount": 1}
2020-06-30T08:59:39.697Z	INFO	new peer connected	{"addr": "172.200.0.2:46692", "peerCount": 2}
2020-06-30T08:59:39.697Z	INFO	new peer connected	{"addr": "172.200.0.1:54140", "peerCount": 3}
2020-06-30T08:59:39.697Z	INFO	new peer connected	{"addr": "172.200.0.4:42890", "peerCount": 4}
2020-06-30T08:59:39.697Z	INFO	new peer connected	{"addr": "172.200.0.4:20336", "peerCount": 5}
2020-06-30T08:59:39.697Z	INFO	new peer connected	{"addr": "172.200.0.2:20334", "peerCount": 6}
2020-06-30T08:59:39.697Z	INFO	started protocol	{"addr": "172.200.0.4:42890", "userAgent": "/NEO-GO:/", "startHeight": 0, "id": 3797159912}
2020-06-30T08:59:39.697Z	WARN	peer disconnected	{"addr": "172.200.0.4:20336", "reason": "already connected", "peerCount": 5}
2020-06-30T08:59:39.697Z	INFO	started protocol	{"addr": "172.200.0.2:20334", "userAgent": "/NEO-GO:/", "startHeight": 0, "id": 1116452361}
2020-06-30T08:59:39.697Z	WARN	peer disconnected	{"addr": "172.200.0.2:46692", "reason": "already connected", "peerCount": 4}
2020-06-30T08:59:39.697Z	WARN	peer disconnected	{"addr": "172.200.0.1:54140", "reason": "identical node id", "peerCount": 3}
2020-06-30T08:59:39.697Z	WARN	peer disconnected	{"addr": "172.200.0.1:20333", "reason": "identical node id", "peerCount": 2}
2020-06-30T08:59:40.673Z	INFO	new peer connected	{"addr": "172.200.0.3:44948", "peerCount": 3}
2020-06-30T08:59:40.673Z	INFO	new peer connected	{"addr": "172.200.0.3:20335", "peerCount": 4}
2020-06-30T08:59:40.673Z	WARN	peer disconnected	{"addr": "172.200.0.3:20335", "reason": "already connected", "peerCount": 3}
2020-06-30T08:59:40.673Z	WARN	peer disconnected	{"addr": "172.200.0.3:44948", "reason": "unexpected empty payload", "peerCount": 2}
2020-06-30T08:59:40.673Z	INFO	new peer connected	{"addr": "172.200.0.3:44950", "peerCount": 3}
2020-06-30T08:59:40.673Z	INFO	new peer connected	{"addr": "172.200.0.3:20335", "peerCount": 4}
2020-06-30T08:59:40.677Z	INFO	node reached synchronized state, starting consensus
2020-06-30T08:59:40.677Z	INFO	started protocol	{"addr": "172.200.0.3:44950", "userAgent": "/NEO-GO:/", "startHeight": 0, "id": 2658713129}
2020-06-30T08:59:40.689Z	WARN	peer disconnected	{"addr": "172.200.0.3:20335", "reason": "already connected", "peerCount": 3}
2020-06-30T08:59:40.697Z	INFO	blockchain persist completed	{"persistedBlocks": 0, "persistedKeys": 23, "headerHeight": 0, "blockHeight": 0, "took": "243.634µs"}
2020-06-30T08:59:41.057Z	INFO	initializing dbft	{"height": 1, "view": 0, "index": 0, "role": "Backup"}
2020-06-30T08:59:41.057Z	DPANIC	invalid message
2020-06-30T08:59:41.058Z	DPANIC	invalid message
```

Reason: payload wasn't decoded as payload.message isn't null anymore.
Fixed.