### PR TITLE
Cache `transaction.FeePerByte()`

### DIFF
--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -64,6 +64,9 @@ type Transaction struct {
 	// for correct signing/verification.
 	Network netmode.Magic
 
+	// feePerByte is the ratio of NetworkFee and tx size, used for calculating tx priority.
+	feePerByte int64
+
 	// Hash of the transaction (double SHA256).
 	hash util.Uint256
 
@@ -278,7 +281,11 @@ func NewTransactionFromBytes(network netmode.Magic, b []byte) (*Transaction, err
 // FeePerByte returns NetworkFee of the transaction divided by
 // its size
 func (t *Transaction) FeePerByte() int64 {
-	return t.NetworkFee / int64(io.GetVarSize(t))
+	if t.feePerByte != 0 {
+		return t.feePerByte
+	}
+	t.feePerByte = t.NetworkFee / int64(io.GetVarSize(t))
+	return t.feePerByte
 }
 
 // transactionJSON is a wrapper for Transaction and

--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -275,6 +275,7 @@ func NewTransactionFromBytes(network netmode.Magic, b []byte) (*Transaction, err
 	if r.Err != nil {
 		return nil, r.Err
 	}
+	tx.feePerByte = tx.NetworkFee / int64(len(b))
 	return tx, nil
 }
 

--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -275,6 +275,10 @@ func NewTransactionFromBytes(network netmode.Magic, b []byte) (*Transaction, err
 	if r.Err != nil {
 		return nil, r.Err
 	}
+	_ = r.ReadB()
+	if r.Err == nil {
+		return nil, errors.New("additional data after the transaction")
+	}
 	tx.feePerByte = tx.NetworkFee / int64(len(b))
 	return tx, nil
 }

--- a/pkg/core/transaction/transaction_test.go
+++ b/pkg/core/transaction/transaction_test.go
@@ -71,6 +71,26 @@ func TestNew(t *testing.T) {
 	testserdes.EncodeDecodeBinary(t, tx, &Transaction{Network: netmode.UnitTestNet})
 }
 
+func TestNewTransactionFromBytes(t *testing.T) {
+	script := []byte{0x51}
+	tx := New(netmode.UnitTestNet, script, 1)
+	tx.NetworkFee = 123
+	data, err := testserdes.EncodeBinary(tx)
+	require.NoError(t, err)
+
+	// set cached fields
+	tx.Hash()
+	tx.FeePerByte()
+
+	tx1, err := NewTransactionFromBytes(netmode.UnitTestNet, data)
+	require.NoError(t, err)
+	require.Equal(t, tx, tx1)
+
+	data = append(data, 42)
+	_, err = NewTransactionFromBytes(netmode.UnitTestNet, data)
+	require.Error(t, err)
+}
+
 func TestEncodingTXWithNoScript(t *testing.T) {
 	_, err := testserdes.EncodeBinary(new(Transaction))
 	require.Error(t, err)

--- a/pkg/rpc/client/rpc_test.go
+++ b/pkg/rpc/client/rpc_test.go
@@ -498,7 +498,12 @@ var rpcClientTestCases = map[string][]rpcClientTestCase{
 				if err != nil {
 					panic(err)
 				}
-				return c.GetRawTransactionVerbose(hash)
+				out, err := c.GetRawTransactionVerbose(hash)
+				if err != nil {
+					return nil, err
+				}
+				out.Transaction.FeePerByte() // set fee per byte
+				return out, nil
 			},
 			serverResponse: txMoveNeoVerbose,
 			result: func(c *Client) interface{} {


### PR DESCRIPTION
Closes #1141 .
`FeePerByte()` takes much less time in benchmark now.