### PR TITLE
rpc: support stringified address in getnep5balances RPC

### DIFF
--- a/pkg/rpc/request/param.go
+++ b/pkg/rpc/request/param.go
@@ -154,6 +154,16 @@ func (p *Param) GetUint160FromAddress() (util.Uint160, error) {
 	return address.StringToUint160(s)
 }
 
+// GetUint160FromAddressOrHex returns Uint160 value of the parameter that was
+// supplied either as raw hex or as an address.
+func (p *Param) GetUint160FromAddressOrHex() (util.Uint160, error) {
+	u, err := p.GetUint160FromHex()
+	if err == nil {
+		return u, err
+	}
+	return p.GetUint160FromAddress()
+}
+
 // GetFuncParam returns current parameter as a function call parameter.
 func (p *Param) GetFuncParam() (FuncParam, error) {
 	if p == nil {

--- a/pkg/rpc/request/param_test.go
+++ b/pkg/rpc/request/param_test.go
@@ -166,6 +166,25 @@ func TestParamGetUint160FromAddress(t *testing.T) {
 	require.NotNil(t, err)
 }
 
+func TestParam_GetUint160FromAddressOrHex(t *testing.T) {
+	in := "AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y"
+	inHex, _ := address.StringToUint160(in)
+
+	t.Run("Address", func(t *testing.T) {
+		p := Param{StringT, in}
+		u, err := p.GetUint160FromAddressOrHex()
+		require.NoError(t, err)
+		require.Equal(t, inHex, u)
+	})
+
+	t.Run("Hex", func(t *testing.T) {
+		p := Param{StringT, inHex.StringLE()}
+		u, err := p.GetUint160FromAddressOrHex()
+		require.NoError(t, err)
+		require.Equal(t, inHex, u)
+	})
+}
+
 func TestParamGetFuncParam(t *testing.T) {
 	fp := FuncParam{
 		Type: smartcontract.StringType,

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -595,7 +595,7 @@ func (s *Server) getNEP5Balances(ps request.Params) (interface{}, *response.Erro
 }
 
 func (s *Server) getNEP5Transfers(ps request.Params) (interface{}, *response.Error) {
-	u, err := ps.ValueWithType(0, request.StringT).GetUint160FromAddress()
+	u, err := ps.Value(0).GetUint160FromAddressOrHex()
 	if err != nil {
 		return nil, response.ErrInvalidParams
 	}

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -566,7 +566,7 @@ func (s *Server) getClaimable(ps request.Params) (interface{}, *response.Error) 
 }
 
 func (s *Server) getNEP5Balances(ps request.Params) (interface{}, *response.Error) {
-	u, err := ps.ValueWithType(0, request.StringT).GetUint160FromHex()
+	u, err := ps.Value(0).GetUint160FromAddressOrHex()
 	if err != nil {
 		return nil, response.ErrInvalidParams
 	}

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -193,24 +193,13 @@ var rpcTestCases = map[string][]rpcTestCase{
 			name:   "positive",
 			params: `["AKkkumHbBipZ46UMZJoFynJMXzSRnBvKcs"]`,
 			result: func(e *executor) interface{} { return &result.NEP5Transfers{} },
-			check: func(t *testing.T, e *executor, acc interface{}) {
-				res, ok := acc.(*result.NEP5Transfers)
-				require.True(t, ok)
-				require.Equal(t, "AKkkumHbBipZ46UMZJoFynJMXzSRnBvKcs", res.Address)
-
-				assetHash, err := util.Uint160DecodeStringLE(testContractHash)
-				require.NoError(t, err)
-
-				require.Equal(t, 1, len(res.Received))
-				require.Equal(t, "10", res.Received[0].Amount)
-				require.Equal(t, assetHash, res.Received[0].Asset)
-				require.Equal(t, address.Uint160ToString(assetHash), res.Received[0].Address)
-
-				require.Equal(t, 1, len(res.Sent))
-				require.Equal(t, "1.23", res.Sent[0].Amount)
-				require.Equal(t, assetHash, res.Sent[0].Asset)
-				require.Equal(t, "AWLYWXB8C9Lt1nHdDZJnC5cpYJjgRDLk17", res.Sent[0].Address)
-			},
+			check:  checkNep5Transfers,
+		},
+		{
+			name:   "positive_hash",
+			params: `["a90f00d94349a320376b7cb86c884b53ad76aa2b"]`,
+			result: func(e *executor) interface{} { return &result.NEP5Transfers{} },
+			check:  checkNep5Transfers,
 		},
 	},
 	"getproof": {
@@ -1165,4 +1154,23 @@ func checkNep5Balances(t *testing.T, e *executor, acc interface{}) {
 	require.Equal(t, "8.77", res.Balances[0].Amount)
 	require.Equal(t, testContractHash, res.Balances[0].Asset.StringLE())
 	require.Equal(t, uint32(208), res.Balances[0].LastUpdated)
+}
+
+func checkNep5Transfers(t *testing.T, e *executor, acc interface{}) {
+	res, ok := acc.(*result.NEP5Transfers)
+	require.True(t, ok)
+	require.Equal(t, "AKkkumHbBipZ46UMZJoFynJMXzSRnBvKcs", res.Address)
+
+	assetHash, err := util.Uint160DecodeStringLE(testContractHash)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(res.Received))
+	require.Equal(t, "10", res.Received[0].Amount)
+	require.Equal(t, assetHash, res.Received[0].Asset)
+	require.Equal(t, address.Uint160ToString(assetHash), res.Received[0].Address)
+
+	require.Equal(t, 1, len(res.Sent))
+	require.Equal(t, "1.23", res.Sent[0].Amount)
+	require.Equal(t, assetHash, res.Sent[0].Asset)
+	require.Equal(t, "AWLYWXB8C9Lt1nHdDZJnC5cpYJjgRDLk17", res.Sent[0].Address)
 }

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -169,15 +169,13 @@ var rpcTestCases = map[string][]rpcTestCase{
 			name:   "positive",
 			params: `["a90f00d94349a320376b7cb86c884b53ad76aa2b"]`,
 			result: func(e *executor) interface{} { return &result.NEP5Balances{} },
-			check: func(t *testing.T, e *executor, acc interface{}) {
-				res, ok := acc.(*result.NEP5Balances)
-				require.True(t, ok)
-				require.Equal(t, "AKkkumHbBipZ46UMZJoFynJMXzSRnBvKcs", res.Address)
-				require.Equal(t, 1, len(res.Balances))
-				require.Equal(t, "8.77", res.Balances[0].Amount)
-				require.Equal(t, testContractHash, res.Balances[0].Asset.StringLE())
-				require.Equal(t, uint32(208), res.Balances[0].LastUpdated)
-			},
+			check:  checkNep5Balances,
+		},
+		{
+			name:   "positive_address",
+			params: `["AKkkumHbBipZ46UMZJoFynJMXzSRnBvKcs"]`,
+			result: func(e *executor) interface{} { return &result.NEP5Balances{} },
+			check:  checkNep5Balances,
 		},
 	},
 	"getnep5transfers": {
@@ -1157,4 +1155,14 @@ func doRPCCallOverHTTP(rpcCall string, url string, t *testing.T) []byte {
 	body, err := ioutil.ReadAll(resp.Body)
 	assert.NoErrorf(t, err, "could not read response from the request: %s", rpcCall)
 	return bytes.TrimSpace(body)
+}
+
+func checkNep5Balances(t *testing.T, e *executor, acc interface{}) {
+	res, ok := acc.(*result.NEP5Balances)
+	require.True(t, ok)
+	require.Equal(t, "AKkkumHbBipZ46UMZJoFynJMXzSRnBvKcs", res.Address)
+	require.Equal(t, 1, len(res.Balances))
+	require.Equal(t, "8.77", res.Balances[0].Amount)
+	require.Equal(t, testContractHash, res.Balances[0].Asset.StringLE())
+	require.Equal(t, uint32(208), res.Balances[0].LastUpdated)
 }


### PR DESCRIPTION
Fix #1143 .

Also extend `getnep5transfers`.