### PR TITLE
cli: fixes for contract deployment and invocation

### DIFF
--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -460,7 +460,7 @@ func invokeInternal(ctx *cli.Context, signAndPush bool) error {
 		if err != nil {
 			return cli.NewExitError(fmt.Errorf("bad script returned from the RPC node: %v", err), 1)
 		}
-		txHash, err := c.SignAndPushInvocationTx(script, acc, 0, gas)
+		txHash, err := c.SignAndPushInvocationTx(script, acc, 0, gas, cosigners)
 		if err != nil {
 			return cli.NewExitError(fmt.Errorf("failed to push invocation tx: %v", err), 1)
 		}
@@ -665,7 +665,7 @@ func contractDeploy(ctx *cli.Context) error {
 		return cli.NewExitError(fmt.Errorf("failed to test-invoke deployment script: %v", err), 1)
 	}
 
-	txHash, err := c.SignAndPushInvocationTx(txScript, acc, invRes.GasConsumed, gas)
+	txHash, err := c.SignAndPushInvocationTx(txScript, acc, invRes.GasConsumed, gas, nil)
 	if err != nil {
 		return cli.NewExitError(fmt.Errorf("failed to push invocation tx: %v", err), 1)
 	}

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -427,7 +427,7 @@ func invokeInternal(ctx *cli.Context, signAndPush bool) error {
 		for i, c := range args[cosignersStart:] {
 			cosigner, err := parseCosigner(c)
 			if err != nil {
-				return cli.NewExitError(fmt.Errorf("failed to parse cosigner #%d: %v", i+cosignersStart+1, err), 1)
+				return cli.NewExitError(fmt.Errorf("failed to parse cosigner #%d: %v", i+1, err), 1)
 			}
 			cosigners = append(cosigners, cosigner)
 		}
@@ -692,7 +692,7 @@ func parseCosigner(c string) (transaction.Cosigner, error) {
 		err error
 		res = transaction.Cosigner{}
 	)
-	data := strings.SplitN(strings.ToLower(c), ":", 2)
+	data := strings.SplitN(c, ":", 2)
 	s := data[0]
 	if len(s) == 2*util.Uint160Size+2 && s[0:2] == "0x" {
 		s = s[2:]

--- a/pkg/rpc/client/nep5.go
+++ b/pkg/rpc/client/nep5.go
@@ -118,7 +118,7 @@ func (c *Client) CreateNEP5TransferTx(acc *wallet.Account, to util.Uint160, toke
 	result, err := c.InvokeScript(script, []transaction.Cosigner{
 		{
 			Account: from,
-			Scopes:  transaction.Global,
+			Scopes:  transaction.CalledByEntry,
 		},
 	})
 	if err != nil {

--- a/pkg/rpc/client/nep5.go
+++ b/pkg/rpc/client/nep5.go
@@ -115,17 +115,6 @@ func (c *Client) CreateNEP5TransferTx(acc *wallet.Account, to util.Uint160, toke
 	emit.Opcode(w.BinWriter, opcode.ASSERT)
 
 	script := w.Bytes()
-	tx := transaction.New(c.opts.Network, script, gas)
-	tx.Sender = from
-	tx.Cosigners = []transaction.Cosigner{
-		{
-			Account:          from,
-			Scopes:           transaction.CalledByEntry,
-			AllowedContracts: nil,
-			AllowedGroups:    nil,
-		},
-	}
-
 	result, err := c.InvokeScript(script, []transaction.Cosigner{
 		{
 			Account: from,
@@ -135,16 +124,20 @@ func (c *Client) CreateNEP5TransferTx(acc *wallet.Account, to util.Uint160, toke
 	if err != nil {
 		return nil, fmt.Errorf("can't add system fee to transaction: %v", err)
 	}
-	if result.GasConsumed > 0 {
-		tx.SystemFee = result.GasConsumed
+	tx := transaction.New(c.opts.Network, script, result.GasConsumed)
+	tx.Sender = from
+	tx.Cosigners = []transaction.Cosigner{
+		{
+			Account: from,
+			Scopes:  transaction.CalledByEntry,
+		},
 	}
-
 	tx.ValidUntilBlock, err = c.CalculateValidUntilBlock()
 	if err != nil {
 		return nil, fmt.Errorf("can't calculate validUntilBlock: %v", err)
 	}
 
-	err = c.AddNetworkFee(tx, acc)
+	err = c.AddNetworkFee(tx, gas, acc)
 	if err != nil {
 		return nil, fmt.Errorf("can't add network fee to transaction: %v", err)
 	}

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -429,12 +429,13 @@ func (c *Client) SubmitBlock(b block.Block) error {
 // SignAndPushInvocationTx signs and pushes given script as an invocation
 // transaction  using given wif to sign it and spending the amount of gas
 // specified. It returns a hash of the invocation transaction and an error.
-func (c *Client) SignAndPushInvocationTx(script []byte, acc *wallet.Account, sysfee int64, netfee util.Fixed8) (util.Uint256, error) {
+func (c *Client) SignAndPushInvocationTx(script []byte, acc *wallet.Account, sysfee int64, netfee util.Fixed8, cosigners []transaction.Cosigner) (util.Uint256, error) {
 	var txHash util.Uint256
 	var err error
 
 	tx := transaction.New(c.opts.Network, script, sysfee)
 	tx.SystemFee = sysfee
+	tx.Cosigners = cosigners
 
 	validUntilBlock, err := c.CalculateValidUntilBlock()
 	if err != nil {

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -449,7 +449,7 @@ func (c *Client) SignAndPushInvocationTx(script []byte, acc *wallet.Account, sys
 	}
 	tx.Sender = addr
 
-	err = c.AddNetworkFee(tx, acc)
+	err = c.AddNetworkFee(tx, int64(netfee), acc)
 	if err != nil {
 		return txHash, errors.Wrapf(err, "failed to add network fee")
 	}
@@ -512,8 +512,9 @@ func (c *Client) CalculateValidUntilBlock() (uint32, error) {
 	return blockCount + validatorsCount, nil
 }
 
-// AddNetworkFee adds network fee for each witness script to transaction.
-func (c *Client) AddNetworkFee(tx *transaction.Transaction, acc *wallet.Account) error {
+// AddNetworkFee adds network fee for each witness script and optional extra
+// network fee to transaction.
+func (c *Client) AddNetworkFee(tx *transaction.Transaction, extraFee int64, acc *wallet.Account) error {
 	size := io.GetVarSize(tx)
 	if acc.Contract != nil {
 		netFee, sizeDelta := core.CalculateNetworkFee(acc.Contract.Script)
@@ -540,6 +541,6 @@ func (c *Client) AddNetworkFee(tx *transaction.Transaction, acc *wallet.Account)
 	if err != nil {
 		return err
 	}
-	tx.NetworkFee += int64(size) * fee
+	tx.NetworkFee += int64(size)*fee + extraFee
 	return nil
 }


### PR DESCRIPTION
1. Add specified cosigners to invocation transaction.
2. Parse cosigners properly.