### PR TITLE
vm: fix stackitem deserialisation

### DIFF
--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -488,7 +488,7 @@ func (s *Server) getApplicationLog(reqParams request.Params) (interface{}, *resp
 
 	appExecResult, err := s.chain.GetAppExecResult(txHash)
 	if err != nil {
-		return nil, response.NewRPCError("Unknown transaction", "", nil)
+		return nil, response.NewRPCError("Unknown transaction", "", err)
 	}
 
 	return result.NewApplicationLog(appExecResult), nil

--- a/pkg/vm/stackitem/serialization.go
+++ b/pkg/vm/stackitem/serialization.go
@@ -2,6 +2,7 @@ package stackitem
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/nspcc-dev/neo-go/pkg/encoding/bigint"
@@ -96,7 +97,7 @@ func DecodeBinaryStackItem(r *io.BinReader) Item {
 	}
 
 	switch t {
-	case ByteArrayT:
+	case ByteArrayT, BufferT:
 		data := r.ReadVarBytes()
 		return NewByteArray(data)
 	case BooleanT:
@@ -132,7 +133,7 @@ func DecodeBinaryStackItem(r *io.BinReader) Item {
 	case AnyT:
 		return Null{}
 	default:
-		r.Err = errors.New("unknown type")
+		r.Err = fmt.Errorf("unknown type: %v", t)
 		return nil
 	}
 }


### PR DESCRIPTION
1. Add ability to deserialise Buffer item.
2. Wrap error of `getapplicationlog` RPC response.