### PR TITLE
wallet, vm, keys: support returning legacy verification script (and not only)

### DIFF
--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -339,7 +339,7 @@ loop:
 				return cli.NewExitError(err, 1)
 			}
 
-			pk, err := keys.NEP2Decrypt(wif, pass)
+			pk, err := keys.NEP2DecryptNEO3(wif, pass)
 			if err != nil {
 				return cli.NewExitError(err, 1)
 			}

--- a/integration/performance_test.go
+++ b/integration/performance_test.go
@@ -74,7 +74,7 @@ func getWif(t *testing.B) *keys.WIF {
 
 // getTX returns Invocation transaction with some random attributes in order to have different hashes.
 func getTX(t *testing.B, wif *keys.WIF) *transaction.Transaction {
-	fromAddress := wif.PrivateKey.Address()
+	fromAddress := wif.PrivateKey.NEO3Address()
 	fromAddressHash, err := address.StringToUint160(fromAddress)
 	require.NoError(t, err)
 

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -239,14 +239,14 @@ func (s *service) validatePayload(p *Payload) bool {
 	}
 
 	pub := validators[p.validatorIndex]
-	h := pub.(*publicKey).GetScriptHash()
+	h := pub.(*publicKey).GetNEO3ScriptHash()
 
 	return p.Verify(h)
 }
 
 func (s *service) getKeyPair(pubs []crypto.PublicKey) (int, crypto.PrivateKey, crypto.PublicKey) {
 	for i := range pubs {
-		sh := pubs[i].(*publicKey).GetScriptHash()
+		sh := pubs[i].(*publicKey).GetNEO3ScriptHash()
 		acc := s.wallet.GetAccount(sh)
 		if acc == nil {
 			continue

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -252,7 +252,7 @@ func (s *service) getKeyPair(pubs []crypto.PublicKey) (int, crypto.PrivateKey, c
 			continue
 		}
 
-		key, err := keys.NEP2Decrypt(acc.EncryptedWIF, s.Config.Wallet.Password)
+		key, err := keys.NEP2DecryptNEO3(acc.EncryptedWIF, s.Config.Wallet.Password)
 		if err != nil {
 			continue
 		}

--- a/pkg/consensus/payload.go
+++ b/pkg/consensus/payload.go
@@ -203,7 +203,7 @@ func (p *Payload) Sign(key *privateKey) error {
 	buf := io.NewBufBinWriter()
 	emit.Bytes(buf.BinWriter, sig)
 	p.Witness.InvocationScript = buf.Bytes()
-	p.Witness.VerificationScript = key.PublicKey().GetVerificationScript()
+	p.Witness.VerificationScript = emit.GetVerificationScript(key.PublicKey().Bytes())
 
 	return nil
 }

--- a/pkg/consensus/payload.go
+++ b/pkg/consensus/payload.go
@@ -203,7 +203,7 @@ func (p *Payload) Sign(key *privateKey) error {
 	buf := io.NewBufBinWriter()
 	emit.Bytes(buf.BinWriter, sig)
 	p.Witness.InvocationScript = buf.Bytes()
-	p.Witness.VerificationScript = emit.GetVerificationScript(key.PublicKey().Bytes())
+	p.Witness.VerificationScript = emit.GetNEO3VerificationScript(key.PublicKey().Bytes())
 
 	return nil
 }

--- a/pkg/consensus/recovery_message.go
+++ b/pkg/consensus/recovery_message.go
@@ -282,7 +282,7 @@ func getVerificationScript(i uint16, validators []crypto.PublicKey) []byte {
 		return nil
 	}
 
-	return emit.GetVerificationScript(pub.PublicKey.Bytes())
+	return emit.GetNEO3VerificationScript(pub.PublicKey.Bytes())
 }
 
 func fromPayload(t messageType, recovery *Payload, p io.Serializable) *Payload {

--- a/pkg/consensus/recovery_message.go
+++ b/pkg/consensus/recovery_message.go
@@ -5,6 +5,7 @@ import (
 	"github.com/nspcc-dev/dbft/payload"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
 	"github.com/pkg/errors"
 )
 
@@ -281,7 +282,7 @@ func getVerificationScript(i uint16, validators []crypto.PublicKey) []byte {
 		return nil
 	}
 
-	return pub.GetVerificationScript()
+	return emit.GetVerificationScript(pub.PublicKey.Bytes())
 }
 
 func fromPayload(t messageType, recovery *Payload, p io.Serializable) *Payload {

--- a/pkg/core/interop/runtime/witness.go
+++ b/pkg/core/interop/runtime/witness.go
@@ -78,7 +78,7 @@ func checkScope(d dao.DAO, tx *transaction.Transaction, v vm.ScriptHashGetter, h
 // CheckKeyedWitness checks hash of signature check contract with a given public
 // key against current list of script hashes for verifying in the interop context.
 func CheckKeyedWitness(ic *interop.Context, v vm.ScriptHashGetter, key *keys.PublicKey) (bool, error) {
-	return CheckHashedWitness(ic, v, key.GetScriptHash())
+	return CheckHashedWitness(ic, v, key.GetNEO3ScriptHash())
 }
 
 // CheckWitness checks witnesses.

--- a/pkg/core/interop_system.go
+++ b/pkg/core/interop_system.go
@@ -487,6 +487,6 @@ func contractCreateStandardAccount(ic *interop.Context, v *vm.VM) error {
 	if err != nil {
 		return err
 	}
-	v.Estack().PushVal(p.GetScriptHash().BytesBE())
+	v.Estack().PushVal(p.GetNEO3ScriptHash().BytesBE())
 	return nil
 }

--- a/pkg/core/interop_system_test.go
+++ b/pkg/core/interop_system_test.go
@@ -166,7 +166,7 @@ func TestContractIsStandard(t *testing.T) {
 		err = ic.DAO.PutContractState(&state.Contract{ID: 42, Script: emit.GetNEO3VerificationScript(pub.Bytes())})
 		require.NoError(t, err)
 
-		v.Estack().PushVal(pub.GetScriptHash().BytesBE())
+		v.Estack().PushVal(pub.GetNEO3ScriptHash().BytesBE())
 		require.NoError(t, contractIsStandard(ic, v))
 		require.True(t, v.Estack().Pop().Bool())
 	})
@@ -193,7 +193,7 @@ func TestContractCreateAccount(t *testing.T) {
 		value := v.Estack().Pop().Bytes()
 		u, err := util.Uint160DecodeBytesBE(value)
 		require.NoError(t, err)
-		require.Equal(t, pub.GetScriptHash(), u)
+		require.Equal(t, pub.GetNEO3ScriptHash(), u)
 	})
 	t.Run("InvalidKey", func(t *testing.T) {
 		v.Estack().PushVal([]byte{1, 2, 3})

--- a/pkg/core/interop_system_test.go
+++ b/pkg/core/interop_system_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/stretchr/testify/require"
@@ -162,7 +163,7 @@ func TestContractIsStandard(t *testing.T) {
 		require.NoError(t, err)
 
 		pub := priv.PublicKey()
-		err = ic.DAO.PutContractState(&state.Contract{ID: 42, Script: pub.GetVerificationScript()})
+		err = ic.DAO.PutContractState(&state.Contract{ID: 42, Script: emit.GetVerificationScript(pub.Bytes())})
 		require.NoError(t, err)
 
 		v.Estack().PushVal(pub.GetScriptHash().BytesBE())

--- a/pkg/core/interop_system_test.go
+++ b/pkg/core/interop_system_test.go
@@ -163,7 +163,7 @@ func TestContractIsStandard(t *testing.T) {
 		require.NoError(t, err)
 
 		pub := priv.PublicKey()
-		err = ic.DAO.PutContractState(&state.Contract{ID: 42, Script: emit.GetVerificationScript(pub.Bytes())})
+		err = ic.DAO.PutContractState(&state.Contract{ID: 42, Script: emit.GetNEO3VerificationScript(pub.Bytes())})
 		require.NoError(t, err)
 
 		v.Estack().PushVal(pub.GetScriptHash().BytesBE())

--- a/pkg/core/native/native_gas.go
+++ b/pkg/core/native/native_gas.go
@@ -95,7 +95,7 @@ func (g *GAS) OnPersist(ic *interop.Context) error {
 	if err != nil {
 		return fmt.Errorf("cannot get block validators: %v", err)
 	}
-	primary := validators[ic.Block.ConsensusData.PrimaryIndex].GetScriptHash()
+	primary := validators[ic.Block.ConsensusData.PrimaryIndex].GetNEO3ScriptHash()
 	var netFee int64
 	for _, tx := range ic.Block.Transactions {
 		netFee += tx.NetworkFee

--- a/pkg/crypto/keys/nep2.go
+++ b/pkg/crypto/keys/nep2.go
@@ -43,7 +43,7 @@ func NEP2ScryptParams() ScryptParams {
 // NEP2Encrypt encrypts a the PrivateKey using a given passphrase
 // under the NEP-2 standard.
 func NEP2Encrypt(priv *PrivateKey, passphrase string) (s string, err error) {
-	address := priv.Address()
+	address := priv.NEO3Address()
 
 	addrHash := hash.Checksum([]byte(address))
 	// Normalize the passphrase according to the NFC standard.
@@ -119,7 +119,7 @@ func NEP2Decrypt(key, passphrase string) (*PrivateKey, error) {
 }
 
 func compareAddressHash(priv *PrivateKey, inhash []byte) bool {
-	address := priv.Address()
+	address := priv.NEO3Address()
 	addrHash := hash.Checksum([]byte(address))
 	return bytes.Equal(addrHash, inhash)
 }

--- a/pkg/crypto/keys/nep2_test.go
+++ b/pkg/crypto/keys/nep2_test.go
@@ -39,7 +39,7 @@ func TestNEP2Decrypt(t *testing.T) {
 		wif := privKey.WIF()
 		assert.Equal(t, testCase.Wif, wif)
 
-		address := privKey.Address()
+		address := privKey.NEO3Address()
 		assert.Equal(t, testCase.Address, address)
 	}
 }

--- a/pkg/crypto/keys/nep2_test.go
+++ b/pkg/crypto/keys/nep2_test.go
@@ -27,7 +27,7 @@ func TestNEP2Encrypt(t *testing.T) {
 
 func TestNEP2Decrypt(t *testing.T) {
 	for _, testCase := range keytestcases.Arr {
-		privKey, err := NEP2Decrypt(testCase.EncryptedWif, testCase.Passphrase)
+		privKey, err := NEP2DecryptNEO3(testCase.EncryptedWif, testCase.Passphrase)
 		if testCase.Invalid {
 			assert.Error(t, err)
 			continue
@@ -49,12 +49,12 @@ func TestNEP2DecryptErrors(t *testing.T) {
 
 	// Not a base58-encoded value
 	s := "qazwsx"
-	_, err := NEP2Decrypt(s, p)
+	_, err := NEP2DecryptNEO3(s, p)
 	assert.Error(t, err)
 
 	// Valid base58, but not a NEP-2 format.
 	s = "KxhEDBQyyEFymvfJD96q8stMbJMbZUb6D1PmXqBWZDU2WvbvVs9o"
-	_, err = NEP2Decrypt(s, p)
+	_, err = NEP2DecryptNEO3(s, p)
 	assert.Error(t, err)
 }
 

--- a/pkg/crypto/keys/private_key.go
+++ b/pkg/crypto/keys/private_key.go
@@ -92,11 +92,18 @@ func (p *PrivateKey) WIF() string {
 	return w
 }
 
-// Address derives the public NEO address that is coupled with the private key, and
+// NEO3Address derives the public NEO3 address that is coupled with the private key, and
 // returns it as a string.
-func (p *PrivateKey) Address() string {
+func (p *PrivateKey) NEO3Address() string {
 	pk := p.PublicKey()
 	return pk.NEO3Address()
+}
+
+// NEO2Address derives the public NEO2 address that is coupled with the private key, and
+// returns it as a string.
+func (p *PrivateKey) NEO2Address() string {
+	pk := p.PublicKey()
+	return pk.NEO2Address()
 }
 
 // GetScriptHash returns verification script hash for public key associated with

--- a/pkg/crypto/keys/private_key.go
+++ b/pkg/crypto/keys/private_key.go
@@ -96,7 +96,7 @@ func (p *PrivateKey) WIF() string {
 // returns it as a string.
 func (p *PrivateKey) Address() string {
 	pk := p.PublicKey()
-	return pk.Address()
+	return pk.NEO3Address()
 }
 
 // GetScriptHash returns verification script hash for public key associated with

--- a/pkg/crypto/keys/private_key.go
+++ b/pkg/crypto/keys/private_key.go
@@ -103,7 +103,7 @@ func (p *PrivateKey) Address() string {
 // the private key.
 func (p *PrivateKey) GetScriptHash() util.Uint160 {
 	pk := p.PublicKey()
-	return pk.GetScriptHash()
+	return pk.GetNEO3ScriptHash()
 }
 
 // Sign signs arbitrary length data using the private key.

--- a/pkg/crypto/keys/private_key_test.go
+++ b/pkg/crypto/keys/private_key_test.go
@@ -18,7 +18,7 @@ func TestPrivateKey(t *testing.T) {
 		}
 
 		assert.Nil(t, err)
-		address := privKey.Address()
+		address := privKey.NEO3Address()
 		assert.Equal(t, testCase.Address, address)
 
 		wif := privKey.WIF()

--- a/pkg/crypto/keys/publickey.go
+++ b/pkg/crypto/keys/publickey.go
@@ -14,7 +14,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
-	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
 	"github.com/pkg/errors"
 )
 
@@ -272,21 +271,9 @@ func (p *PublicKey) EncodeBinary(w *io.BinWriter) {
 	w.WriteBytes(p.Bytes())
 }
 
-// GetVerificationScript returns NEO VM bytecode with CHECKSIG command for the
-// public key.
-func (p *PublicKey) GetVerificationScript() []byte {
-	b := p.Bytes()
-	buf := io.NewBufBinWriter()
-	emit.Bytes(buf.BinWriter, b)
-	emit.Opcode(buf.BinWriter, opcode.PUSHNULL)
-	emit.Syscall(buf.BinWriter, "Neo.Crypto.ECDsaVerify")
-
-	return buf.Bytes()
-}
-
 // GetScriptHash returns a Hash160 of verification script for the key.
 func (p *PublicKey) GetScriptHash() util.Uint160 {
-	return hash.Hash160(p.GetVerificationScript())
+	return hash.Hash160(emit.GetVerificationScript(p.Bytes()))
 }
 
 // Address returns a base58-encoded NEO-specific address based on the key hash.

--- a/pkg/crypto/keys/publickey.go
+++ b/pkg/crypto/keys/publickey.go
@@ -271,14 +271,19 @@ func (p *PublicKey) EncodeBinary(w *io.BinWriter) {
 	w.WriteBytes(p.Bytes())
 }
 
-// GetScriptHash returns a Hash160 of verification script for the key.
-func (p *PublicKey) GetScriptHash() util.Uint160 {
+// GetNEO3ScriptHash returns a Hash160 of NEO3 verification script for the key.
+func (p *PublicKey) GetNEO3ScriptHash() util.Uint160 {
 	return hash.Hash160(emit.GetNEO3VerificationScript(p.Bytes()))
+}
+
+// GetNEO2ScriptHash returns a Hash160 of NEO2 verification script for the key.
+func (p *PublicKey) GetNEO2ScriptHash() util.Uint160 {
+	return hash.Hash160(emit.GetNEO2VerificationScript(p.Bytes()))
 }
 
 // Address returns a base58-encoded NEO-specific address based on the key hash.
 func (p *PublicKey) Address() string {
-	return address.Uint160ToString(p.GetScriptHash())
+	return address.Uint160ToString(p.GetNEO3ScriptHash())
 }
 
 // Verify returns true if the signature is valid and corresponds

--- a/pkg/crypto/keys/publickey.go
+++ b/pkg/crypto/keys/publickey.go
@@ -281,9 +281,14 @@ func (p *PublicKey) GetNEO2ScriptHash() util.Uint160 {
 	return hash.Hash160(emit.GetNEO2VerificationScript(p.Bytes()))
 }
 
-// Address returns a base58-encoded NEO-specific address based on the key hash.
-func (p *PublicKey) Address() string {
+// NEO3Address returns a base58-encoded NEO3-specific address based on the key hash.
+func (p *PublicKey) NEO3Address() string {
 	return address.Uint160ToString(p.GetNEO3ScriptHash())
+}
+
+// NEO2Address returns a base58-encoded NEO2-specific address based on the key hash.
+func (p *PublicKey) NEO2Address() string {
+	return address.Uint160ToString(p.GetNEO2ScriptHash())
 }
 
 // Verify returns true if the signature is valid and corresponds

--- a/pkg/crypto/keys/publickey.go
+++ b/pkg/crypto/keys/publickey.go
@@ -273,7 +273,7 @@ func (p *PublicKey) EncodeBinary(w *io.BinWriter) {
 
 // GetScriptHash returns a Hash160 of verification script for the key.
 func (p *PublicKey) GetScriptHash() util.Uint160 {
-	return hash.Hash160(emit.GetVerificationScript(p.Bytes()))
+	return hash.Hash160(emit.GetNEO3VerificationScript(p.Bytes()))
 }
 
 // Address returns a base58-encoded NEO-specific address based on the key hash.

--- a/pkg/crypto/keys/publickey_test.go
+++ b/pkg/crypto/keys/publickey_test.go
@@ -105,7 +105,7 @@ func TestDecodeFromStringUncompressed(t *testing.T) {
 func TestPubkeyToAddress(t *testing.T) {
 	pubKey, err := NewPublicKeyFromString("031ee4e73a17d8f76dc02532e2620bcb12425b33c0c9f9694cc2caa8226b68cad4")
 	require.NoError(t, err)
-	actual := pubKey.Address()
+	actual := pubKey.NEO3Address()
 	expected := "NNqoUeNb2tfhEExY7mrPbxf4EZZRKX5nHF"
 	require.Equal(t, expected, actual)
 }

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -152,7 +152,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 						}},
 					Address: testchain.PrivateKeyByID(0).GetScriptHash().StringLE(),
 				}
-				require.Equal(t, testchain.PrivateKeyByID(0).Address(), res.Address)
+				require.Equal(t, testchain.PrivateKeyByID(0).NEO3Address(), res.Address)
 				require.ElementsMatch(t, expected.Balances, res.Balances)
 			},
 		},
@@ -170,7 +170,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 		},
 		{
 			name:   "positive",
-			params: `["` + testchain.PrivateKeyByID(0).Address() + `"]`,
+			params: `["` + testchain.PrivateKeyByID(0).NEO3Address() + `"]`,
 			result: func(e *executor) interface{} { return &result.NEP5Transfers{} },
 			check: func(t *testing.T, e *executor, acc interface{}) {
 				res, ok := acc.(*result.NEP5Transfers)
@@ -199,7 +199,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 						{
 							Timestamp:   blockSendRubles.Timestamp,
 							Asset:       rublesHash,
-							Address:     testchain.PrivateKeyByID(1).Address(),
+							Address:     testchain.PrivateKeyByID(1).NEO3Address(),
 							Amount:      "1.23",
 							Index:       6,
 							NotifyIndex: 0,
@@ -208,7 +208,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 						{
 							Timestamp:   blockSendNEO.Timestamp,
 							Asset:       e.chain.GoverningTokenHash(),
-							Address:     testchain.PrivateKeyByID(1).Address(),
+							Address:     testchain.PrivateKeyByID(1).NEO3Address(),
 							Amount:      "1000",
 							Index:       4,
 							NotifyIndex: 0,
@@ -253,7 +253,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 							TxHash:      txReceiveNEOHash,
 						},
 					},
-					Address: testchain.PrivateKeyByID(0).Address(),
+					Address: testchain.PrivateKeyByID(0).NEO3Address(),
 				}
 
 				// take burned gas into account

--- a/pkg/smartcontract/context/context_test.go
+++ b/pkg/smartcontract/context/context_test.go
@@ -29,7 +29,7 @@ func TestParameterContext_AddSignatureSimpleContract(t *testing.T) {
 	t.Run("invalid contract", func(t *testing.T) {
 		c := NewParameterContext("Neo.Core.ContractTransaction", tx)
 		ctr := &wallet.Contract{
-			Script: emit.GetVerificationScript(pub.Bytes()),
+			Script: emit.GetNEO3VerificationScript(pub.Bytes()),
 			Parameters: []wallet.ContractParam{
 				newParam(smartcontract.SignatureType, "parameter0"),
 				newParam(smartcontract.SignatureType, "parameter1"),
@@ -49,7 +49,7 @@ func TestParameterContext_AddSignatureSimpleContract(t *testing.T) {
 
 	c := NewParameterContext("Neo.Core.ContractTransaction", tx)
 	ctr := &wallet.Contract{
-		Script:     emit.GetVerificationScript(pub.Bytes()),
+		Script:     emit.GetNEO3VerificationScript(pub.Bytes()),
 		Parameters: []wallet.ContractParam{newParam(smartcontract.SignatureType, "parameter0")},
 	}
 	require.NoError(t, c.AddSignature(ctr, pub, sig))

--- a/pkg/smartcontract/context/context_test.go
+++ b/pkg/smartcontract/context/context_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/vm"
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
 	"github.com/nspcc-dev/neo-go/pkg/wallet"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,7 @@ func TestParameterContext_AddSignatureSimpleContract(t *testing.T) {
 	t.Run("invalid contract", func(t *testing.T) {
 		c := NewParameterContext("Neo.Core.ContractTransaction", tx)
 		ctr := &wallet.Contract{
-			Script: pub.GetVerificationScript(),
+			Script: emit.GetVerificationScript(pub.Bytes()),
 			Parameters: []wallet.ContractParam{
 				newParam(smartcontract.SignatureType, "parameter0"),
 				newParam(smartcontract.SignatureType, "parameter1"),
@@ -48,7 +49,7 @@ func TestParameterContext_AddSignatureSimpleContract(t *testing.T) {
 
 	c := NewParameterContext("Neo.Core.ContractTransaction", tx)
 	ctr := &wallet.Contract{
-		Script:     pub.GetVerificationScript(),
+		Script:     emit.GetVerificationScript(pub.Bytes()),
 		Parameters: []wallet.ContractParam{newParam(smartcontract.SignatureType, "parameter0")},
 	}
 	require.NoError(t, c.AddSignature(ctr, pub, sig))

--- a/pkg/vm/emit/emit.go
+++ b/pkg/vm/emit/emit.go
@@ -180,13 +180,23 @@ func InteropNameToID(name []byte) uint32 {
 	return binary.LittleEndian.Uint32(h[:4])
 }
 
-// GetVerificationScript returns NEO VM bytecode with CHECKSIG command for the
+// GetNEO3VerificationScript returns NEO3 VM bytecode with CHECKSIG command for the
 // bytes given.
-func GetVerificationScript(b []byte) []byte {
+func GetNEO3VerificationScript(b []byte) []byte {
 	buf := io.NewBufBinWriter()
 	Bytes(buf.BinWriter, b)
 	Opcode(buf.BinWriter, opcode.PUSHNULL)
 	Syscall(buf.BinWriter, "Neo.Crypto.ECDsaVerify")
 
+	return buf.Bytes()
+}
+
+// GetNEO2VerificationScript returns NEO2 VM bytecode with CHECKSIG command for the
+// bytes given.
+func GetNEO2VerificationScript(b []byte) []byte {
+	buf := io.NewBufBinWriter()
+	buf.WriteB(0x21) // PUSHBYTES33
+	buf.WriteBytes(b)
+	buf.WriteB(0xAC) // CHECKSIG
 	return buf.Bytes()
 }

--- a/pkg/vm/emit/emit.go
+++ b/pkg/vm/emit/emit.go
@@ -179,3 +179,14 @@ func InteropNameToID(name []byte) uint32 {
 	h := sha256.Sum256(name)
 	return binary.LittleEndian.Uint32(h[:4])
 }
+
+// GetVerificationScript returns NEO VM bytecode with CHECKSIG command for the
+// bytes given.
+func GetVerificationScript(b []byte) []byte {
+	buf := io.NewBufBinWriter()
+	Bytes(buf.BinWriter, b)
+	Opcode(buf.BinWriter, opcode.PUSHNULL)
+	Syscall(buf.BinWriter, "Neo.Crypto.ECDsaVerify")
+
+	return buf.Bytes()
+}

--- a/pkg/wallet/account.go
+++ b/pkg/wallet/account.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
 )
 
@@ -116,7 +117,7 @@ func (a *Account) getVerificationScript() []byte {
 	if a.Contract != nil {
 		return a.Contract.Script
 	}
-	return a.PrivateKey().PublicKey().GetVerificationScript()
+	return emit.GetVerificationScript(a.PrivateKey().PublicKey().Bytes())
 }
 
 // Decrypt decrypts the EncryptedWIF with the given passphrase returning error
@@ -216,7 +217,7 @@ func newAccountFromPrivateKey(p *keys.PrivateKey) *Account {
 		Address:    pubAddr,
 		wif:        wif,
 		Contract: &Contract{
-			Script:     pubKey.GetVerificationScript(),
+			Script:     emit.GetVerificationScript(pubKey.Bytes()),
 			Parameters: getContractParams(1),
 		},
 	}

--- a/pkg/wallet/account.go
+++ b/pkg/wallet/account.go
@@ -117,7 +117,7 @@ func (a *Account) getVerificationScript() []byte {
 	if a.Contract != nil {
 		return a.Contract.Script
 	}
-	return emit.GetVerificationScript(a.PrivateKey().PublicKey().Bytes())
+	return emit.GetNEO3VerificationScript(a.PrivateKey().PublicKey().Bytes())
 }
 
 // Decrypt decrypts the EncryptedWIF with the given passphrase returning error
@@ -217,7 +217,7 @@ func newAccountFromPrivateKey(p *keys.PrivateKey) *Account {
 		Address:    pubAddr,
 		wif:        wif,
 		Contract: &Contract{
-			Script:     emit.GetVerificationScript(pubKey.Bytes()),
+			Script:     emit.GetNEO3VerificationScript(pubKey.Bytes()),
 			Parameters: getContractParams(1),
 		},
 	}

--- a/pkg/wallet/account.go
+++ b/pkg/wallet/account.go
@@ -208,7 +208,7 @@ func (a *Account) ConvertMultisig(m int, pubs []*keys.PublicKey) error {
 // newAccountFromPrivateKey creates a wallet from the given PrivateKey.
 func newAccountFromPrivateKey(p *keys.PrivateKey) *Account {
 	pubKey := p.PublicKey()
-	pubAddr := p.Address()
+	pubAddr := p.NEO3Address()
 	wif := p.WIF()
 
 	a := &Account{

--- a/pkg/wallet/account.go
+++ b/pkg/wallet/account.go
@@ -128,7 +128,7 @@ func (a *Account) Decrypt(passphrase string) error {
 	if a.EncryptedWIF == "" {
 		return errors.New("no encrypted wif in the account")
 	}
-	a.privateKey, err = keys.NEP2Decrypt(a.EncryptedWIF, passphrase)
+	a.privateKey, err = keys.NEP2DecryptNEO3(a.EncryptedWIF, passphrase)
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func NewAccountFromWIF(wif string) (*Account, error) {
 
 // NewAccountFromEncryptedWIF creates a new Account from the given encrypted WIF.
 func NewAccountFromEncryptedWIF(wif string, pass string) (*Account, error) {
-	priv, err := keys.NEP2Decrypt(wif, pass)
+	priv, err := keys.NEP2DecryptNEO3(wif, pass)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #1110.

To get rid of `address.Prefix` inside of `keys` package (see [comment](https://github.com/nspcc-dev/neo-go/pull/1115#discussion_r446064683)) I had to split all of this methods into NEO2 and NEO3 versions. Not sure it's a good decision.