### PR TITLE
transaction: drop old attributes

### DIFF
--- a/integration/performance_test.go
+++ b/integration/performance_test.go
@@ -83,7 +83,7 @@ func getTX(t *testing.B, wif *keys.WIF) *transaction.Transaction {
 	tx.Sender = fromAddressHash
 	tx.Attributes = append(tx.Attributes,
 		transaction.Attribute{
-			Usage: transaction.Description,
+			Usage: transaction.DescriptionURL,
 			Data:  []byte(randString(10)),
 		})
 	return tx

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1166,12 +1166,6 @@ func (bc *Blockchain) verifyTx(t *transaction.Transaction, block *block.Block) e
 		}
 	}
 
-	for _, a := range t.Attributes {
-		if a.Usage == transaction.ECDH02 || a.Usage == transaction.ECDH03 {
-			return errors.Errorf("invalid attribute's usage = %s ", a.Usage)
-		}
-	}
-
 	return bc.verifyTxWitnesses(t, block)
 }
 

--- a/pkg/core/interop_neo_test.go
+++ b/pkg/core/interop_neo_test.go
@@ -285,7 +285,7 @@ func createVMAndTX(t *testing.T) (*vm.VM, *transaction.Transaction, *interop.Con
 
 	bytes := make([]byte, 1)
 	attributes := append(tx.Attributes, transaction.Attribute{
-		Usage: transaction.Description,
+		Usage: transaction.DescriptionURL,
 		Data:  bytes,
 	})
 

--- a/pkg/core/mempool/mem_pool_test.go
+++ b/pkg/core/mempool/mem_pool_test.go
@@ -70,7 +70,7 @@ func TestOverCapacity(t *testing.T) {
 	for i := 0; i < mempoolSize; i++ {
 		tx := transaction.New(netmode.UnitTestNet, []byte{byte(opcode.PUSH1)}, 0)
 		tx.Attributes = append(tx.Attributes, transaction.Attribute{
-			Usage: transaction.Hash1,
+			Usage: transaction.DescriptionURL,
 			Data:  util.Uint256{1, 2, 3, 4}.BytesBE(),
 		})
 		tx.NetworkFee = 10000
@@ -84,7 +84,7 @@ func TestOverCapacity(t *testing.T) {
 	// Less prioritized txes are not allowed anymore.
 	tx := transaction.New(netmode.UnitTestNet, []byte{byte(opcode.PUSH1)}, 0)
 	tx.Attributes = append(tx.Attributes, transaction.Attribute{
-		Usage: transaction.Hash1,
+		Usage: transaction.DescriptionURL,
 		Data:  util.Uint256{1, 2, 3, 4}.BytesBE(),
 	})
 	tx.NetworkFee = 100

--- a/pkg/core/transaction/attr_usage.go
+++ b/pkg/core/transaction/attr_usage.go
@@ -7,44 +7,5 @@ type AttrUsage uint8
 
 // List of valid attribute usages.
 const (
-	ContractHash   AttrUsage = 0x00
-	ECDH02         AttrUsage = 0x02
-	ECDH03         AttrUsage = 0x03
-	Vote           AttrUsage = 0x30
-	CertURL        AttrUsage = 0x80
 	DescriptionURL AttrUsage = 0x81
-	Description    AttrUsage = 0x90
-
-	Hash1  AttrUsage = 0xa1
-	Hash2  AttrUsage = 0xa2
-	Hash3  AttrUsage = 0xa3
-	Hash4  AttrUsage = 0xa4
-	Hash5  AttrUsage = 0xa5
-	Hash6  AttrUsage = 0xa6
-	Hash7  AttrUsage = 0xa7
-	Hash8  AttrUsage = 0xa8
-	Hash9  AttrUsage = 0xa9
-	Hash10 AttrUsage = 0xaa
-	Hash11 AttrUsage = 0xab
-	Hash12 AttrUsage = 0xac
-	Hash13 AttrUsage = 0xad
-	Hash14 AttrUsage = 0xae
-	Hash15 AttrUsage = 0xaf
-
-	Remark   AttrUsage = 0xf0
-	Remark1  AttrUsage = 0xf1
-	Remark2  AttrUsage = 0xf2
-	Remark3  AttrUsage = 0xf3
-	Remark4  AttrUsage = 0xf4
-	Remark5  AttrUsage = 0xf5
-	Remark6  AttrUsage = 0xf6
-	Remark7  AttrUsage = 0xf7
-	Remark8  AttrUsage = 0xf8
-	Remark9  AttrUsage = 0xf9
-	Remark10 AttrUsage = 0xfa
-	Remark11 AttrUsage = 0xfb
-	Remark12 AttrUsage = 0xfc
-	Remark13 AttrUsage = 0xfd
-	Remark14 AttrUsage = 0xfe
-	Remark15 AttrUsage = 0xff
 )

--- a/pkg/core/transaction/attribute.go
+++ b/pkg/core/transaction/attribute.go
@@ -1,7 +1,7 @@
 package transaction
 
 import (
-	"encoding/hex"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,27 +25,12 @@ type attrJSON struct {
 func (attr *Attribute) DecodeBinary(br *io.BinReader) {
 	attr.Usage = AttrUsage(br.ReadB())
 
-	// very special case
-	if attr.Usage == ECDH02 || attr.Usage == ECDH03 {
-		attr.Data = make([]byte, 33)
-		attr.Data[0] = byte(attr.Usage)
-		br.ReadBytes(attr.Data[1:])
-		return
-	}
 	var datasize uint64
 	switch attr.Usage {
-	case ContractHash, Vote, Hash1, Hash2, Hash3, Hash4, Hash5,
-		Hash6, Hash7, Hash8, Hash9, Hash10, Hash11, Hash12, Hash13,
-		Hash14, Hash15:
-		datasize = 32
 	case DescriptionURL:
 		// It's not VarUint as per C# implementation, dunno why
 		var urllen = br.ReadB()
 		datasize = uint64(urllen)
-	case Description, Remark, Remark1, Remark2, Remark3, Remark4,
-		Remark5, Remark6, Remark7, Remark8, Remark9, Remark10, Remark11,
-		Remark12, Remark13, Remark14, Remark15:
-		datasize = br.ReadVarUint()
 	default:
 		br.Err = fmt.Errorf("failed decoding TX attribute usage: 0x%2x", int(attr.Usage))
 		return
@@ -58,17 +43,8 @@ func (attr *Attribute) DecodeBinary(br *io.BinReader) {
 func (attr *Attribute) EncodeBinary(bw *io.BinWriter) {
 	bw.WriteB(byte(attr.Usage))
 	switch attr.Usage {
-	case ECDH02, ECDH03:
-		bw.WriteBytes(attr.Data[1:])
-	case Description, Remark, Remark1, Remark2, Remark3, Remark4,
-		Remark5, Remark6, Remark7, Remark8, Remark9, Remark10, Remark11,
-		Remark12, Remark13, Remark14, Remark15:
-		bw.WriteVarBytes(attr.Data)
 	case DescriptionURL:
 		bw.WriteB(byte(len(attr.Data)))
-		fallthrough
-	case ContractHash, Vote, Hash1, Hash2, Hash3, Hash4, Hash5, Hash6,
-		Hash7, Hash8, Hash9, Hash10, Hash11, Hash12, Hash13, Hash14, Hash15:
 		bw.WriteBytes(attr.Data)
 	default:
 		bw.Err = fmt.Errorf("failed encoding TX attribute usage: 0x%2x", attr.Usage)
@@ -79,7 +55,7 @@ func (attr *Attribute) EncodeBinary(bw *io.BinWriter) {
 func (attr *Attribute) MarshalJSON() ([]byte, error) {
 	return json.Marshal(attrJSON{
 		Usage: attr.Usage.String(),
-		Data:  hex.EncodeToString(attr.Data),
+		Data:  base64.StdEncoding.EncodeToString(attr.Data),
 	})
 }
 
@@ -90,87 +66,13 @@ func (attr *Attribute) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	binData, err := hex.DecodeString(aj.Data)
+	binData, err := base64.StdEncoding.DecodeString(aj.Data)
 	if err != nil {
 		return err
 	}
 	switch aj.Usage {
-	case "ContractHash":
-		attr.Usage = ContractHash
-	case "ECDH02":
-		attr.Usage = ECDH02
-	case "ECDH03":
-		attr.Usage = ECDH03
-	case "Vote":
-		attr.Usage = Vote
-	case "CertURL":
-		attr.Usage = CertURL
 	case "DescriptionURL":
 		attr.Usage = DescriptionURL
-	case "Description":
-		attr.Usage = Description
-	case "Hash1":
-		attr.Usage = Hash1
-	case "Hash2":
-		attr.Usage = Hash2
-	case "Hash3":
-		attr.Usage = Hash3
-	case "Hash4":
-		attr.Usage = Hash4
-	case "Hash5":
-		attr.Usage = Hash5
-	case "Hash6":
-		attr.Usage = Hash6
-	case "Hash7":
-		attr.Usage = Hash7
-	case "Hash8":
-		attr.Usage = Hash8
-	case "Hash9":
-		attr.Usage = Hash9
-	case "Hash10":
-		attr.Usage = Hash10
-	case "Hash11":
-		attr.Usage = Hash11
-	case "Hash12":
-		attr.Usage = Hash12
-	case "Hash13":
-		attr.Usage = Hash13
-	case "Hash14":
-		attr.Usage = Hash14
-	case "Hash15":
-		attr.Usage = Hash15
-	case "Remark":
-		attr.Usage = Remark
-	case "Remark1":
-		attr.Usage = Remark1
-	case "Remark2":
-		attr.Usage = Remark2
-	case "Remark3":
-		attr.Usage = Remark3
-	case "Remark4":
-		attr.Usage = Remark4
-	case "Remark5":
-		attr.Usage = Remark5
-	case "Remark6":
-		attr.Usage = Remark6
-	case "Remark7":
-		attr.Usage = Remark7
-	case "Remark8":
-		attr.Usage = Remark8
-	case "Remark9":
-		attr.Usage = Remark9
-	case "Remark10":
-		attr.Usage = Remark10
-	case "Remark11":
-		attr.Usage = Remark11
-	case "Remark12":
-		attr.Usage = Remark12
-	case "Remark13":
-		attr.Usage = Remark13
-	case "Remark14":
-		attr.Usage = Remark14
-	case "Remark15":
-		attr.Usage = Remark15
 	default:
 		return errors.New("wrong Usage")
 

--- a/pkg/core/transaction/attrusage_string.go
+++ b/pkg/core/transaction/attrusage_string.go
@@ -8,84 +8,17 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[ContractHash-0]
-	_ = x[ECDH02-2]
-	_ = x[ECDH03-3]
-	_ = x[Vote-48]
-	_ = x[CertURL-128]
 	_ = x[DescriptionURL-129]
-	_ = x[Description-144]
-	_ = x[Hash1-161]
-	_ = x[Hash2-162]
-	_ = x[Hash3-163]
-	_ = x[Hash4-164]
-	_ = x[Hash5-165]
-	_ = x[Hash6-166]
-	_ = x[Hash7-167]
-	_ = x[Hash8-168]
-	_ = x[Hash9-169]
-	_ = x[Hash10-170]
-	_ = x[Hash11-171]
-	_ = x[Hash12-172]
-	_ = x[Hash13-173]
-	_ = x[Hash14-174]
-	_ = x[Hash15-175]
-	_ = x[Remark-240]
-	_ = x[Remark1-241]
-	_ = x[Remark2-242]
-	_ = x[Remark3-243]
-	_ = x[Remark4-244]
-	_ = x[Remark5-245]
-	_ = x[Remark6-246]
-	_ = x[Remark7-247]
-	_ = x[Remark8-248]
-	_ = x[Remark9-249]
-	_ = x[Remark10-250]
-	_ = x[Remark11-251]
-	_ = x[Remark12-252]
-	_ = x[Remark13-253]
-	_ = x[Remark14-254]
-	_ = x[Remark15-255]
 }
 
-const (
-	_AttrUsage_name_0 = "ContractHash"
-	_AttrUsage_name_1 = "ECDH02ECDH03"
-	_AttrUsage_name_2 = "Vote"
-	_AttrUsage_name_3 = "CertURLDescriptionURL"
-	_AttrUsage_name_4 = "Description"
-	_AttrUsage_name_5 = "Hash1Hash2Hash3Hash4Hash5Hash6Hash7Hash8Hash9Hash10Hash11Hash12Hash13Hash14Hash15"
-	_AttrUsage_name_6 = "RemarkRemark1Remark2Remark3Remark4Remark5Remark6Remark7Remark8Remark9Remark10Remark11Remark12Remark13Remark14Remark15"
-)
+const _AttrUsage_name = "DescriptionURL"
 
-var (
-	_AttrUsage_index_1 = [...]uint8{0, 6, 12}
-	_AttrUsage_index_3 = [...]uint8{0, 7, 21}
-	_AttrUsage_index_5 = [...]uint8{0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 51, 57, 63, 69, 75, 81}
-	_AttrUsage_index_6 = [...]uint8{0, 6, 13, 20, 27, 34, 41, 48, 55, 62, 69, 77, 85, 93, 101, 109, 117}
-)
+var _AttrUsage_index = [...]uint8{0, 14}
 
 func (i AttrUsage) String() string {
-	switch {
-	case i == 0:
-		return _AttrUsage_name_0
-	case 2 <= i && i <= 3:
-		i -= 2
-		return _AttrUsage_name_1[_AttrUsage_index_1[i]:_AttrUsage_index_1[i+1]]
-	case i == 48:
-		return _AttrUsage_name_2
-	case 128 <= i && i <= 129:
-		i -= 128
-		return _AttrUsage_name_3[_AttrUsage_index_3[i]:_AttrUsage_index_3[i+1]]
-	case i == 144:
-		return _AttrUsage_name_4
-	case 161 <= i && i <= 175:
-		i -= 161
-		return _AttrUsage_name_5[_AttrUsage_index_5[i]:_AttrUsage_index_5[i+1]]
-	case 240 <= i && i <= 255:
-		i -= 240
-		return _AttrUsage_name_6[_AttrUsage_index_6[i]:_AttrUsage_index_6[i+1]]
-	default:
-		return "AttrUsage(" + strconv.FormatInt(int64(i), 10) + ")"
+	i -= 129
+	if i >= AttrUsage(len(_AttrUsage_index)-1) {
+		return "AttrUsage(" + strconv.FormatInt(int64(i+129), 10) + ")"
 	}
+	return _AttrUsage_name[_AttrUsage_index[i]:_AttrUsage_index[i+1]]
 }


### PR DESCRIPTION
They're not supported in Neo 3. Also change data encoding to base64 following
Neo 3 changes.
