### PR TITLE
rpc: set transaction's script for test invocation

### DIFF
--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -833,6 +833,7 @@ func (s *Server) invokeFunction(reqParams request.Params) (interface{}, *respons
 	if err != nil {
 		return nil, response.NewInternalServerError("can't create invocation script", err)
 	}
+	tx.Script = script
 	return s.runScriptInVM(script, tx), nil
 }
 
@@ -855,6 +856,7 @@ func (s *Server) invokescript(reqParams request.Params) (interface{}, *response.
 		}
 		tx.Cosigners = cosigners
 	}
+	tx.Script = script
 	return s.runScriptInVM(script, tx), nil
 }
 


### PR DESCRIPTION
GetScriptContainer() interop can try to get this transaction and this attempt
will lead to hash calculation with transaction serialization, but transaction
can't be successfully serialized if it doesn't have a script set, so this
makes test invocations fail.