### PR TITLE
network: copy peers for Shutdown iteration

### DIFF
--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -191,7 +191,7 @@ func (s *Server) Shutdown() {
 	s.log.Info("shutting down server", zap.Int("peers", s.PeerCount()))
 	s.transport.Close()
 	s.discovery.Close()
-	for p := range s.peers {
+	for p := range s.Peers() {
 		p.Disconnect(errServerShutdown)
 	}
 	s.bQueue.discard()


### PR DESCRIPTION
We can't lock them (or there will be a deadlock), but we need to fix this:

fatal error: concurrent map iteration and map write

goroutine 1 [running]:
runtime.throw(0xdec086, 0x26)
        /usr/lib64/go/1.12/src/runtime/panic.go:617 +0x72 fp=0xc02fec2bf8 sp=0xc02fec2bc8 pc=0x42d932
runtime.mapiternext(0xc02fec2d40)
        /usr/lib64/go/1.12/src/runtime/map.go:860 +0x597 fp=0xc02fec2c80 sp=0xc02fec2bf8 pc=0x40efe7
github.com/nspcc-dev/neo-go/pkg/network.(*Server).Shutdown(0xc0000fc160)
        /home/rik/dev/neo-go2/pkg/network/server.go:194 +0x238 fp=0xc02fec2db0 sp=0xc02fec2c80 pc=0xa89da8
github.com/nspcc-dev/neo-go/cli/server.startServer(0xc0000fcc60, 0x0, 0x0)
        /home/rik/dev/neo-go2/cli/server/server.go:399 +0x7a9 fp=0xc02fec3820 sp=0xc02fec2db0 pc=0xae2079
...
