### PR TITLE
interop: post-preview2 adjustment

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -1139,14 +1139,13 @@ func (c *codegen) getByteArray(expr ast.Expr) []byte {
 }
 
 func (c *codegen) convertSyscall(expr *ast.CallExpr, api, name string) {
-	api, ok := syscalls[api][name]
+	syscall, ok := syscalls[api][name]
 	if !ok {
-		c.prog.Err = fmt.Errorf("unknown VM syscall api: %s", name)
+		c.prog.Err = fmt.Errorf("unknown VM syscall api: %s.%s", api, name)
 		return
 	}
-	emit.Syscall(c.prog.BinWriter, api)
-	switch name {
-	case "GetTransaction", "GetBlock", "GetScriptContainer":
+	emit.Syscall(c.prog.BinWriter, syscall.API)
+	if syscall.ConvertResultToStruct {
 		c.emitConvert(stackitem.StructT)
 	}
 

--- a/pkg/compiler/syscall.go
+++ b/pkg/compiler/syscall.go
@@ -14,7 +14,7 @@ var syscalls = map[string]map[string]Syscall{
 	},
 	"blockchain": {
 		"GetBlock":                {"System.Blockchain.GetBlock", true},
-		"GetContract":             {"System.Blockchain.GetContract", false},
+		"GetContract":             {"System.Blockchain.GetContract", true},
 		"GetHeight":               {"System.Blockchain.GetHeight", false},
 		"GetTransaction":          {"System.Blockchain.GetTransaction", true},
 		"GetTransactionFromBlock": {"System.Blockchain.GetTransactionFromBlock", false},

--- a/pkg/compiler/syscall.go
+++ b/pkg/compiler/syscall.go
@@ -9,8 +9,10 @@ type Syscall struct {
 // All lists are sorted, keep 'em this way, please.
 var syscalls = map[string]map[string]Syscall{
 	"binary": {
-		"Deserialize": {"System.Binary.Deserialize", false},
-		"Serialize":   {"System.Binary.Serialize", false},
+		"Base64Decode": {"System.Binary.Base64Decode", false},
+		"Base64Encode": {"System.Binary.Base64Encode", false},
+		"Deserialize":  {"System.Binary.Deserialize", false},
+		"Serialize":    {"System.Binary.Serialize", false},
 	},
 	"blockchain": {
 		"GetBlock":                {"System.Blockchain.GetBlock", true},

--- a/pkg/compiler/syscall.go
+++ b/pkg/compiler/syscall.go
@@ -25,6 +25,7 @@ var syscalls = map[string]map[string]Syscall{
 		"CreateStandardAccount": {"System.Contract.CreateStandardAccount", false},
 		"Destroy":               {"System.Contract.Destroy", false},
 		"IsStandard":            {"System.Contract.IsStandard", false},
+		"GetCallFlags":          {"System.Contract.GetCallFlags", false},
 		"Update":                {"System.Contract.Update", false},
 	},
 	"crypto": {

--- a/pkg/compiler/syscall.go
+++ b/pkg/compiler/syscall.go
@@ -1,73 +1,78 @@
 package compiler
 
-var syscalls = map[string]map[string]string{
-	"binary": {
-		"Serialize":   "System.Binary.Serialize",
-		"Deserialize": "System.Binary.Deserialize",
-	},
-	"crypto": {
-		"ECDsaSecp256r1Verify":        "Neo.Crypto.VerifyWithECDsaSecp256r1",
-		"ECDsaSecp256k1Verify":        "Neo.Crypto.VerifyWithECDsaSecp256k1",
-		"ECDSASecp256r1CheckMultisig": "Neo.Crypto.CheckMultisigWithECDsaSecp256r1",
-		"ECDSASecp256k1CheckMultisig": "Neo.Crypto.CheckMultisigWithECDsaSecp256k1",
-	},
-	"enumerator": {
-		"Concat": "System.Enumerator.Concat",
-		"Create": "System.Enumerator.Create",
-		"Next":   "System.Enumerator.Next",
-		"Value":  "System.Enumerator.Value",
-	},
-	"json": {
-		"Serialize":   "System.Json.Serialize",
-		"Deserialize": "System.Json.Deserialize",
-	},
-	"storage": {
-		"ConvertContextToReadOnly": "System.Storage.AsReadOnly",
-		"Delete":                   "System.Storage.Delete",
-		"Find":                     "System.Storage.Find",
-		"Get":                      "System.Storage.Get",
-		"GetContext":               "System.Storage.GetContext",
-		"GetReadOnlyContext":       "System.Storage.GetReadOnlyContext",
-		"Put":                      "System.Storage.Put",
-	},
-	"runtime": {
-		"GetScriptContainer":     "System.Runtime.GetScriptContainer",
-		"GetCallingScriptHash":   "System.Runtime.GetCallingScriptHash",
-		"GetEntryScriptHash":     "System.Runtime.GetEntryScriptHash",
-		"GetExecutingScriptHash": "System.Runtime.GetExecutingScriptHash",
-		"GetNotifications":       "System.Runtime.GetNotifications",
-		"GetInvocationCounter":   "System.Runtime.GetInvocationCounter",
+// Syscall represents NEO or System syscall API with flag for proper AVM generation
+type Syscall struct {
+	API                   string
+	ConvertResultToStruct bool
+}
 
-		"GasLeft":      "System.Runtime.GasLeft",
-		"GetTrigger":   "System.Runtime.GetTrigger",
-		"CheckWitness": "System.Runtime.CheckWitness",
-		"Notify":       "System.Runtime.Notify",
-		"Log":          "System.Runtime.Log",
-		"GetTime":      "System.Runtime.GetTime",
+// All lists are sorted, keep 'em this way, please.
+var syscalls = map[string]map[string]Syscall{
+	"binary": {
+		"Deserialize": {"System.Binary.Deserialize", false},
+		"Serialize":   {"System.Binary.Serialize", false},
 	},
 	"blockchain": {
-		"GetBlock":                "System.Blockchain.GetBlock",
-		"GetContract":             "System.Blockchain.GetContract",
-		"GetHeight":               "System.Blockchain.GetHeight",
-		"GetTransaction":          "System.Blockchain.GetTransaction",
-		"GetTransactionFromBlock": "System.Blockchain.GetTransactionFromBlock",
-		"GetTransactionHeight":    "System.Blockchain.GetTransactionHeight",
+		"GetBlock":                {"System.Blockchain.GetBlock", true},
+		"GetContract":             {"System.Blockchain.GetContract", false},
+		"GetHeight":               {"System.Blockchain.GetHeight", false},
+		"GetTransaction":          {"System.Blockchain.GetTransaction", true},
+		"GetTransactionFromBlock": {"System.Blockchain.GetTransactionFromBlock", false},
+		"GetTransactionHeight":    {"System.Blockchain.GetTransactionHeight", false},
 	},
 	"contract": {
-		"Create":  "System.Contract.Create",
-		"Destroy": "System.Contract.Destroy",
-		"Update":  "System.Contract.Update",
-
-		"IsStandard":            "System.Contract.IsStandard",
-		"CreateStandardAccount": "System.Contract.CreateStandardAccount",
+		"Create":                {"System.Contract.Create", false},
+		"CreateStandardAccount": {"System.Contract.CreateStandardAccount", false},
+		"Destroy":               {"System.Contract.Destroy", false},
+		"IsStandard":            {"System.Contract.IsStandard", false},
+		"Update":                {"System.Contract.Update", false},
+	},
+	"crypto": {
+		"ECDsaSecp256k1Verify":        {"Neo.Crypto.VerifyWithECDsaSecp256k1", false},
+		"ECDSASecp256k1CheckMultisig": {"Neo.Crypto.CheckMultisigWithECDsaSecp256k1", false},
+		"ECDsaSecp256r1Verify":        {"Neo.Crypto.VerifyWithECDsaSecp256r1", false},
+		"ECDSASecp256r1CheckMultisig": {"Neo.Crypto.CheckMultisigWithECDsaSecp256r1", false},
+	},
+	"enumerator": {
+		"Concat": {"System.Enumerator.Concat", false},
+		"Create": {"System.Enumerator.Create", false},
+		"Next":   {"System.Enumerator.Next", false},
+		"Value":  {"System.Enumerator.Value", false},
 	},
 	"iterator": {
-		"Concat": "System.Iterator.Concat",
-		"Create": "System.Iterator.Create",
-		"Key":    "System.Iterator.Key",
-		"Keys":   "System.Iterator.Keys",
-		"Next":   "System.Enumerator.Next",
-		"Value":  "System.Enumerator.Value",
-		"Values": "System.Iterator.Values",
+		"Concat": {"System.Iterator.Concat", false},
+		"Create": {"System.Iterator.Create", false},
+		"Key":    {"System.Iterator.Key", false},
+		"Keys":   {"System.Iterator.Keys", false},
+		"Next":   {"System.Enumerator.Next", false},
+		"Value":  {"System.Enumerator.Value", false},
+		"Values": {"System.Iterator.Values", false},
+	},
+	"json": {
+		"Deserialize": {"System.Json.Deserialize", false},
+		"Serialize":   {"System.Json.Serialize", false},
+	},
+	"runtime": {
+		"GasLeft":                {"System.Runtime.GasLeft", false},
+		"GetInvocationCounter":   {"System.Runtime.GetInvocationCounter", false},
+		"GetCallingScriptHash":   {"System.Runtime.GetCallingScriptHash", false},
+		"GetEntryScriptHash":     {"System.Runtime.GetEntryScriptHash", false},
+		"GetExecutingScriptHash": {"System.Runtime.GetExecutingScriptHash", false},
+		"GetNotifications":       {"System.Runtime.GetNotifications", false},
+		"GetScriptContainer":     {"System.Runtime.GetScriptContainer", true},
+		"GetTime":                {"System.Runtime.GetTime", false},
+		"GetTrigger":             {"System.Runtime.GetTrigger", false},
+		"CheckWitness":           {"System.Runtime.CheckWitness", false},
+		"Log":                    {"System.Runtime.Log", false},
+		"Notify":                 {"System.Runtime.Notify", false},
+	},
+	"storage": {
+		"ConvertContextToReadOnly": {"System.Storage.AsReadOnly", false},
+		"Delete":                   {"System.Storage.Delete", false},
+		"Find":                     {"System.Storage.Find", false},
+		"Get":                      {"System.Storage.Get", false},
+		"GetContext":               {"System.Storage.GetContext", false},
+		"GetReadOnlyContext":       {"System.Storage.GetReadOnlyContext", false},
+		"Put":                      {"System.Storage.Put", false},
 	},
 }

--- a/pkg/compiler/syscall.go
+++ b/pkg/compiler/syscall.go
@@ -21,7 +21,7 @@ var syscalls = map[string]map[string]Syscall{
 		"GetTransactionHeight":    {"System.Blockchain.GetTransactionHeight", false},
 	},
 	"contract": {
-		"Create":                {"System.Contract.Create", false},
+		"Create":                {"System.Contract.Create", true},
 		"CreateStandardAccount": {"System.Contract.CreateStandardAccount", false},
 		"Destroy":               {"System.Contract.Destroy", false},
 		"IsStandard":            {"System.Contract.IsStandard", false},

--- a/pkg/core/interop_neo.go
+++ b/pkg/core/interop_neo.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"sort"
@@ -191,4 +192,23 @@ func runtimeSerialize(_ *interop.Context, v *vm.VM) error {
 // runtimeDeserialize deserializes ByteArray from a stack into an item.
 func runtimeDeserialize(_ *interop.Context, v *vm.VM) error {
 	return vm.RuntimeDeserialize(v)
+}
+
+// runtimeEncode encodes top stack item into a base64 string.
+func runtimeEncode(_ *interop.Context, v *vm.VM) error {
+	src := v.Estack().Pop().Bytes()
+	result := base64.StdEncoding.EncodeToString(src)
+	v.Estack().PushVal([]byte(result))
+	return nil
+}
+
+// runtimeDecode decodes top stack item from base64 string to byte array.
+func runtimeDecode(_ *interop.Context, v *vm.VM) error {
+	src := string(v.Estack().Pop().Bytes())
+	result, err := base64.StdEncoding.DecodeString(src)
+	if err != nil {
+		return err
+	}
+	v.Estack().PushVal(result)
+	return nil
 }

--- a/pkg/core/interop_system.go
+++ b/pkg/core/interop_system.go
@@ -422,6 +422,9 @@ func contractCallEx(ic *interop.Context, v *vm.VM) error {
 	method := v.Estack().Pop().Item()
 	args := v.Estack().Pop().Item()
 	flags := smartcontract.CallFlag(int32(v.Estack().Pop().BigInt().Int64()))
+	if flags&^smartcontract.All != 0 {
+		return errors.New("call flags out of range")
+	}
 	return contractCallExInternal(ic, v, h, method, args, flags)
 }
 

--- a/pkg/core/interop_system.go
+++ b/pkg/core/interop_system.go
@@ -155,12 +155,12 @@ func bcGetTransactionFromBlock(ic *interop.Context, v *vm.VM) error {
 	if err != nil {
 		return err
 	}
+	index := v.Estack().Pop().BigInt().Int64()
 	block, err := ic.DAO.GetBlock(hash)
 	if err != nil || !isTraceableBlock(ic, block.Index) {
 		v.Estack().PushVal(stackitem.Null{})
 		return nil
 	}
-	index := v.Estack().Pop().BigInt().Int64()
 	if index < 0 || index >= int64(len(block.Transactions)) {
 		return errors.New("wrong transaction index")
 	}

--- a/pkg/core/interop_system.go
+++ b/pkg/core/interop_system.go
@@ -530,3 +530,9 @@ func contractCreateStandardAccount(ic *interop.Context, v *vm.VM) error {
 	v.Estack().PushVal(p.GetScriptHash().BytesBE())
 	return nil
 }
+
+// contractGetCallFlags returns current context calling flags.
+func contractGetCallFlags(_ *interop.Context, v *vm.VM) error {
+	v.Estack().PushVal(v.Context().GetCallFlags())
+	return nil
+}

--- a/pkg/core/interop_system.go
+++ b/pkg/core/interop_system.go
@@ -486,8 +486,17 @@ func contractIsStandard(ic *interop.Context, v *vm.VM) error {
 	}
 	var result bool
 	cs, _ := ic.DAO.GetContractState(u)
-	if cs == nil || vm.IsStandardContract(cs.Script) {
-		result = true
+	if cs != nil {
+		result = vm.IsStandardContract(cs.Script)
+	} else {
+		if tx, ok := ic.Container.(*transaction.Transaction); ok {
+			for _, witness := range tx.Scripts {
+				if witness.ScriptHash() == u {
+					result = vm.IsStandardContract(witness.VerificationScript)
+					break
+				}
+			}
+		}
 	}
 	v.Estack().PushVal(result)
 	return nil

--- a/pkg/core/interop_system_test.go
+++ b/pkg/core/interop_system_test.go
@@ -582,3 +582,12 @@ func TestContractUpdate(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestContractGetCallFlags(t *testing.T) {
+	v, ic, bc := createVM(t)
+	defer bc.Close()
+
+	v.LoadScriptWithHash([]byte{byte(opcode.RET)}, util.Uint160{1, 2, 3}, smartcontract.All)
+	require.NoError(t, contractGetCallFlags(ic, v))
+	require.Equal(t, int64(smartcontract.All), v.Estack().Pop().Value().(*big.Int).Int64())
+}

--- a/pkg/core/interops.go
+++ b/pkg/core/interops.go
@@ -69,6 +69,8 @@ func getInteropFromSlice(ic *interop.Context, slice []interop.Function) func(uin
 
 // All lists are sorted, keep 'em this way, please.
 var systemInterops = []interop.Function{
+	{Name: "System.Binary.Base64Decode", Func: runtimeDecode, Price: 100000},
+	{Name: "System.Binary.Base64Encode", Func: runtimeEncode, Price: 100000},
 	{Name: "System.Binary.Deserialize", Func: runtimeDeserialize, Price: 500000},
 	{Name: "System.Binary.Serialize", Func: runtimeSerialize, Price: 100000},
 	{Name: "System.Blockchain.GetBlock", Func: bcGetBlock, Price: 2500000,

--- a/pkg/core/interops.go
+++ b/pkg/core/interops.go
@@ -93,6 +93,7 @@ var systemInterops = []interop.Function{
 	{Name: "System.Contract.Destroy", Func: contractDestroy, Price: 1000000,
 		AllowedTriggers: trigger.Application, RequiredFlags: smartcontract.AllowModifyStates},
 	{Name: "System.Contract.IsStandard", Func: contractIsStandard, Price: 30000},
+	{Name: "System.Contract.GetCallFlags", Func: contractGetCallFlags, Price: 30000},
 	{Name: "System.Contract.Update", Func: contractUpdate, Price: 0,
 		AllowedTriggers: trigger.Application, RequiredFlags: smartcontract.AllowModifyStates},
 	{Name: "System.Enumerator.Concat", Func: enumerator.Concat, Price: 400},

--- a/pkg/interop/binary/binary.go
+++ b/pkg/interop/binary/binary.go
@@ -16,3 +16,15 @@ func Serialize(item interface{}) []byte {
 func Deserialize(b []byte) interface{} {
 	return nil
 }
+
+// Base64Encode encodes given byte slice into a base64 string and returns byte
+// representation of this string. It uses `System.Binary.Base64Encode` interop.
+func Base64Encode(b []byte) []byte {
+	return nil
+}
+
+// Base64Decode decodes given base64 string represented as a byte slice into
+// byte slice. It uses `System.Binary.Base64Decode` interop.
+func Base64Decode(b []byte) []byte {
+	return nil
+}

--- a/pkg/interop/blockchain/blockchain.go
+++ b/pkg/interop/blockchain/blockchain.go
@@ -3,6 +3,8 @@ Package blockchain provides functions to access various blockchain data.
 */
 package blockchain
 
+import "github.com/nspcc-dev/neo-go/pkg/interop/contract"
+
 // Transaction represents a NEO transaction. It's similar to Transaction class
 // in Neo .net framework.
 type Transaction struct {
@@ -53,14 +55,6 @@ type Block struct {
 	TransactionsLength int
 }
 
-// Contract represents a Neo contract and is used in interop functions.
-type Contract struct {
-	Script     []byte
-	Manifest   []byte
-	HasStorage bool
-	IsPayable  bool
-}
-
 // GetHeight returns current block height (index of the last accepted block).
 // Note that when transaction is being run as a part of new block this block is
 // considered as not yet accepted (persisted) and thus you'll get an index of
@@ -103,6 +97,6 @@ func GetTransactionHeight(hash []byte) int {
 // format represented as a slice of 20 bytes). Refer to the `contract` package
 // for details on how to use the returned structure. This function uses
 // `System.Blockchain.GetContract` syscall.
-func GetContract(scriptHash []byte) Contract {
-	return Contract{}
+func GetContract(scriptHash []byte) contract.Contract {
+	return contract.Contract{}
 }

--- a/pkg/interop/blockchain/blockchain.go
+++ b/pkg/interop/blockchain/blockchain.go
@@ -3,10 +3,6 @@ Package blockchain provides functions to access various blockchain data.
 */
 package blockchain
 
-import (
-	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
-)
-
 // Transaction represents a NEO transaction. It's similar to Transaction class
 // in Neo .net framework.
 type Transaction struct {
@@ -57,6 +53,14 @@ type Block struct {
 	TransactionsLength int
 }
 
+// Contract represents a Neo contract and is used in interop functions.
+type Contract struct {
+	Script     []byte
+	Manifest   []byte
+	HasStorage bool
+	IsPayable  bool
+}
+
 // GetHeight returns current block height (index of the last accepted block).
 // Note that when transaction is being run as a part of new block this block is
 // considered as not yet accepted (persisted) and thus you'll get an index of
@@ -99,6 +103,6 @@ func GetTransactionHeight(hash []byte) int {
 // format represented as a slice of 20 bytes). Refer to the `contract` package
 // for details on how to use the returned structure. This function uses
 // `System.Blockchain.GetContract` syscall.
-func GetContract(scriptHash []byte) contract.Contract {
-	return contract.Contract{}
+func GetContract(scriptHash []byte) Contract {
+	return Contract{}
 }

--- a/pkg/interop/contract/contract.go
+++ b/pkg/interop/contract/contract.go
@@ -28,8 +28,8 @@ func Create(script []byte, manifest []byte) Contract {
 // Create. The old contract will be deleted by this call, if it has any storage
 // associated it will be migrated to the new contract. New contract is returned.
 // This function uses `System.Contract.Update` syscall.
-func Update(script []byte, manifest []byte) Contract {
-	return Contract{}
+func Update(script []byte, manifest []byte) {
+	return
 }
 
 // Destroy deletes calling contract (the one that calls Destroy) from the

--- a/pkg/interop/contract/contract.go
+++ b/pkg/interop/contract/contract.go
@@ -4,10 +4,15 @@ Package contract provides functions to work with contracts.
 package contract
 
 // Contract represents a Neo contract and is used in interop functions. It's
-// an opaque data structure that you can manipulate with using functions from
+// a data structure that you can manipulate with using functions from
 // this package. It's similar in function to the Contract class in the Neo .net
 // framework.
-type Contract struct{}
+type Contract struct {
+	Script     []byte
+	Manifest   []byte
+	HasStorage bool
+	IsPayable  bool
+}
 
 // Create creates a new contract using a set of input parameters:
 //     script      contract's bytecode (limited in length by 1M)

--- a/pkg/interop/contract/contract.go
+++ b/pkg/interop/contract/contract.go
@@ -49,3 +49,9 @@ func IsStandard(h []byte) bool {
 func CreateStandardAccount(pub []byte) []byte {
 	return nil
 }
+
+// GetCallFlags returns calling flags which execution context was created with.
+// This function uses `System.Contract.GetCallFlags` syscall.
+func GetCallFlags() int64 {
+	return 0
+}

--- a/pkg/smartcontract/manifest/manifest.go
+++ b/pkg/smartcontract/manifest/manifest.go
@@ -85,6 +85,20 @@ func (m *Manifest) CanCall(toCall *Manifest, method string) bool {
 	return false
 }
 
+// IsValid checks whether the given hash is the one specified in manifest and
+// verifies it against all the keys in manifest groups.
+func (m *Manifest) IsValid(hash util.Uint160) bool {
+	if m.ABI.Hash != hash {
+		return false
+	}
+	for _, g := range m.Groups {
+		if !g.IsValid(hash) {
+			return false
+		}
+	}
+	return true
+}
+
 // MarshalJSON implements json.Marshaler interface.
 func (m *Manifest) MarshalJSON() ([]byte, error) {
 	features := make(map[string]bool)

--- a/pkg/smartcontract/manifest/method.go
+++ b/pkg/smartcontract/manifest/method.go
@@ -4,8 +4,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 
+	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/util"
 )
 
 // Parameter represents smartcontract's parameter's definition.
@@ -58,6 +60,11 @@ func DefaultEntryPoint() *Method {
 		},
 		ReturnType: smartcontract.AnyType,
 	}
+}
+
+// IsValid checks whether group's signature corresponds to the given hash.
+func (g *Group) IsValid(h util.Uint160) bool {
+	return g.PublicKey.Verify(g.Signature, hash.Sha256(h.BytesBE()).BytesBE())
 }
 
 // MarshalJSON implements json.Marshaler interface.


### PR DESCRIPTION
First part of #1055.

1. Were added:
    - System.Binary.Base64Encode
    - System.Binary.Base64Decode
    - System.Contract.GetCallFlags

2. Were fixed:
    - System.Blockchain.GetContract
    - System.Blockchain.GetTransactionFromBlock
    - System.Contract.CallEx
    - System.Contract.Create
    - System.Contract.IsStandard
    - System.Contract.Update

3. No errors in:
    - System.Binary.Deserialize
    - System.Binary.Serialize
    - System.Blockchain.GetBlock
    - System.Blockchain.GetHeight
    - System.Blockchain.GetTransaction
    - System.Blockchain.GetTransactionHeight
    - System.Contract.CreateStandardAccount
    - System.Contract.Destroy

4. Separate adjustment is needed (see #1181)
    - System.Contract.Call
    - System.Contract.CallEx

