### PR TITLE
core: fix stateroot height update for testnet

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1844,9 +1844,9 @@ func (bc *Blockchain) updateStateHeight(newHeight uint32) error {
 	h, err := bc.dao.GetCurrentStateRootHeight()
 	if err != nil {
 		return errors.WithMessage(err, "can't get current state root height")
-	} else if newHeight == h+1 {
+	} else if (h < bc.config.StateRootEnableIndex && newHeight == bc.config.StateRootEnableIndex) || newHeight == h+1 {
 		updateStateHeightMetric(newHeight)
-		return bc.dao.PutCurrentStateRootHeight(h + 1)
+		return bc.dao.PutCurrentStateRootHeight(newHeight)
 	}
 	return nil
 }

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -630,7 +630,7 @@ func (s *Server) handleRootsCmd(p Peer, rs *payload.StateRoots) error {
 	}
 	h := s.chain.StateHeight()
 	if h < s.chain.GetConfig().StateRootEnableIndex {
-		h = s.chain.GetConfig().StateRootEnableIndex
+		h = s.chain.GetConfig().StateRootEnableIndex - 1
 	}
 	for i := range rs.Roots {
 		if rs.Roots[i].Index <= h {


### PR DESCRIPTION
When synchronizing with stateroot-enabled network from genesis and if
stateroot is not enabled in block zero we were failing to update state height
because initially it's updated with a jump from 0 to StateRootEnableIndex, so
we should allow that to happen to have correct state height.
