### PR TITLE
Generate multitransfer NEP5 transactions on client

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     command: "node --config-path /config --privnet"
     volumes:
       - ../config/protocol.privnet.docker.single.yml:/config/protocol.privnet.yml
-      - ./wallets/wallet1.json:/wallet1.json
+      - ./wallets/wallet1_solo.json:/wallet1.json
       - volume_chain:/chains
     networks:
       neo_go_network:

--- a/config/protocol.privnet.docker.single.yml
+++ b/config/protocol.privnet.docker.single.yml
@@ -39,6 +39,7 @@ ApplicationConfiguration:
   RPC:
     Enabled: true
     EnableCORSWorkaround: false
+    MaxGasInvoke: 10
     Port: 30333
   Prometheus:
     Enabled: true


### PR DESCRIPTION
I have introduces another command and left `transfer` untouched for backwards compatibility and ease of use. Maybe we should just change API for `transfer`.
Usage example: `./neogo wallet nep5 multitransfer -w wallet1_solo.json --from NVNvVRW5Q5naSx2k2iZm7xRgtRNGuZppAK --token neo -r http://127.0.0.1:30333 NYqxsNMHxDg3T19APYP27mBZFfauC4zngR:2 NVNvVRW5Q5naSx2k2iZm7xRgtRNGuZppAK:3`

Don't allow to transfer multiple assets in a single command as it seems overcomplicated.

Close #940 .