### PR TITLE
crypto: fix failing Secp256r1 test

### DIFF
--- a/pkg/core/interop_neo_test.go
+++ b/pkg/core/interop_neo_test.go
@@ -213,6 +213,12 @@ func TestECDSAVerify(t *testing.T) {
 		pub[0] = 0xFF // invalid prefix
 		runCase(t, true, false, sign, pub, msg)
 	})
+
+	t.Run("invalid message", func(t *testing.T) {
+		sign := priv.Sign(msg)
+		runCase(t, false, false, sign, priv.PublicKey().Bytes(),
+			stackitem.NewArray([]stackitem.Item{stackitem.NewByteArray(msg)}))
+	})
 }
 
 func TestRuntimeEncode(t *testing.T) {

--- a/pkg/core/interop_neo_test.go
+++ b/pkg/core/interop_neo_test.go
@@ -210,7 +210,7 @@ func TestECDSAVerify(t *testing.T) {
 	t.Run("invalid public key", func(t *testing.T) {
 		sign := priv.Sign(msg)
 		pub := priv.PublicKey().Bytes()
-		pub = pub[10:]
+		pub[0] = 0xFF // invalid prefix
 		runCase(t, true, false, sign, pub, msg)
 	})
 }

--- a/pkg/crypto/keys/private_key.go
+++ b/pkg/crypto/keys/private_key.go
@@ -136,8 +136,11 @@ func (p *PrivateKey) Sign(data []byte) []byte {
 	)
 
 	r, s := rfc6979.SignECDSA(privateKey, digest[:], sha256.New)
+	return getSignatureSlice(privateKey.Curve, r, s)
+}
 
-	params := privateKey.Curve.Params()
+func getSignatureSlice(curve elliptic.Curve, r, s *big.Int) []byte {
+	params := curve.Params()
 	curveOrderByteSize := params.P.BitLen() / 8
 	rBytes, sBytes := r.Bytes(), s.Bytes()
 	signature := make([]byte, curveOrderByteSize*2)


### PR DESCRIPTION
1. Pad R and S when computing signature in `Secp256k1` test.
2. Ensure public key is invalid in interop test.

Fix #1223.
