### PR TITLE
Support pointers in compiler

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -9,6 +9,8 @@ there are some important deviations that you need to be aware of that make it
 a dialect of Go rather than a complete port of the language:
  * `make()` ane `new()` are not supported, most of the time you can substitute
    them with composite literals
+ * pointers are supported only for struct literals, one can't take an address
+   of an arbitrary variable
  * there is no real distinction between different integer types, all of them
    work as big.Int in Go with a limit of 256 bit in width, so you can use
    `int` for just about anything. This is the way integers work in Neo VM and

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -610,6 +610,16 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 		c.emitLoadConst(c.typeAndValueOf(n))
 		return nil
 
+	case *ast.StarExpr:
+		_, ok := c.getStruct(c.typeOf(n.X))
+		if !ok {
+			c.prog.Err = errors.New("dereferencing is only supported on structs")
+			return nil
+		}
+		ast.Walk(c, n.X)
+		c.emitConvert(stackitem.StructT)
+		return nil
+
 	case *ast.Ident:
 		if tv := c.typeAndValueOf(n); tv.Value != nil {
 			c.emitLoadConst(tv)

--- a/pkg/compiler/pointer_test.go
+++ b/pkg/compiler/pointer_test.go
@@ -1,0 +1,18 @@
+package compiler_test
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestAddressOfLiteral(t *testing.T) {
+	src := `package foo
+	type Foo struct { A int	}
+	func Main() int {
+		f := &Foo{}
+		setA(f, 3)
+		return f.A
+	}
+	func setA(s *Foo, a int) { s.A = a }`
+	eval(t, src, big.NewInt(3))
+}

--- a/pkg/compiler/pointer_test.go
+++ b/pkg/compiler/pointer_test.go
@@ -16,3 +16,15 @@ func TestAddressOfLiteral(t *testing.T) {
 	func setA(s *Foo, a int) { s.A = a }`
 	eval(t, src, big.NewInt(3))
 }
+
+func TestPointerDereference(t *testing.T) {
+	src := `package foo
+	type Foo struct { A int	}
+	func Main() int {
+		f := &Foo{A: 4}
+		setA(*f, 3)
+		return f.A
+	}
+	func setA(s Foo, a int) { s.A = a }`
+	eval(t, src, big.NewInt(4))
+}

--- a/pkg/compiler/pointer_test.go
+++ b/pkg/compiler/pointer_test.go
@@ -28,3 +28,41 @@ func TestPointerDereference(t *testing.T) {
 	func setA(s Foo, a int) { s.A = a }`
 	eval(t, src, big.NewInt(4))
 }
+
+func TestStructArgCopy(t *testing.T) {
+	t.Run("Simple", func(t *testing.T) {
+		src := `package foo                                                                                                                                                                                                                                                                                                                                                                  
+		type Foo struct { A int }                                                                                                                                                                                                                                                                                                                                                            
+		func Main() int {                                                                                                                                                                                                                                                                                                                                                                    
+			f := Foo{A: 4}                                                                                                                                                                                                                                                                                                                                                               
+			setA(f, 3)                                                                                                                                                                                                                                                                                                                                                                   
+			return f.A                                                                                                                                                                                                                                                                                                                                                                   
+		}                                                                                                                                                                                                                                                                                                                                                                                    
+		func setA(s Foo, a int) { s.A = a }`
+		eval(t, src, big.NewInt(4))
+	})
+	t.Run("StructField", func(t *testing.T) {
+		src := `package foo
+		type Bar struct { A int }
+		type Foo struct { B Bar }                                                                                                                                                                                                                                                                                                                                                            
+		func Main() int {                                                                                                                                                                                                                                                                                                                                                                    
+			f := Foo{B: Bar{A: 4}}                                                                                                                                                                                                                                                                                                                                                               
+			setA(f, 3)                                                                                                                                                                                                                                                                                                                                                                   
+			return f.B.A                                                                                                                                                                                                                                                                                                                                                                   
+		}                                                                                                                                                                                                                                                                                                                                                                                    
+		func setA(s Foo, a int) { s.B.A = a }`
+		eval(t, src, big.NewInt(4))
+	})
+	t.Run("StructPointerField", func(t *testing.T) {
+		src := `package foo
+		type Bar struct { A int }
+		type Foo struct { B *Bar }                                                                                                                                                                                                                                                                                                                                                            
+		func Main() int {                                                                                                                                                                                                                                                                                                                                                                    
+			f := Foo{B: &Bar{A: 4}}                                                                                                                                                                                                                                                                                                                                                               
+			setA(f, 3)                                                                                                                                                                                                                                                                                                                                                                   
+			return f.B.A                                                                                                                                                                                                                                                                                                                                                                   
+		}                                                                                                                                                                                                                                                                                                                                                                                    
+		func setA(s Foo, a int) { s.B.A = a }`
+		eval(t, src, big.NewInt(3))
+	})
+}


### PR DESCRIPTION
Close #1032 .

Things to discuss:
1. Do we need to support taking pointers from the variable? This can be done by using `Array(Struct)` wrapper instead of `Struct -> Array`, but doesn't worth the effort IMO.
2. Do we need to copy struct when passing it as a parameter? This way we become more compatible with the Go spec, but again does it worth the effort? While simple struct copy can be done with `Struct -> Array -> Struct` conversion, this won't copy non-pointer struct fields, so we need to do something different.