### PR TITLE
network: handle length mismatch in decompression routine

### DIFF
--- a/pkg/network/compress.go
+++ b/pkg/network/compress.go
@@ -30,5 +30,8 @@ func decompress(source []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return dest[:size], nil
+	if uint32(size) != length {
+		return nil, errors.New("decompressed payload size doesn't match header")
+	}
+	return dest, nil
 }


### PR DESCRIPTION
It's a protocol level error when uncompressed payload size doesn't match the
one specified in the header.
