### PR TITLE
Allow to use `vm parse` directly

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/cli/server"
 	"github.com/nspcc-dev/neo-go/cli/smartcontract"
+	"github.com/nspcc-dev/neo-go/cli/util"
 	"github.com/nspcc-dev/neo-go/cli/vm"
 	"github.com/nspcc-dev/neo-go/cli/wallet"
 	"github.com/nspcc-dev/neo-go/pkg/config"
@@ -21,6 +22,7 @@ func main() {
 	ctl.Commands = append(ctl.Commands, smartcontract.NewCommands()...)
 	ctl.Commands = append(ctl.Commands, wallet.NewCommands()...)
 	ctl.Commands = append(ctl.Commands, vm.NewCommands()...)
+	ctl.Commands = append(ctl.Commands, util.NewCommands()...)
 
 	if err := ctl.Run(os.Args); err != nil {
 		panic(err)

--- a/cli/util/convert.go
+++ b/cli/util/convert.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"fmt"
+
+	vmcli "github.com/nspcc-dev/neo-go/pkg/vm/cli"
+	"github.com/urfave/cli"
+)
+
+func NewCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:  "util",
+			Usage: "Various helper commands",
+			Subcommands: []cli.Command{
+				{
+					Name:  "convert",
+					Usage: "Convert provided argument into other possible formats",
+					UsageText: `convert <arg>
+
+<arg> is an argument which is tried to be interpreted as an item of different types
+        and converted to other formats. Strings are escaped and output in quotes.`,
+					Action: handleParse,
+				},
+			},
+		},
+	}
+}
+
+func handleParse(ctx *cli.Context) error {
+	res, err := vmcli.Parse(ctx.Args())
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+	fmt.Print(res)
+	return nil
+}

--- a/pkg/vm/cli/cli.go
+++ b/pkg/vm/cli/cli.go
@@ -454,11 +454,20 @@ func (c *VMCLI) Run() error {
 }
 
 func handleParse(c *ishell.Context) {
-	if len(c.Args) < 1 {
-		c.Err(errors.New("missing argument"))
+	res, err := Parse(c.Args)
+	if err != nil {
+		c.Err(err)
 		return
 	}
-	arg := c.Args[0]
+	c.Print(res)
+}
+
+// Parse converts it's argument to other formats.
+func Parse(args []string) (string, error) {
+	if len(args) < 1 {
+		return "", errors.New("missing argument")
+	}
+	arg := args[0]
 	buf := bytes.NewBuffer(nil)
 	if val, err := strconv.ParseInt(arg, 10, 64); err == nil {
 		bs := bigint.ToBytes(big.NewInt(val))
@@ -493,14 +502,12 @@ func handleParse(c *ishell.Context) {
 	buf = bytes.NewBuffer(nil)
 	w := tabwriter.NewWriter(buf, 0, 0, 4, ' ', 0)
 	if _, err := w.Write(out); err != nil {
-		c.Err(err)
-		return
+		return "", err
 	}
 	if err := w.Flush(); err != nil {
-		c.Err(err)
-		return
+		return "", err
 	}
-	c.Print(string(buf.Bytes()))
+	return string(buf.Bytes()), nil
 }
 
 func parseArgs(args []string) ([]stackitem.Item, error) {

--- a/pkg/vm/cli/cli.go
+++ b/pkg/vm/cli/cli.go
@@ -500,7 +500,7 @@ func Parse(args []string) (string, error) {
 
 	out := buf.Bytes()
 	buf = bytes.NewBuffer(nil)
-	w := tabwriter.NewWriter(buf, 0, 0, 4, ' ', 0)
+	w := tabwriter.NewWriter(buf, 0, 4, 4, '\t', 0)
 	if _, err := w.Write(out); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Close #1257 . 