### PR TITLE
rpc: use lowercase JSON field names for StateHeight

### DIFF
--- a/pkg/rpc/client/rpc_test.go
+++ b/pkg/rpc/client/rpc_test.go
@@ -626,7 +626,7 @@ var rpcClientTestCases = map[string][]rpcClientTestCase{
 			invoke: func(c *Client) (interface{}, error) {
 				return c.GetStateHeight()
 			},
-			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{"blockHeight":208,"stateHeight":200}}`,
+			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{"blockheight":208,"stateheight":200}}`,
 			result: func(c *Client) interface{} {
 				return &result.StateHeight{
 					BlockHeight: 208,

--- a/pkg/rpc/response/result/mpt.go
+++ b/pkg/rpc/response/result/mpt.go
@@ -11,8 +11,8 @@ import (
 
 // StateHeight is a result of getstateheight RPC.
 type StateHeight struct {
-	BlockHeight uint32 `json:"blockHeight"`
-	StateHeight uint32 `json:"stateHeight"`
+	BlockHeight uint32 `json:"blockheight"`
+	StateHeight uint32 `json:"stateheight"`
 }
 
 // ProofWithKey represens key-proof pair.


### PR DESCRIPTION
Follow neo-project/neo#1808. Note that this is an incompatible change, but
this feature is still considered to be experimental upstream.
