### PR TITLE
core: restrict verification scripts with CallFlags.None

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1463,7 +1463,7 @@ func (bc *Blockchain) verifyHashAgainstScript(hash util.Uint160, witness *transa
 	vm := interopCtx.SpawnVM()
 	vm.SetPriceGetter(getPrice)
 	vm.GasLimit = gas
-	vm.LoadScriptWithFlags(verification, smartcontract.ReadOnly)
+	vm.LoadScriptWithFlags(verification, smartcontract.NoneFlag)
 	vm.LoadScript(witness.InvocationScript)
 	if useKeys {
 		bc.keyCacheLock.RLock()


### PR DESCRIPTION
Follow neo-project/neo#1776. Looks very suspicious to me as it severely limits
verification scripts, but we have to be compatible at this point.
