### PR TITLE
Port `getnep5transfers` changes to master

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -805,21 +805,23 @@ func (bc *Blockchain) processNEP5Transfer(cache *dao.Cached, h util.Uint256, b *
 	}
 }
 
-// GetNEP5TransferLog returns NEP5 transfer log for the acc.
-func (bc *Blockchain) GetNEP5TransferLog(acc util.Uint160) *state.NEP5TransferLog {
+// ForEachNEP5Transfer executes f for each nep5 transfer in log.
+func (bc *Blockchain) ForEachNEP5Transfer(acc util.Uint160, f func(*state.NEP5Transfer) error) error {
 	balances, err := bc.dao.GetNEP5Balances(acc)
 	if err != nil {
 		return nil
 	}
-	result := new(state.NEP5TransferLog)
 	for i := uint32(0); i <= balances.NextTransferBatch; i++ {
 		lg, err := bc.dao.GetNEP5TransferLog(acc, i)
 		if err != nil {
 			return nil
 		}
-		result.Raw = append(result.Raw, lg.Raw...)
+		err = lg.ForEach(f)
+		if err != nil {
+			return err
+		}
 	}
-	return result
+	return nil
 }
 
 // GetNEP5Balances returns NEP5 balances for the acc.

--- a/pkg/core/blockchainer/blockchainer.go
+++ b/pkg/core/blockchainer/blockchainer.go
@@ -30,6 +30,7 @@ type Blockchainer interface {
 	GetContractScriptHash(id int32) (util.Uint160, error)
 	GetEnrollments() ([]state.Validator, error)
 	GetGoverningTokenBalance(acc util.Uint160) (*big.Int, uint32)
+	ForEachNEP5Transfer(util.Uint160, func(*state.NEP5Transfer) error) error
 	GetHeaderHash(int) util.Uint256
 	GetHeader(hash util.Uint256) (*block.Header, error)
 	CurrentHeaderHash() util.Uint256
@@ -39,7 +40,6 @@ type Blockchainer interface {
 	GetAccountState(util.Uint160) *state.Account
 	GetAppExecResult(util.Uint256) (*state.AppExecResult, error)
 	GetNextBlockValidators() ([]*keys.PublicKey, error)
-	GetNEP5TransferLog(util.Uint160) *state.NEP5TransferLog
 	GetNEP5Balances(util.Uint160) *state.NEP5Balances
 	GetValidators() ([]*keys.PublicKey, error)
 	GetStandByCommittee() keys.PublicKeys

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -94,7 +94,7 @@ func (chain testChain) GetAccountState(util.Uint160) *state.Account {
 func (chain testChain) GetNextBlockValidators() ([]*keys.PublicKey, error) {
 	panic("TODO")
 }
-func (chain testChain) GetNEP5TransferLog(util.Uint160) *state.NEP5TransferLog {
+func (chain testChain) ForEachNEP5Transfer(util.Uint160, func(*state.NEP5Transfer) error) error {
 	panic("TODO")
 }
 func (chain testChain) GetNEP5Balances(util.Uint160) *state.NEP5Balances {

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -541,9 +541,8 @@ func (s *Server) getNEP5Transfers(ps request.Params) (interface{}, *response.Err
 		Received: []result.NEP5Transfer{},
 		Sent:     []result.NEP5Transfer{},
 	}
-	lg := s.chain.GetNEP5TransferLog(u)
 	cache := make(map[int32]decimals)
-	err = lg.ForEach(func(tr *state.NEP5Transfer) error {
+	err = s.chain.ForEachNEP5Transfer(u, func(tr *state.NEP5Transfer) error {
 		d, err := s.getDecimals(tr.Asset, cache)
 		if err != nil {
 			return nil


### PR DESCRIPTION
Close #1280 .

1. Replace `GetNEP5TransferLog` with `ForEachNEP5Transfer`.
2. Allow to use timestamps in the request. (they are now in ms).