### PR TITLE
compiler: use constants in interops

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -261,7 +261,7 @@ func Main(operation string, args []interface{}) bool {
 	token := newToken()
 	trigger := runtime.GetTrigger()
 
-	if trigger == runtime.Verification() {
+	if trigger == runtime.Verification {
 		isOwner := runtime.CheckWitness(token.Owner)
 		if isOwner {
 			return true
@@ -269,7 +269,7 @@ func Main(operation string, args []interface{}) bool {
 		return false
 	}
 
-	if trigger == runtime.Application() {
+	if trigger == runtime.Application {
 		if operation == "mintTokens" {
 			token.AddToCirculation(100)
 		}

--- a/examples/runtime/runtime.go
+++ b/examples/runtime/runtime.go
@@ -13,12 +13,12 @@ func Main(operation string, args []interface{}) bool {
 	trigger := runtime.GetTrigger()
 
 	// Log owner upon Verification trigger
-	if trigger == runtime.Verification() {
+	if trigger == runtime.Verification {
 		return CheckWitness()
 	}
 
 	// Discerns between log and notify for this test
-	if trigger == runtime.Application() {
+	if trigger == runtime.Application {
 		return handleOperation(operation, args)
 	}
 

--- a/examples/token-sale/token_sale.go
+++ b/examples/token-sale/token_sale.go
@@ -112,7 +112,7 @@ func Main(operation string, args []interface{}) interface{} {
 
 	// This is used to verify if a transfer of system assets (NEO and Gas)
 	// involving this contract's address can proceed.
-	if trigger == runtime.Verification() {
+	if trigger == runtime.Verification {
 		// Check if the invoker is the owner of the contract.
 		if runtime.CheckWitness(cfg.Owner) {
 			return true
@@ -120,7 +120,7 @@ func Main(operation string, args []interface{}) interface{} {
 		// Otherwise TODO
 		return false
 	}
-	if trigger == runtime.Application() {
+	if trigger == runtime.Application {
 		return handleOperation(operation, args, ctx, cfg)
 	}
 	return true

--- a/pkg/interop/runtime/runtime.go
+++ b/pkg/interop/runtime/runtime.go
@@ -4,6 +4,13 @@ It has similar function to Runtime class in .net framwork for Neo.
 */
 package runtime
 
+// Trigger values to compare with GetTrigger result.
+const (
+	System       byte = 0x01
+	Application  byte = 0x40
+	Verification byte = 0x20
+)
+
 // CheckWitness verifies if the given script hash (160-bit BE value in a 20 byte
 // slice) or key (compressed serialized 33-byte form) is one of the signers of
 // this invocation. It uses `System.Runtime.CheckWitness` syscall.
@@ -41,24 +48,6 @@ func GetTime() int {
 // `System.Runtime.GetTrigger` syscall.
 func GetTrigger() byte {
 	return 0x00
-}
-
-// System returns the System trigger type value to compare with
-// GetTrigger return value.
-func System() byte {
-	return 0x01
-}
-
-// Application returns the Application trigger type value to compare with
-// GetTrigger return value.
-func Application() byte {
-	return 0x40
-}
-
-// Verification returns the Verification trigger type value to compare with
-// GetTrigger return value.
-func Verification() byte {
-	return 0x20
 }
 
 // GasLeft returns the amount of gas available for the current execution.


### PR DESCRIPTION
We now support using exported constants, so there is no
need in declaring functions. All functions from `interop/`
are not to be compiled.

Fix #1298.
