### PR TITLE
rpc/client: provide scripts in AddNetworkFee

### DIFF
--- a/cli/wallet/validator.go
+++ b/cli/wallet/validator.go
@@ -100,7 +100,7 @@ func handleCandidate(ctx *cli.Context, method string) error {
 	w := io.NewBufBinWriter()
 	emit.AppCallWithOperationAndArgs(w.BinWriter, client.NeoContractHash, method, acc.PrivateKey().PublicKey().Bytes())
 	emit.Opcode(w.BinWriter, opcode.ASSERT)
-	tx, err := c.CreateTxFromScript(w.Bytes(), acc, int64(gas))
+	tx, err := c.CreateTxFromScript(w.Bytes(), acc, -1, int64(gas))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	} else if err = acc.SignTx(tx); err != nil {
@@ -155,7 +155,7 @@ func handleVote(ctx *cli.Context) error {
 	emit.AppCallWithOperationAndArgs(w.BinWriter, client.NeoContractHash, "vote", addr.BytesBE(), pubArg)
 	emit.Opcode(w.BinWriter, opcode.ASSERT)
 
-	tx, err := c.CreateTxFromScript(w.Bytes(), acc, int64(gas))
+	tx, err := c.CreateTxFromScript(w.Bytes(), acc, -1, int64(gas))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -9,7 +9,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/block"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
-	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/rpc/request"
@@ -513,27 +512,25 @@ func (c *Client) CalculateValidUntilBlock() (uint32, error) {
 }
 
 // AddNetworkFee adds network fee for each witness script and optional extra
-// network fee to transaction.
-func (c *Client) AddNetworkFee(tx *transaction.Transaction, extraFee int64, acc *wallet.Account) error {
-	size := io.GetVarSize(tx)
-	if acc.Contract != nil {
-		netFee, sizeDelta := core.CalculateNetworkFee(acc.Contract.Script)
-		tx.NetworkFee += netFee
-		size += sizeDelta
+// network fee to transaction. `accs` is an array signer's accounts.
+func (c *Client) AddNetworkFee(tx *transaction.Transaction, extraFee int64, accs ...*wallet.Account) error {
+	if len(tx.Signers) != len(accs) {
+		return errors.New("number of signers must match number of scripts")
 	}
-	for _, cosigner := range tx.Signers {
-		script := acc.Contract.Script
-		if !cosigner.Account.Equals(hash.Hash160(acc.Contract.Script)) {
+	size := io.GetVarSize(tx)
+	for i, cosigner := range tx.Signers {
+		if accs[i].Contract.Script == nil {
 			contract, err := c.GetContractState(cosigner.Account)
-			if err != nil {
-				return err
+			if err == nil {
+				if contract == nil {
+					continue
+				}
+				netFee, sizeDelta := core.CalculateNetworkFee(contract.Script)
+				tx.NetworkFee += netFee
+				size += sizeDelta
 			}
-			if contract == nil {
-				continue
-			}
-			script = contract.Script
 		}
-		netFee, sizeDelta := core.CalculateNetworkFee(script)
+		netFee, sizeDelta := core.CalculateNetworkFee(accs[i].Contract.Script)
 		tx.NetworkFee += netFee
 		size += sizeDelta
 	}

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -9,7 +9,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/block"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
-	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/rpc/request"
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result"
@@ -410,26 +409,7 @@ func (c *Client) SignAndPushInvocationTx(script []byte, acc *wallet.Account, sys
 	var txHash util.Uint256
 	var err error
 
-	tx := transaction.New(c.opts.Network, script, sysfee)
-	tx.SystemFee = sysfee
-
-	addr, err := address.StringToUint160(acc.Address)
-	if err != nil {
-		return txHash, fmt.Errorf("failed to get address: %w", err)
-	}
-	tx.Signers = getSigners(addr, cosigners)
-
-	validUntilBlock, err := c.CalculateValidUntilBlock()
-	if err != nil {
-		return txHash, fmt.Errorf("failed to add validUntilBlock to transaction: %w", err)
-	}
-	tx.ValidUntilBlock = validUntilBlock
-
-	err = c.AddNetworkFee(tx, int64(netfee), acc)
-	if err != nil {
-		return txHash, fmt.Errorf("failed to add network fee: %w", err)
-	}
-
+	tx, err := c.CreateTxFromScript(script, acc, sysfee, int64(netfee), cosigners...)
 	if err = acc.SignTx(tx); err != nil {
 		return txHash, fmt.Errorf("failed to sign tx: %w", err)
 	}

--- a/pkg/rpc/server/client_test.go
+++ b/pkg/rpc/server/client_test.go
@@ -109,10 +109,10 @@ func TestAddNetworkFee(t *testing.T) {
 
 	t.Run("Multi", func(t *testing.T) {
 		tx := transaction.New(testchain.Network(), []byte{byte(opcode.PUSH1)}, 0)
-		accs := getAccounts(t, 3)
-		pubs := keys.PublicKeys{accs[1].PrivateKey().PublicKey(), accs[2].PrivateKey().PublicKey()}
-		require.NoError(t, accs[1].ConvertMultisig(1, pubs))
-		require.NoError(t, accs[2].ConvertMultisig(1, pubs))
+		accs := getAccounts(t, 4)
+		pubs := keys.PublicKeys{accs[1].PrivateKey().PublicKey(), accs[2].PrivateKey().PublicKey(), accs[3].PrivateKey().PublicKey()}
+		require.NoError(t, accs[1].ConvertMultisig(2, pubs))
+		require.NoError(t, accs[2].ConvertMultisig(2, pubs))
 		tx.Signers = []transaction.Signer{
 			{
 				Account: accs[0].PrivateKey().GetScriptHash(),
@@ -126,6 +126,7 @@ func TestAddNetworkFee(t *testing.T) {
 		require.NoError(t, c.AddNetworkFee(tx, 10, accs[0], accs[1]))
 		require.NoError(t, accs[0].SignTx(tx))
 		require.NoError(t, accs[1].SignTx(tx))
+		require.NoError(t, accs[2].SignTx(tx))
 		cFee, _ := core.CalculateNetworkFee(accs[0].Contract.Script)
 		cFeeM, _ := core.CalculateNetworkFee(accs[1].Contract.Script)
 		require.Equal(t, int64(io.GetVarSize(tx))*feePerByte+cFee+cFeeM+10, tx.NetworkFee)

--- a/pkg/rpc/server/client_test.go
+++ b/pkg/rpc/server/client_test.go
@@ -156,3 +156,16 @@ func TestSignAndPushInvocationTx(t *testing.T) {
 	require.Equal(t, h, tx.Hash())
 	require.EqualValues(t, 30, tx.SystemFee)
 }
+
+func TestPing(t *testing.T) {
+	chain, rpcSrv, httpSrv := initServerWithInMemoryChain(t)
+	defer chain.Close()
+
+	c, err := client.New(context.Background(), httpSrv.URL, client.Options{Network: testchain.Network()})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Ping())
+	require.NoError(t, rpcSrv.Shutdown())
+	httpSrv.Close()
+	require.Error(t, c.Ping())
+}

--- a/pkg/rpc/server/client_test.go
+++ b/pkg/rpc/server/client_test.go
@@ -5,9 +5,16 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/config/netmode"
+	"github.com/nspcc-dev/neo-go/pkg/core"
+	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/internal/testchain"
+	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/rpc/client"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/nspcc-dev/neo-go/pkg/wallet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,5 +62,72 @@ func TestClient_NEP5(t *testing.T) {
 		b, err := c.NEP5BalanceOf(h, acc)
 		require.NoError(t, err)
 		require.EqualValues(t, 877, b)
+	})
+}
+
+func TestAddNetworkFee(t *testing.T) {
+	chain, rpcSrv, httpSrv := initServerWithInMemoryChain(t)
+	defer chain.Close()
+	defer rpcSrv.Shutdown()
+
+	c, err := client.New(context.Background(), httpSrv.URL, client.Options{Network: testchain.Network()})
+	require.NoError(t, err)
+
+	getAccounts := func(t *testing.T, n int) []*wallet.Account {
+		accs := make([]*wallet.Account, n)
+		var err error
+		for i := range accs {
+			accs[i], err = wallet.NewAccount()
+			require.NoError(t, err)
+		}
+		return accs
+	}
+
+	feePerByte := chain.FeePerByte()
+
+	t.Run("Invalid", func(t *testing.T) {
+		tx := transaction.New(testchain.Network(), []byte{byte(opcode.PUSH1)}, 0)
+		accs := getAccounts(t, 2)
+		tx.Signers = []transaction.Signer{{
+			Account: accs[0].PrivateKey().GetScriptHash(),
+			Scopes:  transaction.CalledByEntry,
+		}}
+		require.Error(t, c.AddNetworkFee(tx, 10, accs[0], accs[1]))
+	})
+	t.Run("Simple", func(t *testing.T) {
+		tx := transaction.New(testchain.Network(), []byte{byte(opcode.PUSH1)}, 0)
+		accs := getAccounts(t, 1)
+		tx.Signers = []transaction.Signer{{
+			Account: accs[0].PrivateKey().GetScriptHash(),
+			Scopes:  transaction.CalledByEntry,
+		}}
+		require.NoError(t, c.AddNetworkFee(tx, 10, accs[0]))
+		require.NoError(t, accs[0].SignTx(tx))
+		cFee, _ := core.CalculateNetworkFee(accs[0].Contract.Script)
+		require.Equal(t, int64(io.GetVarSize(tx))*feePerByte+cFee+10, tx.NetworkFee)
+	})
+
+	t.Run("Multi", func(t *testing.T) {
+		tx := transaction.New(testchain.Network(), []byte{byte(opcode.PUSH1)}, 0)
+		accs := getAccounts(t, 3)
+		pubs := keys.PublicKeys{accs[1].PrivateKey().PublicKey(), accs[2].PrivateKey().PublicKey()}
+		require.NoError(t, accs[1].ConvertMultisig(1, pubs))
+		require.NoError(t, accs[2].ConvertMultisig(1, pubs))
+		tx.Signers = []transaction.Signer{
+			{
+				Account: accs[0].PrivateKey().GetScriptHash(),
+				Scopes:  transaction.CalledByEntry,
+			},
+			{
+				Account: hash.Hash160(accs[1].Contract.Script),
+				Scopes:  transaction.Global,
+			},
+		}
+		require.NoError(t, c.AddNetworkFee(tx, 10, accs[0], accs[1]))
+		require.NoError(t, accs[0].SignTx(tx))
+		require.NoError(t, accs[1].SignTx(tx))
+		cFee, _ := core.CalculateNetworkFee(accs[0].Contract.Script)
+		cFeeM, _ := core.CalculateNetworkFee(accs[1].Contract.Script)
+		require.Equal(t, int64(io.GetVarSize(tx))*feePerByte+cFee+cFeeM+10, tx.NetworkFee)
 	})
 }

--- a/pkg/vm/context.go
+++ b/pkg/vm/context.go
@@ -221,7 +221,7 @@ func (c *Context) Equals(s stackitem.Item) bool {
 
 func (c *Context) atBreakPoint() bool {
 	for _, n := range c.breakPoints {
-		if n == c.ip {
+		if n == c.nextip {
 			return true
 		}
 	}

--- a/pkg/vm/debug_test.go
+++ b/pkg/vm/debug_test.go
@@ -1,0 +1,42 @@
+package vm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVM_Debug(t *testing.T) {
+	prog := makeProgram(opcode.CALL, 3, opcode.RET,
+		opcode.PUSH2, opcode.PUSH3, opcode.ADD, opcode.RET)
+	t.Run("BreakPoint", func(t *testing.T) {
+		v := load(prog)
+		v.AddBreakPoint(3)
+		v.AddBreakPoint(5)
+		require.NoError(t, v.Run())
+		require.Equal(t, 3, v.Context().NextIP())
+		require.NoError(t, v.Run())
+		require.Equal(t, 5, v.Context().NextIP())
+		require.NoError(t, v.Run())
+		require.Equal(t, 1, v.estack.len)
+		require.Equal(t, big.NewInt(5), v.estack.Top().Value())
+	})
+	t.Run("StepInto", func(t *testing.T) {
+		v := load(prog)
+		require.NoError(t, v.StepInto())
+		require.Equal(t, 3, v.Context().NextIP())
+		require.NoError(t, v.StepOut())
+		require.Equal(t, 2, v.Context().NextIP())
+		require.Equal(t, 1, v.estack.len)
+		require.Equal(t, big.NewInt(5), v.estack.Top().Value())
+	})
+	t.Run("StepOver", func(t *testing.T) {
+		v := load(prog)
+		require.NoError(t, v.StepOver())
+		require.Equal(t, 2, v.Context().NextIP())
+		require.Equal(t, 1, v.estack.len)
+		require.Equal(t, big.NewInt(5), v.estack.Top().Value())
+	})
+}

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -516,7 +516,7 @@ func checkEnumeratorStack(t *testing.T, vm *VM, arr []stackitem.Item) {
 	}
 }
 
-func testIterableCreate(t *testing.T, typ string) {
+func testIterableCreate(t *testing.T, typ string, isByteArray bool) {
 	isIter := typ == "Iterator"
 	prog := getSyscallProg("System." + typ + ".Create")
 	prog = append(prog, getEnumeratorProg(2, isIter)...)
@@ -526,7 +526,12 @@ func testIterableCreate(t *testing.T, typ string) {
 		stackitem.NewBigInteger(big.NewInt(42)),
 		stackitem.NewByteArray([]byte{3, 2, 1}),
 	}
-	vm.estack.Push(&Element{value: stackitem.NewArray(arr)})
+	if isByteArray {
+		arr[1] = stackitem.Make(7)
+		vm.estack.PushVal([]byte{42, 7})
+	} else {
+		vm.estack.Push(&Element{value: stackitem.NewArray(arr)})
+	}
 
 	runVM(t, vm)
 	if isIter {
@@ -543,11 +548,13 @@ func testIterableCreate(t *testing.T, typ string) {
 }
 
 func TestEnumeratorCreate(t *testing.T) {
-	testIterableCreate(t, "Enumerator")
+	t.Run("Array", func(t *testing.T) { testIterableCreate(t, "Enumerator", false) })
+	t.Run("ByteArray", func(t *testing.T) { testIterableCreate(t, "Enumerator", true) })
 }
 
 func TestIteratorCreate(t *testing.T) {
-	testIterableCreate(t, "Iterator")
+	t.Run("Array", func(t *testing.T) { testIterableCreate(t, "Iterator", false) })
+	t.Run("ByteArray", func(t *testing.T) { testIterableCreate(t, "Iterator", true) })
 }
 
 func testIterableConcat(t *testing.T, typ string) {

--- a/pkg/wallet/account.go
+++ b/pkg/wallet/account.go
@@ -104,9 +104,17 @@ func (a *Account) SignTx(t *transaction.Transaction) error {
 	}
 	sign := a.privateKey.Sign(data)
 
+	verif := a.getVerificationScript()
+	invoc := append([]byte{byte(opcode.PUSHDATA1), 64}, sign...)
+	for i := range t.Scripts {
+		if bytes.Equal(t.Scripts[i].VerificationScript, verif) {
+			t.Scripts[i].InvocationScript = append(t.Scripts[i].InvocationScript, invoc...)
+			return nil
+		}
+	}
 	t.Scripts = append(t.Scripts, transaction.Witness{
-		InvocationScript:   append([]byte{byte(opcode.PUSHDATA1), 64}, sign...),
-		VerificationScript: a.getVerificationScript(),
+		InvocationScript:   invoc,
+		VerificationScript: verif,
 	})
 
 	return nil


### PR DESCRIPTION
To calculate network fee properly we must know type of every
signer (simple, multisig, contract). Providing scripts is the most
simple and flexible way to know this.

Also add tests for some functions from `client` package.
Close #1304.