### PR TITLE
Allow to import state roots from dump

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -287,7 +287,7 @@ func restoreDB(ctx *cli.Context) error {
 	}
 	i := dumpStart
 	for ; i < start; i++ {
-		_, err := readBlock(reader)
+		_, err := readBytes(reader)
 		if err != nil {
 			return cli.NewExitError(err, 1)
 		}
@@ -306,7 +306,7 @@ func restoreDB(ctx *cli.Context) error {
 			return cli.NewExitError("cancelled", 1)
 		default:
 		}
-		bytes, err := readBlock(reader)
+		bytes, err := readBytes(reader)
 		if err != nil {
 			return cli.NewExitError(err, 1)
 		}
@@ -342,8 +342,8 @@ func restoreDB(ctx *cli.Context) error {
 	return nil
 }
 
-// readBlock performs reading of block size and then bytes with the length equal to that size.
-func readBlock(reader *io.BinReader) ([]byte, error) {
+// readBytes performs reading of block size and then bytes with the length equal to that size.
+func readBytes(reader *io.BinReader) ([]byte, error) {
 	var size = reader.ReadU32LE()
 	bytes := make([]byte, size)
 	reader.ReadBytes(bytes)

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -272,7 +272,7 @@ func restoreDB(ctx *cli.Context) error {
 		dumpSize = reader.ReadU32LE()
 	}
 	if reader.Err != nil {
-		return cli.NewExitError(err, 1)
+		return cli.NewExitError(reader.Err, 1)
 	}
 	if start < dumpStart {
 		return cli.NewExitError(fmt.Errorf("input file start from %d block, can't import %d", dumpStart, start), 1)


### PR DESCRIPTION
Close #1307 .

Testing done:
1. Imported test dump, and exported it with roots.
2. Imported test dump with roots with no errors, including incremental import (`--count 1 --start x`).
3. Block dump files exported with and without `--state` argument don't differ.