### PR TITLE
core: fix getOnPersistWrapper for native contracts

### DIFF
--- a/pkg/core/native/native_nep5.go
+++ b/pkg/core/native/native_nep5.go
@@ -2,6 +2,7 @@ package native
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/dao"
@@ -303,6 +304,10 @@ func toUint160(s stackitem.Item) util.Uint160 {
 
 func getOnPersistWrapper(f func(ic *interop.Context) error) interop.Method {
 	return func(ic *interop.Context, _ []stackitem.Item) stackitem.Item {
-		return stackitem.NewBool(f(ic) == nil)
+		err := f(ic)
+		if err != nil {
+			panic(fmt.Errorf("OnPersist for native contract: %w", err))
+		}
+		return stackitem.Null{}
 	}
 }


### PR DESCRIPTION
According to manifest, OnPersist.ReturnType is void, so we shouldn't
return anything from it. It's not so important, as we drop this value at
the end of OnPersist invocation.