### PR TITLE
network: decode CMDNotFound

### DIFF
--- a/pkg/network/message.go
+++ b/pkg/network/message.go
@@ -159,6 +159,8 @@ func (m *Message) decodePayload() error {
 		p = &payload.MerkleBlock{}
 	case CMDPing, CMDPong:
 		p = &payload.Ping{}
+	case CMDNotFound:
+		p = &payload.Inventory{}
 	default:
 		return fmt.Errorf("can't decode command %s", m.Command.String())
 	}


### PR DESCRIPTION
We don't react on this command, but we should be able to decode it.