### PR TITLE
consensus: payloads from recovery messages are network-dependent too

### DIFF
--- a/pkg/consensus/recovery_message.go
+++ b/pkg/consensus/recovery_message.go
@@ -287,6 +287,7 @@ func getVerificationScript(i uint16, validators []crypto.PublicKey) []byte {
 
 func fromPayload(t messageType, recovery *Payload, p io.Serializable) *Payload {
 	return &Payload{
+		network: recovery.network,
 		message: &message{
 			Type:       t,
 			ViewNumber: recovery.message.ViewNumber,


### PR DESCRIPTION
Fixes wrong hash calculated for prepare request leading to bad prepare
response and inability to run heterogeneous 2+2 Go/C# nodes consensus.
