### PR TITLE
Fix MEMCPY, support `copy` and `make` in compiler

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -7,8 +7,8 @@ The neo-go compiler compiles Go programs to bytecode that the NEO virtual machin
 The compiler is mostly compatible with regular Go language specification, but
 there are some important deviations that you need to be aware of that make it
 a dialect of Go rather than a complete port of the language:
- * `make()` ane `new()` are not supported, most of the time you can substitute
-   them with composite literals
+ * `new()` is not supported, most of the time you can substitute structs with composite literals
+ * `make()` is supported for maps and slices with elements of basic types
  * pointers are supported only for struct literals, one can't take an address
    of an arbitrary variable
  * there is no real distinction between different integer types, all of them

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -9,6 +9,7 @@ there are some important deviations that you need to be aware of that make it
 a dialect of Go rather than a complete port of the language:
  * `new()` is not supported, most of the time you can substitute structs with composite literals
  * `make()` is supported for maps and slices with elements of basic types
+ * `copy()` is supported only for byte slices, because of underlying `MEMCPY` opcode
  * pointers are supported only for struct literals, one can't take an address
    of an arbitrary variable
  * there is no real distinction between different integer types, all of them

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// Go language builtin functions.
-	goBuiltins = []string{"len", "append", "panic"}
+	goBuiltins = []string{"len", "append", "panic", "make"}
 	// Custom builtin utility functions.
 	customBuiltins = []string{
 		"FromAddress", "Equals",

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// Go language builtin functions.
-	goBuiltins = []string{"len", "append", "panic", "make"}
+	goBuiltins = []string{"len", "append", "panic", "make", "copy"}
 	// Custom builtin utility functions.
 	customBuiltins = []string{
 		"FromAddress", "Equals",

--- a/pkg/compiler/init_test.go
+++ b/pkg/compiler/init_test.go
@@ -70,8 +70,6 @@ func TestImportOrder(t *testing.T) {
 		import _ "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/pkg2"
 		import "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/pkg3"
 		func Main() int { return pkg3.A }`
-		v := vmAndCompile(t, src)
-		v.PrintOps()
 		eval(t, src, big.NewInt(2))
 	})
 	t.Run("2,1", func(t *testing.T) {

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -364,3 +364,67 @@ func TestMake(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestCopy(t *testing.T) {
+	t.Run("Invalid", func(t *testing.T) {
+		src := `package foo
+		func Main() []int {
+			src := []int{3, 2, 1}
+			dst := make([]int, 2)
+			copy(dst, src)
+			return dst
+		}`
+		_, err := compiler.Compile("foo.go", strings.NewReader(src))
+		require.Error(t, err)
+	})
+	t.Run("Simple", func(t *testing.T) {
+		src := `package foo
+		func Main() []byte {
+			src := []byte{3, 2, 1}
+			dst := make([]byte, 2)
+			copy(dst, src)
+			return dst
+		}`
+		eval(t, src, []byte{3, 2})
+	})
+	t.Run("LowSrcIndex", func(t *testing.T) {
+		src := `package foo
+		func Main() []byte {
+			src := []byte{3, 2, 1}
+			dst := make([]byte, 2)
+			copy(dst, src[1:])
+			return dst
+		}`
+		eval(t, src, []byte{2, 1})
+	})
+	t.Run("LowDstIndex", func(t *testing.T) {
+		src := `package foo
+		func Main() []byte {
+			src := []byte{3, 2, 1}
+			dst := make([]byte, 2)
+			copy(dst[1:], src[1:])
+			return dst
+		}`
+		eval(t, src, []byte{0, 2})
+	})
+	t.Run("BothIndices", func(t *testing.T) {
+		src := `package foo
+		func Main() []byte {
+			src := []byte{4, 3, 2, 1}
+			dst := make([]byte, 4)
+			copy(dst[1:], src[1:3])
+			return dst
+		}`
+		eval(t, src, []byte{0, 3, 2, 0})
+	})
+	t.Run("EmptySliceExpr", func(t *testing.T) {
+		src := `package foo
+		func Main() []byte {
+			src := []byte{3, 2, 1}
+			dst := make([]byte, 2)
+			copy(dst[1:], src[:])
+			return dst
+		}`
+		eval(t, src, []byte{0, 3})
+	})
+}

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -27,6 +27,11 @@ func isBasicTypeOfKind(typ types.Type, ks ...types.BasicKind) bool {
 	return false
 }
 
+func isMap(typ types.Type) bool {
+	_, ok := typ.Underlying().(*types.Map)
+	return ok
+}
+
 func isByte(typ types.Type) bool {
 	return isBasicTypeOfKind(typ, types.Uint8, types.Int8)
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -659,7 +659,7 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 			panic("invalid destination index")
 		}
 		dst := v.estack.Pop().value.(*stackitem.Buffer).Value().([]byte)
-		if sum := si + n; sum < 0 || sum > len(dst) {
+		if sum := di + n; sum < 0 || sum > len(dst) {
 			panic("size is too big")
 		}
 		copy(dst[di:], src[si:si+n])

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1344,6 +1344,10 @@ func TestMEMCPY(t *testing.T) {
 		buf := stackitem.NewBuffer([]byte{0, 1, 2, 3})
 		runWithArgs(t, prog, stackitem.NewBuffer([]byte{0, 6, 7, 3}), buf, buf, 1, []byte{4, 5, 6, 7}, 2, 2)
 	})
+	t.Run("NonZeroDstIndex", func(t *testing.T) {
+		buf := stackitem.NewBuffer([]byte{0, 1, 2})
+		runWithArgs(t, prog, stackitem.NewBuffer([]byte{0, 6, 7}), buf, buf, 1, []byte{4, 5, 6, 7}, 2, 2)
+	})
 	t.Run("NegativeSize", getTestFuncForVM(prog, nil, stackitem.NewBuffer([]byte{0, 1}), 0, []byte{2}, 0, -1))
 	t.Run("NegativeSrcIndex", getTestFuncForVM(prog, nil, stackitem.NewBuffer([]byte{0, 1}), 0, []byte{2}, -1, 1))
 	t.Run("NegativeDstIndex", getTestFuncForVM(prog, nil, stackitem.NewBuffer([]byte{0, 1}), -1, []byte{2}, 0, 1))


### PR DESCRIPTION
1. Support `make` for everything and `copy` for byte slices.
2. Fix bug in MEMCPY.