### PR TITLE
rpc: support 0x form of Uint256 in requests (2.x)

### DIFF
--- a/pkg/rpc/request/param.go
+++ b/pkg/rpc/request/param.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
@@ -127,7 +128,7 @@ func (p *Param) GetUint256() (util.Uint256, error) {
 		return util.Uint256{}, err
 	}
 
-	return util.Uint256DecodeStringLE(s)
+	return util.Uint256DecodeStringLE(strings.TrimPrefix(s, "0x"))
 }
 
 // GetUint160FromHex returns Uint160 value of the parameter encoded in hex.

--- a/pkg/rpc/request/param_test.go
+++ b/pkg/rpc/request/param_test.go
@@ -123,6 +123,11 @@ func TestParamGetUint256(t *testing.T) {
 	assert.Equal(t, u256, u)
 	require.Nil(t, err)
 
+	p = Param{StringT, "0x" + gas}
+	u, err = p.GetUint256()
+	require.NoError(t, err)
+	assert.Equal(t, u256, u)
+
 	p = Param{StringT, 42}
 	_, err = p.GetUint256()
 	require.NotNil(t, err)


### PR DESCRIPTION
Port of #1368 for 2.x.