### PR TITLE
manifest: support interface checking

### DIFF
--- a/cli/contract_test.go
+++ b/cli/contract_test.go
@@ -142,6 +142,24 @@ func TestCompileExamples(t *testing.T) {
 			e.Run(t, opts...)
 		})
 	}
+
+	t.Run("invalid events in manifest", func(t *testing.T) {
+		const dir = "./testdata/"
+		for _, name := range []string{"invalid1", "invalid2", "invalid3"} {
+			outPath := path.Join(tmpDir, name+".nef")
+			manifestPath := path.Join(tmpDir, name+".manifest.json")
+			defer func() {
+				os.Remove(outPath)
+				os.Remove(manifestPath)
+			}()
+			e.RunWithError(t, "neo-go", "contract", "compile",
+				"--in", path.Join(dir, name),
+				"--out", outPath,
+				"--manifest", manifestPath,
+				"--config", path.Join(dir, name, "invalid.yml"),
+			)
+		}
+	})
 }
 
 func filterFilename(infos []os.FileInfo, ext string) string {

--- a/cli/contract_test.go
+++ b/cli/contract_test.go
@@ -104,3 +104,54 @@ func TestComlileAndInvokeFunction(t *testing.T) {
 		require.Equal(t, []byte("on update|sub update"), res.Stack[0].Value())
 	})
 }
+
+func TestCompileExamples(t *testing.T) {
+	const examplePath = "../examples"
+	infos, err := ioutil.ReadDir(examplePath)
+	require.NoError(t, err)
+
+	// For proper nef generation.
+	config.Version = "0.90.0-test"
+
+	tmpDir := os.TempDir()
+
+	e := newExecutor(t, false)
+	defer e.Close(t)
+
+	for _, info := range infos {
+		t.Run(info.Name(), func(t *testing.T) {
+			infos, err := ioutil.ReadDir(path.Join(examplePath, info.Name()))
+			require.NoError(t, err)
+			require.False(t, len(infos) == 0, "detected smart contract folder with no contract in it")
+
+			outPath := path.Join(tmpDir, info.Name()+".nef")
+			manifestPath := path.Join(tmpDir, info.Name()+".manifest.json")
+			defer func() {
+				os.Remove(outPath)
+				os.Remove(manifestPath)
+			}()
+
+			cfgName := filterFilename(infos, ".yml")
+			opts := []string{
+				"neo-go", "contract", "compile",
+				"--in", path.Join(examplePath, info.Name()),
+				"--out", outPath,
+				"--manifest", manifestPath,
+				"--config", path.Join(examplePath, info.Name(), cfgName),
+			}
+			e.Run(t, opts...)
+		})
+	}
+}
+
+func filterFilename(infos []os.FileInfo, ext string) string {
+	for _, info := range infos {
+		if !info.IsDir() {
+			name := info.Name()
+			if strings.HasSuffix(name, ext) {
+				return name
+			}
+		}
+	}
+	return ""
+}

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -154,6 +154,10 @@ func NewCommands() []cli.Command {
 						Name:  "no-standards",
 						Usage: "do not check compliance with supported standards",
 					},
+					cli.BoolFlag{
+						Name:  "no-events",
+						Usage: "do not check emitted events with the manifest",
+					},
 				},
 			},
 			{
@@ -404,6 +408,7 @@ func contractCompile(ctx *cli.Context) error {
 		ManifestFile: manifestFile,
 
 		NoStandardCheck: ctx.Bool("no-standards"),
+		NoEventsCheck:   ctx.Bool("no-events"),
 	}
 
 	if len(confFile) != 0 {

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -150,6 +150,10 @@ func NewCommands() []cli.Command {
 						Name:  "config, c",
 						Usage: "Configuration input file (*.yml)",
 					},
+					cli.BoolFlag{
+						Name:  "no-standards",
+						Usage: "do not check compliance with supported standards",
+					},
 				},
 			},
 			{
@@ -398,6 +402,8 @@ func contractCompile(ctx *cli.Context) error {
 
 		DebugInfo:    debugFile,
 		ManifestFile: manifestFile,
+
+		NoStandardCheck: ctx.Bool("no-standards"),
 	}
 
 	if len(confFile) != 0 {

--- a/cli/testdata/invalid1/invalid.go
+++ b/cli/testdata/invalid1/invalid.go
@@ -1,0 +1,21 @@
+// invalid is an example of contract which doesn't pass event check.
+package invalid1
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/interop"
+	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
+)
+
+// Notify1 emits correctly typed event.
+func Notify1() bool {
+	runtime.Notify("Event", interop.Hash160{1, 2, 3})
+
+	return true
+}
+
+// Notify2 emits invalid event (ByteString instead of Hash160).
+func Notify2() bool {
+	runtime.Notify("Event", []byte{1, 2, 3})
+
+	return true
+}

--- a/cli/testdata/invalid1/invalid.yml
+++ b/cli/testdata/invalid1/invalid.yml
@@ -1,0 +1,7 @@
+name: "Invalid example"
+supportedstandards: []
+events:
+  - name: Event
+    parameters:
+      - name: address
+        type: Hash160

--- a/cli/testdata/invalid2/invalid.go
+++ b/cli/testdata/invalid2/invalid.go
@@ -1,0 +1,21 @@
+// invalid is an example of contract which doesn't pass event check.
+package invalid2
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/interop"
+	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
+)
+
+// Notify1 emits correctly typed event.
+func Notify1() bool {
+	runtime.Notify("Event", interop.Hash160{1, 2, 3})
+
+	return true
+}
+
+// Notify2 emits invalid event (extra parameter).
+func Notify2() bool {
+	runtime.Notify("Event", interop.Hash160{1, 2, 3}, "extra parameter")
+
+	return true
+}

--- a/cli/testdata/invalid2/invalid.yml
+++ b/cli/testdata/invalid2/invalid.yml
@@ -1,0 +1,7 @@
+name: "Invalid example"
+supportedstandards: []
+events:
+  - name: Event
+    parameters:
+      - name: address
+        type: Hash160

--- a/cli/testdata/invalid3/invalid.go
+++ b/cli/testdata/invalid3/invalid.go
@@ -1,0 +1,21 @@
+// invalid is an example of contract which doesn't pass event check.
+package invalid3
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/interop"
+	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
+)
+
+// Notify1 emits correctly typed event.
+func Notify1() bool {
+	runtime.Notify("Event", interop.Hash160{1, 2, 3})
+
+	return true
+}
+
+// Notify2 emits invalid event (missing from manifest).
+func Notify2() bool {
+	runtime.Notify("AnotherEvent", interop.Hash160{1, 2, 3})
+
+	return true
+}

--- a/cli/testdata/invalid3/invalid.yml
+++ b/cli/testdata/invalid3/invalid.yml
@@ -1,0 +1,7 @@
+name: "Invalid example"
+supportedstandards: []
+events:
+  - name: Event
+    parameters:
+      - name: address
+        type: Hash160

--- a/examples/engine/engine.yml
+++ b/examples/engine/engine.yml
@@ -4,4 +4,16 @@ events:
   - name: Tx
     parameters:
       - name: txHash
-        type: ByteString
+        type: Hash256
+  - name: Calling
+    parameters:
+      - name: hash
+        type: Hash160
+  - name: Executing
+    parameters:
+      - name: hash
+        type: Hash160
+  - name: Entry
+    parameters:
+      - name: hash
+        type: Hash160

--- a/examples/iterator/iterator.go
+++ b/examples/iterator/iterator.go
@@ -13,7 +13,9 @@ func NotifyKeysAndValues() bool {
 	keys := iterator.Keys(iter)
 
 	runtime.Notify("found storage values", values)
-	runtime.Notify("found storage keys", keys)
+	// For illustration purposes event is emitted with 'Any' type.
+	var typedKeys interface{} = keys
+	runtime.Notify("found storage keys", typedKeys)
 
 	return true
 }

--- a/examples/iterator/iterator.yml
+++ b/examples/iterator/iterator.yml
@@ -4,7 +4,7 @@ events:
   - name: found storage values
     parameters:
       - name: values
-        type: Any
+        type: InteropInterface
   - name: found storage keys
     parameters:
       - name: keys

--- a/examples/token-sale/token_sale.go
+++ b/examples/token-sale/token_sale.go
@@ -1,6 +1,7 @@
 package tokensale
 
 import (
+	"github.com/nspcc-dev/neo-go/pkg/interop"
 	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
 	"github.com/nspcc-dev/neo-go/pkg/interop/storage"
 	"github.com/nspcc-dev/neo-go/pkg/interop/util"
@@ -134,39 +135,39 @@ func checkOwnerWitness() bool {
 }
 
 // Decimals returns the token decimals
-func Decimals() interface{} {
+func Decimals() int {
 	if trigger != runtime.Application {
-		return false
+		panic("invalid trigger")
 	}
 	return token.Decimals
 }
 
 // Symbol returns the token symbol
-func Symbol() interface{} {
+func Symbol() string {
 	if trigger != runtime.Application {
-		return false
+		panic("invalid trigger")
 	}
 	return token.Symbol
 }
 
 // TotalSupply returns the token total supply value
-func TotalSupply() interface{} {
+func TotalSupply() int {
 	if trigger != runtime.Application {
-		return false
+		panic("invalid trigger")
 	}
 	return getIntFromDB(ctx, token.CirculationKey)
 }
 
 // BalanceOf returns the amount of token on the specified address
-func BalanceOf(holder []byte) interface{} {
+func BalanceOf(holder interop.Hash160) int {
 	if trigger != runtime.Application {
-		return false
+		panic("invalid trigger")
 	}
 	return getIntFromDB(ctx, holder)
 }
 
 // Transfer transfers specified amount of token from one user to another
-func Transfer(from, to []byte, amount int) bool {
+func Transfer(from, to interop.Hash160, amount int, _ interface{}) bool {
 	if trigger != runtime.Application {
 		return false
 	}

--- a/examples/token-sale/token_sale.yml
+++ b/examples/token-sale/token_sale.yml
@@ -1,3 +1,11 @@
 name: "My awesome token"
 supportedstandards: ["NEP-17"]
-events: []
+events:
+- name: Transfer
+  parameters:
+  - name: from
+    type: Hash160
+  - name: to
+    type: Hash160
+  - name: amount
+    type: Integer

--- a/examples/token/token.go
+++ b/examples/token/token.go
@@ -48,7 +48,7 @@ func TotalSupply() int {
 }
 
 // BalanceOf returns the amount of token on the specified address
-func BalanceOf(holder interop.Hash160) interface{} {
+func BalanceOf(holder interop.Hash160) int {
 	return token.BalanceOf(ctx, holder)
 }
 
@@ -58,6 +58,6 @@ func Transfer(from interop.Hash160, to interop.Hash160, amount int, data interfa
 }
 
 // Mint initial supply of tokens
-func Mint(to []byte) bool {
+func Mint(to interop.Hash160) bool {
 	return token.Mint(ctx, to)
 }

--- a/examples/token/token.yml
+++ b/examples/token/token.yml
@@ -4,8 +4,8 @@ events:
   - name: Transfer
     parameters:
       - name: from
-        type: ByteString
+        type: Hash160
       - name: to
-        type: ByteString
+        type: Hash160
       - name: amount
         type: Integer

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest/standard"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/nef"
 	"golang.org/x/tools/go/loader"
 )
@@ -33,6 +34,10 @@ type Options struct {
 
 	// The name of the output for contract manifest file.
 	ManifestFile string
+
+	// NoStandardCheck specifies if supported standards compliance needs to be checked.
+	// This setting has effect only if manifest is emitted.
+	NoStandardCheck bool
 
 	// Name is contract's name to be written to manifest.
 	Name string
@@ -213,6 +218,11 @@ func CompileAndSave(src string, o *Options) ([]byte, error) {
 		m, err := di.ConvertToManifest(o.Name, o.ContractEvents, o.ContractSupportedStandards...)
 		if err != nil {
 			return b, fmt.Errorf("failed to convert debug info to manifest: %w", err)
+		}
+		if !o.NoStandardCheck {
+			if err := standard.Check(m, o.ContractSupportedStandards...); err != nil {
+				return b, err
+			}
 		}
 		mData, err := json.Marshal(m)
 		if err != nil {

--- a/pkg/compiler/debug.go
+++ b/pkg/compiler/debug.go
@@ -24,6 +24,8 @@ type DebugInfo struct {
 	Documents []string          `json:"documents"`
 	Methods   []MethodDebugInfo `json:"methods"`
 	Events    []EventDebugInfo  `json:"events"`
+	// EmittedEvents contains events occuring in code.
+	EmittedEvents map[string][][]string `json:"-"`
 }
 
 // MethodDebugInfo represents smart-contract's method debug information.
@@ -162,6 +164,7 @@ func (c *codegen) emitDebugInfo(contract []byte) *DebugInfo {
 		}
 		d.Methods = append(d.Methods, *m)
 	}
+	d.EmittedEvents = c.emittedEvents
 	return d
 }
 

--- a/pkg/smartcontract/manifest/manifest.go
+++ b/pkg/smartcontract/manifest/manifest.go
@@ -89,6 +89,16 @@ func (a *ABI) GetMethod(name string) *Method {
 	return nil
 }
 
+// GetEvent returns event with the specified name.
+func (a *ABI) GetEvent(name string) *Event {
+	for i := range a.Events {
+		if a.Events[i].Name == name {
+			return &a.Events[i]
+		}
+	}
+	return nil
+}
+
 // CanCall returns true is current contract is allowed to call
 // method of another contract.
 func (m *Manifest) CanCall(toCall *Manifest, method string) bool {

--- a/pkg/smartcontract/manifest/standard/comply.go
+++ b/pkg/smartcontract/manifest/standard/comply.go
@@ -1,0 +1,76 @@
+package standard
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+)
+
+// Various validation errors.
+var (
+	ErrMethodMissing         = errors.New("method missing")
+	ErrEventMissing          = errors.New("event missing")
+	ErrInvalidReturnType     = errors.New("invalid return type")
+	ErrInvalidParameterCount = errors.New("invalid parameter count")
+	ErrInvalidParameterType  = errors.New("invalid parameter type")
+)
+
+var checks = map[string]*manifest.Manifest{
+	manifest.NEP17StandardName: nep17,
+}
+
+// Check checks if manifest complies with all provided standards.
+// Currently only NEP-17 is supported.
+func Check(m *manifest.Manifest, standards ...string) error {
+	for i := range standards {
+		s, ok := checks[standards[i]]
+		if ok {
+			if err := Comply(m, s); err != nil {
+				return fmt.Errorf("manifest is not compliant with '%s': %w", standards[i], err)
+			}
+		}
+	}
+	return nil
+}
+
+// Comply if m has all methods and event from st manifest and they have the same signature.
+// Parameter names are ignored.
+func Comply(m, st *manifest.Manifest) error {
+	for _, stm := range st.ABI.Methods {
+		name := stm.Name
+		md := m.ABI.GetMethod(name)
+		if md == nil {
+			return fmt.Errorf("%w: '%s'", ErrMethodMissing, name)
+		} else if stm.ReturnType != md.ReturnType {
+			return fmt.Errorf("%w: '%s' (expected %s, got %s)", ErrInvalidReturnType,
+				name, stm.ReturnType, md.ReturnType)
+		} else if len(stm.Parameters) != len(md.Parameters) {
+			return fmt.Errorf("%w: '%s' (expected %d, got %d)", ErrInvalidParameterCount,
+				name, len(stm.Parameters), len(md.Parameters))
+		}
+		for i := range stm.Parameters {
+			if stm.Parameters[i].Type != md.Parameters[i].Type {
+				return fmt.Errorf("%w: '%s'[%d] (expected %s, got %s)", ErrInvalidParameterType,
+					name, i, stm.Parameters[i].Type, md.Parameters[i].Type)
+			}
+		}
+	}
+	for _, ste := range st.ABI.Events {
+		name := ste.Name
+		ed := m.ABI.GetEvent(name)
+		if ed == nil {
+			return fmt.Errorf("%w: event '%s'", ErrEventMissing, name)
+		} else if len(ste.Parameters) != len(ed.Parameters) {
+			return fmt.Errorf("%w: event '%s' (expected %d, got %d)", ErrInvalidParameterCount,
+				name, len(ste.Parameters), len(ed.Parameters))
+		}
+		for i := range ste.Parameters {
+			if ste.Parameters[i].Type != ed.Parameters[i].Type {
+				return fmt.Errorf("%w: event '%s' (expected %s, got %s)", ErrInvalidParameterType,
+					name, ste.Parameters[i].Type, ed.Parameters[i].Type)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/smartcontract/manifest/standard/comply_test.go
+++ b/pkg/smartcontract/manifest/standard/comply_test.go
@@ -1,0 +1,113 @@
+package standard
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func fooMethodBarEvent() *manifest.Manifest {
+	return &manifest.Manifest{
+		ABI: manifest.ABI{
+			Methods: []manifest.Method{
+				{
+					Name: "foo",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.ByteArrayType},
+						{Type: smartcontract.PublicKeyType},
+					},
+					ReturnType: smartcontract.IntegerType,
+				},
+			},
+			Events: []manifest.Event{
+				{
+					Name: "bar",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.StringType},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestComplyMissingMethod(t *testing.T) {
+	m := fooMethodBarEvent()
+	m.ABI.GetMethod("foo").Name = "notafoo"
+	err := Comply(m, fooMethodBarEvent())
+	require.True(t, errors.Is(err, ErrMethodMissing))
+}
+
+func TestComplyInvalidReturnType(t *testing.T) {
+	m := fooMethodBarEvent()
+	m.ABI.GetMethod("foo").ReturnType = smartcontract.VoidType
+	err := Comply(m, fooMethodBarEvent())
+	require.True(t, errors.Is(err, ErrInvalidReturnType))
+}
+
+func TestComplyMethodParameterCount(t *testing.T) {
+	t.Run("Method", func(t *testing.T) {
+		m := fooMethodBarEvent()
+		f := m.ABI.GetMethod("foo")
+		f.Parameters = append(f.Parameters, manifest.Parameter{Type: smartcontract.BoolType})
+		err := Comply(m, fooMethodBarEvent())
+		require.True(t, errors.Is(err, ErrInvalidParameterCount))
+	})
+	t.Run("Event", func(t *testing.T) {
+		m := fooMethodBarEvent()
+		ev := m.ABI.GetEvent("bar")
+		ev.Parameters = append(ev.Parameters[:0])
+		err := Comply(m, fooMethodBarEvent())
+		require.True(t, errors.Is(err, ErrInvalidParameterCount))
+	})
+}
+
+func TestComplyParameterType(t *testing.T) {
+	t.Run("Method", func(t *testing.T) {
+		m := fooMethodBarEvent()
+		m.ABI.GetMethod("foo").Parameters[0].Type = smartcontract.InteropInterfaceType
+		err := Comply(m, fooMethodBarEvent())
+		require.True(t, errors.Is(err, ErrInvalidParameterType))
+	})
+	t.Run("Event", func(t *testing.T) {
+		m := fooMethodBarEvent()
+		m.ABI.GetEvent("bar").Parameters[0].Type = smartcontract.InteropInterfaceType
+		err := Comply(m, fooMethodBarEvent())
+		require.True(t, errors.Is(err, ErrInvalidParameterType))
+	})
+}
+
+func TestMissingEvent(t *testing.T) {
+	m := fooMethodBarEvent()
+	m.ABI.GetEvent("bar").Name = "notabar"
+	err := Comply(m, fooMethodBarEvent())
+	require.True(t, errors.Is(err, ErrEventMissing))
+}
+
+func TestComplyValid(t *testing.T) {
+	m := fooMethodBarEvent()
+	m.ABI.Methods = append(m.ABI.Methods, manifest.Method{
+		Name:       "newmethod",
+		Offset:     123,
+		ReturnType: smartcontract.ByteArrayType,
+	})
+	m.ABI.Events = append(m.ABI.Events, manifest.Event{
+		Name: "otherevent",
+		Parameters: []manifest.Parameter{{
+			Name: "names do not matter",
+			Type: smartcontract.IntegerType,
+		}},
+	})
+	require.NoError(t, Comply(m, fooMethodBarEvent()))
+}
+
+func TestCheck(t *testing.T) {
+	m := manifest.NewManifest(util.Uint160{}, "Test")
+	require.Error(t, Check(m, manifest.NEP17StandardName))
+
+	require.NoError(t, Check(nep17, manifest.NEP17StandardName))
+}

--- a/pkg/smartcontract/manifest/standard/doc.go
+++ b/pkg/smartcontract/manifest/standard/doc.go
@@ -1,0 +1,5 @@
+/*
+Package standard contains interfaces for well-defined standards
+and function for checking if arbitrary manifest complies with them.
+*/
+package standard

--- a/pkg/smartcontract/manifest/standard/nep17.go
+++ b/pkg/smartcontract/manifest/standard/nep17.go
@@ -1,0 +1,57 @@
+package standard
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+)
+
+var nep17 = &manifest.Manifest{
+	ABI: manifest.ABI{
+		Methods: []manifest.Method{
+			{
+				Name: "balanceOf",
+				Parameters: []manifest.Parameter{
+					{Type: smartcontract.Hash160Type},
+				},
+				ReturnType: smartcontract.IntegerType,
+			},
+			{
+				Name:       "decimals",
+				ReturnType: smartcontract.IntegerType,
+			},
+			{
+				Name:       "symbol",
+				ReturnType: smartcontract.StringType,
+			},
+			{
+				Name:       "totalSupply",
+				ReturnType: smartcontract.IntegerType,
+			},
+			{
+				Name: "transfer",
+				Parameters: []manifest.Parameter{
+					{Type: smartcontract.Hash160Type},
+					{Type: smartcontract.Hash160Type},
+					{Type: smartcontract.IntegerType},
+					{Type: smartcontract.AnyType},
+				},
+				ReturnType: smartcontract.BoolType,
+			},
+		},
+		Events: []manifest.Event{
+			{
+				Name: "Transfer",
+				Parameters: []manifest.Parameter{
+					{Type: smartcontract.Hash160Type},
+					{Type: smartcontract.Hash160Type},
+					{Type: smartcontract.IntegerType},
+				},
+			},
+		},
+	},
+}
+
+// IsNEP17 checks if m is NEP-17 compliant.
+func IsNEP17(m *manifest.Manifest) error {
+	return Comply(m, nep17)
+}


### PR DESCRIPTION
There are some standards (NEP5, etc.) which impose
some restrictions on what methods and events a contract
must contain and their signatures. This commit supports
checking if arbitrary manifest complies with the standard.
