### PR TITLE
compiler: fix a bug with type conversion in switch

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -1512,7 +1512,9 @@ func (c *codegen) convertBuiltin(expr *ast.CallExpr) {
 	case "panic":
 		emit.Opcode(c.prog.BinWriter, opcode.THROW)
 	case "recover":
-		c.emitLoadByIndex(varGlobal, c.exceptionIndex)
+		if !c.scope.voidCalls[expr] {
+			c.emitLoadByIndex(varGlobal, c.exceptionIndex)
+		}
 		emit.Opcode(c.prog.BinWriter, opcode.PUSHNULL)
 		c.emitStoreByIndex(varGlobal, c.exceptionIndex)
 	case "ToInteger", "ToByteArray", "ToBool":

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -1455,6 +1455,14 @@ func (c *codegen) convertBuiltin(expr *ast.CallExpr) {
 		emit.Int(c.prog.BinWriter, 3)
 		emit.Opcode(c.prog.BinWriter, opcode.ROLL)
 		emit.Opcode(c.prog.BinWriter, opcode.MIN)
+		if !c.scope.voidCalls[expr] {
+			// insert top item to the bottom of MEMCPY args, so that it is left on stack
+			emit.Opcode(c.prog.BinWriter, opcode.DUP)
+			emit.Int(c.prog.BinWriter, 6)
+			emit.Opcode(c.prog.BinWriter, opcode.REVERSEN)
+			emit.Int(c.prog.BinWriter, 5)
+			emit.Opcode(c.prog.BinWriter, opcode.REVERSEN)
+		}
 		emit.Opcode(c.prog.BinWriter, opcode.MEMCPY)
 	case "make":
 		typ := c.typeOf(expr.Args[0])

--- a/pkg/compiler/defer_test.go
+++ b/pkg/compiler/defer_test.go
@@ -128,8 +128,8 @@ func TestRecover(t *testing.T) {
 			return h() + a
 		}
 		func h() int {
-			defer func() { a += 2; _ = recover() }()
-			defer func() { a *= 3; _ = recover(); panic("again") }()
+			defer func() { a += 2; recover() }()
+			defer func() { a *= 3; recover(); panic("again") }()
 			a = 1
 			panic("msg")
 			return a

--- a/pkg/compiler/for_test.go
+++ b/pkg/compiler/for_test.go
@@ -737,6 +737,20 @@ func TestForLoopRangeMap(t *testing.T) {
 	eval(t, src, big.NewInt(42))
 }
 
+func TestForLoopRangeTypeConversion(t *testing.T) {
+	src := `package foo
+	type intArr []int
+	func Main() int {
+		a := []int{1, 2, 3}
+		s := 0
+		for _, v := range intArr(a) {
+			s += v
+		}
+		return s
+	}`
+	eval(t, src, big.NewInt(6))
+}
+
 func TestForLoopComplexConditions(t *testing.T) {
 	src := `
 	package foo

--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -102,6 +102,11 @@ func (c *funcScope) analyzeVoidCalls(node ast.Node) bool {
 		}
 	case *ast.BinaryExpr:
 		return false
+	case *ast.RangeStmt:
+		ce, ok := n.X.(*ast.CallExpr)
+		if ok {
+			c.voidCalls[ce] = false
+		}
 	case *ast.IfStmt:
 		// we can't just return `false`, because we still need to process body
 		ce, ok := n.Cond.(*ast.CallExpr)

--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -108,6 +108,11 @@ func (c *funcScope) analyzeVoidCalls(node ast.Node) bool {
 		if ok {
 			c.voidCalls[ce] = false
 		}
+	case *ast.SwitchStmt:
+		ce, ok := n.Tag.(*ast.CallExpr)
+		if ok {
+			c.voidCalls[ce] = false
+		}
 	case *ast.CaseClause:
 		for _, e := range n.List {
 			ce, ok := e.(*ast.CallExpr)

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -427,4 +427,14 @@ func TestCopy(t *testing.T) {
 		}`
 		eval(t, src, []byte{0, 3})
 	})
+	t.Run("AssignToVariable", func(t *testing.T) {
+		src := `package foo
+		func Main() int {
+			src := []byte{3, 2, 1}
+			dst := make([]byte, 2)
+			n := copy(dst, src)
+			return n
+		}`
+		eval(t, src, big.NewInt(2))
+	})
 }

--- a/pkg/compiler/switch_test.go
+++ b/pkg/compiler/switch_test.go
@@ -34,6 +34,21 @@ var switchTestCases = []testCase{
 		big.NewInt(2),
 	},
 	{
+		"type conversion in tag",
+		`package main
+		type state int
+		func Main() int {
+			a := 1
+			switch state(a) {
+			case 1:
+				return 42
+			default:
+				return 11
+			}
+		}`,
+		big.NewInt(42),
+	},
+	{
 		"simple switch fail",
 		`package main
 		func Main() int {


### PR DESCRIPTION
It was incorrectly parsed as void call.

@roman-khimov @AnnaShaleva do we have any other structures where expression value is used but not assigned to a variable? (besides `if` and `switch`). Maybe I forgot something.

Also do some other improvements for void calls processing (handle `recover` and `copy`).