### PR TITLE
core: fix NEO UTXO tracking, drop Fixed8 multiplier

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -933,10 +933,15 @@ func processTransfer(cache *dao.Cached, tx *transaction.Transaction, b *block.Bl
 	if !isGoverning && !out.AssetID.Equals(UtilityTokenID()) {
 		return nil
 	}
+	var amount = int64(out.Amount)
+	// NEO has no fractional part and Fixed8 representation is just misleading here.
+	if isGoverning {
+		amount = out.Amount.IntegralValue()
+	}
 	tr := &state.Transfer{
 		IsGoverning: isGoverning,
 		IsSent:      isSent,
-		Amount:      int64(out.Amount),
+		Amount:      amount,
 		Block:       b.Index,
 		Timestamp:   b.Timestamp,
 		Tx:          tx.Hash(),

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -1288,7 +1288,7 @@ func checkTransfers(t *testing.T, e *executor, acc interface{}, asset string, st
 	u := getUTXOForBlock(res, false, "neo", 1)
 	if start <= 1 && (stop == 0 || stop >= 1) && (asset == "neo" || asset == "") {
 		require.NotNil(t, u)
-		require.EqualValues(t, int64(util.Fixed8FromInt64(99999000)), u.Amount)
+		require.EqualValues(t, int64(99999000), u.Amount)
 	} else {
 		require.Nil(t, u)
 	}
@@ -1306,7 +1306,7 @@ func checkTransfers(t *testing.T, e *executor, acc interface{}, asset string, st
 	u = getUTXOForBlock(res, true, "neo", 206)
 	if start <= 206 && (stop == 0 || stop >= 206) && (asset == "neo" || asset == "") {
 		require.NotNil(t, u)
-		require.EqualValues(t, int64(util.Fixed8FromInt64(99999000)), u.Amount)
+		require.EqualValues(t, int64(99999000), u.Amount)
 	} else {
 		require.Nil(t, u)
 	}
@@ -1314,7 +1314,7 @@ func checkTransfers(t *testing.T, e *executor, acc interface{}, asset string, st
 	u = getUTXOForBlock(res, false, "neo", 206)
 	if start <= 206 && (stop == 0 || stop >= 206) && (asset == "neo" || asset == "") {
 		require.NotNil(t, u)
-		require.EqualValues(t, int64(util.Fixed8FromInt64(99998000)), u.Amount)
+		require.EqualValues(t, int64(99998000), u.Amount)
 	} else {
 		require.Nil(t, u)
 	}


### PR DESCRIPTION
When this vout:
         {
            "n" : 0,
            "address" : "ASkbjwosE3aKyGtDQkEgqhNq3Zpv8Xkt14",
            "asset" : "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
            "value" : "606"
         },

Becomes this transfer:
               {
                  "txid" : "0x192ab8e422aed6ac868cb329d6f9af20964134b591908c736d32a2fd8a51d7bf",
                  "amount" : "60600000000",
                  "block_index" : 6113653,
                  "timestamp" : 1599199074
               }

Something is wrong here.