### PR TITLE
core: do not persist Policy contract

### DIFF
--- a/pkg/core/native/contract.go
+++ b/pkg/core/native/contract.go
@@ -57,6 +57,11 @@ func (cs *Contracts) GetPersistScript() []byte {
 	w := io.NewBufBinWriter()
 	for i := range cs.Contracts {
 		md := cs.Contracts[i].Metadata()
+		// Not every contract is persisted:
+		// https://github.com/neo-project/neo/blob/master/src/neo/Ledger/Blockchain.cs#L90
+		if md.ContractID == policyContractID {
+			continue
+		}
 		emit.Int(w.BinWriter, 0)
 		emit.Opcode(w.BinWriter, opcode.NEWARRAY)
 		emit.String(w.BinWriter, "onPersist")


### PR DESCRIPTION
Close #1389 .

I have decided to exclude `Policy` instead of enumerating `NEO` and `GAS`, because calling `onPersist` seems like a default behaviour and can be tested.