### PR TITLE
transaction: set output position when decoding

### DIFF
--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -117,6 +117,7 @@ func (t *Transaction) DecodeBinary(br *io.BinReader) {
 			br.Err = errors.New("negative output")
 			return
 		}
+		t.Outputs[i].Position = i
 	}
 	br.ReadArray(&t.Scripts)
 

--- a/pkg/rpc/response/result/tx_raw_output.go
+++ b/pkg/rpc/response/result/tx_raw_output.go
@@ -30,10 +30,6 @@ type TransactionMetadata struct {
 func NewTransactionOutputRaw(tx *transaction.Transaction, header *block.Header, chain core.Blockchainer) TransactionOutputRaw {
 	// confirmations formula
 	confirmations := int(chain.BlockHeight() - header.Base.Index + 1)
-	// set index position
-	for i, o := range tx.Outputs {
-		o.Position = i
-	}
 	return TransactionOutputRaw{
 		Transaction: tx,
 		TransactionMetadata: TransactionMetadata{


### PR DESCRIPTION
We had a kludge for getrawtransaction to set this useless field, but
7e371588a7186a13786abb246395b3f52d066873 broke it. Add it right into the
decoder now to fix all types of queries (getblock/getrawtransaction/gettxout).

Fixes #1392.