### PR TITLE
Add limits to get(nep5|utxo)transfers

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1026,7 +1026,7 @@ func (bc *Blockchain) processNEP5Transfer(cache *dao.Cached, tx *transaction.Tra
 }
 
 // ForEachTransfer executes f for each transfer in log.
-func (bc *Blockchain) ForEachTransfer(acc util.Uint160, tr *state.Transfer, f func() error) error {
+func (bc *Blockchain) ForEachTransfer(acc util.Uint160, tr *state.Transfer, f func() (bool, error)) error {
 	nb, err := bc.dao.GetNextTransferBatch(acc)
 	if err != nil {
 		return nil
@@ -1036,16 +1036,19 @@ func (bc *Blockchain) ForEachTransfer(acc util.Uint160, tr *state.Transfer, f fu
 		if err != nil {
 			return nil
 		}
-		err = lg.ForEach(state.TransferSize, tr, f)
+		cont, err := lg.ForEach(state.TransferSize, tr, f)
 		if err != nil {
 			return err
+		}
+		if !cont {
+			break
 		}
 	}
 	return nil
 }
 
 // ForEachNEP5Transfer executes f for each nep5 transfer in log.
-func (bc *Blockchain) ForEachNEP5Transfer(acc util.Uint160, tr *state.NEP5Transfer, f func() error) error {
+func (bc *Blockchain) ForEachNEP5Transfer(acc util.Uint160, tr *state.NEP5Transfer, f func() (bool, error)) error {
 	balances, err := bc.dao.GetNEP5Balances(acc)
 	if err != nil {
 		return nil
@@ -1055,9 +1058,12 @@ func (bc *Blockchain) ForEachNEP5Transfer(acc util.Uint160, tr *state.NEP5Transf
 		if err != nil {
 			return nil
 		}
-		err = lg.ForEach(state.NEP5TransferSize, tr, f)
+		cont, err := lg.ForEach(state.NEP5TransferSize, tr, f)
 		if err != nil {
 			return err
+		}
+		if !cont {
+			break
 		}
 	}
 	return nil

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1031,8 +1031,8 @@ func (bc *Blockchain) ForEachTransfer(acc util.Uint160, tr *state.Transfer, f fu
 	if err != nil {
 		return nil
 	}
-	for i := uint32(0); i <= nb; i++ {
-		lg, err := bc.dao.GetTransferLog(acc, i)
+	for i := int(nb); i >= 0; i-- {
+		lg, err := bc.dao.GetTransferLog(acc, uint32(i))
 		if err != nil {
 			return nil
 		}
@@ -1050,8 +1050,8 @@ func (bc *Blockchain) ForEachNEP5Transfer(acc util.Uint160, tr *state.NEP5Transf
 	if err != nil {
 		return nil
 	}
-	for i := uint32(0); i <= balances.NextTransferBatch; i++ {
-		lg, err := bc.dao.GetNEP5TransferLog(acc, i)
+	for i := int(balances.NextTransferBatch); i >= 0; i-- {
+		lg, err := bc.dao.GetNEP5TransferLog(acc, uint32(i))
 		if err != nil {
 			return nil
 		}

--- a/pkg/core/blockchainer.go
+++ b/pkg/core/blockchainer.go
@@ -26,8 +26,8 @@ type Blockchainer interface {
 	GetBlock(hash util.Uint256) (*block.Block, error)
 	GetContractState(hash util.Uint160) *state.Contract
 	GetEnrollments() ([]*state.Validator, error)
-	ForEachNEP5Transfer(util.Uint160, *state.NEP5Transfer, func() error) error
-	ForEachTransfer(util.Uint160, *state.Transfer, func() error) error
+	ForEachNEP5Transfer(util.Uint160, *state.NEP5Transfer, func() (bool, error)) error
+	ForEachTransfer(util.Uint160, *state.Transfer, func() (bool, error)) error
 	GetHeaderHash(int) util.Uint256
 	GetHeader(hash util.Uint256) (*block.Header, error)
 	CurrentHeaderHash() util.Uint256

--- a/pkg/core/state/nep5.go
+++ b/pkg/core/state/nep5.go
@@ -114,8 +114,8 @@ func (lg *TransferLog) ForEach(size int, tr io.Serializable, f func() error) err
 	if lg == nil {
 		return nil
 	}
-	for i := 0; i < len(lg.Raw); i += size {
-		r := io.NewBinReaderFromBuf(lg.Raw[i : i+size])
+	for i := len(lg.Raw); i > 0; i -= size {
+		r := io.NewBinReaderFromBuf(lg.Raw[i-size : i])
 		tr.DecodeBinary(r)
 		if r.Err != nil {
 			return r.Err

--- a/pkg/core/state/nep5_test.go
+++ b/pkg/core/state/nep5_test.go
@@ -30,13 +30,13 @@ func TestNEP5TransferLog_Append(t *testing.T) {
 
 	i := len(expected) - 1
 	tr := new(NEP5Transfer)
-	err := lg.ForEach(NEP5TransferSize, tr, func() error {
+	cont, err := lg.ForEach(NEP5TransferSize, tr, func() (bool, error) {
 		require.Equal(t, expected[i], tr)
 		i--
-		return nil
+		return true, nil
 	})
 	require.NoError(t, err)
-
+	require.True(t, cont)
 }
 
 func TestNEP5Tracker_EncodeBinary(t *testing.T) {

--- a/pkg/core/state/nep5_test.go
+++ b/pkg/core/state/nep5_test.go
@@ -28,11 +28,11 @@ func TestNEP5TransferLog_Append(t *testing.T) {
 
 	require.Equal(t, len(expected), lg.Size()/NEP5TransferSize)
 
-	i := 0
+	i := len(expected) - 1
 	tr := new(NEP5Transfer)
 	err := lg.ForEach(NEP5TransferSize, tr, func() error {
 		require.Equal(t, expected[i], tr)
-		i++
+		i--
 		return nil
 	})
 	require.NoError(t, err)

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -96,7 +96,7 @@ func (chain testChain) GetAccountState(util.Uint160) *state.Account {
 func (chain testChain) GetNEP5Metadata(util.Uint160) (*state.NEP5Metadata, error) {
 	panic("TODO")
 }
-func (chain testChain) ForEachNEP5Transfer(util.Uint160, *state.NEP5Transfer, func() error) error {
+func (chain testChain) ForEachNEP5Transfer(util.Uint160, *state.NEP5Transfer, func() (bool, error)) error {
 	panic("TODO")
 }
 func (chain testChain) GetNEP5Balances(util.Uint160) *state.NEP5Balances {
@@ -108,7 +108,7 @@ func (chain testChain) GetValidators(...*transaction.Transaction) ([]*keys.Publi
 func (chain testChain) GetEnrollments() ([]*state.Validator, error) {
 	panic("TODO")
 }
-func (chain testChain) ForEachTransfer(util.Uint160, *state.Transfer, func() error) error {
+func (chain testChain) ForEachTransfer(util.Uint160, *state.Transfer, func() (bool, error)) error {
 	panic("TODO")
 }
 func (chain testChain) GetScriptHashesForVerifying(*transaction.Transaction) ([]util.Uint160, error) {

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -1284,24 +1284,25 @@ func checkNep5TransfersAux(t *testing.T, e *executor, acc interface{}, onlyFirst
 
 	if onlyFirst {
 		require.Equal(t, 1, len(res.Received))
+		require.Equal(t, "1000", res.Received[0].Amount)
+		require.Equal(t, assetHashOld, res.Received[0].Asset)
+		require.Equal(t, address.Uint160ToString(assetHashOld), res.Received[0].Address)
 	} else {
 		require.Equal(t, 3, len(res.Received))
-	}
 
-	require.Equal(t, "1000", res.Received[0].Amount)
-	require.Equal(t, assetHashOld, res.Received[0].Asset)
-	require.Equal(t, address.Uint160ToString(assetHashOld), res.Received[0].Address)
+		require.Equal(t, "1000", res.Received[2].Amount)
+		require.Equal(t, assetHashOld, res.Received[2].Asset)
+		require.Equal(t, address.Uint160ToString(assetHashOld), res.Received[2].Address)
 
-	if !onlyFirst {
 		require.Equal(t, "2", res.Received[1].Amount)
 		require.Equal(t, assetHash, res.Received[1].Asset)
 		require.Equal(t, "AWLYWXB8C9Lt1nHdDZJnC5cpYJjgRDLk17", res.Received[1].Address)
 		require.Equal(t, uint32(0), res.Received[1].NotifyIndex)
 
-		require.Equal(t, "1", res.Received[2].Amount)
-		require.Equal(t, assetHash, res.Received[2].Asset)
-		require.Equal(t, "AWLYWXB8C9Lt1nHdDZJnC5cpYJjgRDLk17", res.Received[2].Address)
-		require.Equal(t, uint32(1), res.Received[2].NotifyIndex)
+		require.Equal(t, "1", res.Received[0].Amount)
+		require.Equal(t, assetHash, res.Received[0].Asset)
+		require.Equal(t, "AWLYWXB8C9Lt1nHdDZJnC5cpYJjgRDLk17", res.Received[0].Address)
+		require.Equal(t, uint32(1), res.Received[0].NotifyIndex)
 	}
 
 	require.Equal(t, 1, len(res.Sent))


### PR DESCRIPTION
### Problem

Suppose we want to get 10 most recent transfers, without this change we would either set start date to 0 (forcing server to return everything) or try to guess it (making multiple queries).

### Solution

With limits in place we can set start date to 0, but still get only 10 transfers.