### PR TITLE
Getalltransfertx 2.x

### DIFF
--- a/pkg/rpc/client/doc.go
+++ b/pkg/rpc/client/doc.go
@@ -19,6 +19,7 @@ TODO:
 Supported methods
 
 	getaccountstate
+	getalltransfertx
 	getapplicationlog
 	getassetstate
 	getbestblockhash
@@ -40,6 +41,7 @@ Supported methods
 	gettxout
 	getunclaimed
 	getunspents
+	getutxotransfers
 	getvalidators
 	getversion
 	invoke

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -404,6 +404,38 @@ func (c *Client) GetUnspents(address string) (*result.Unspents, error) {
 	return resp, nil
 }
 
+// GetUTXOTransfers is a wrapper for getutxoransfers RPC. Address parameter
+// is mandatory, while all the others are optional. It's only supported since
+// neo-go 0.77.0 with limit and page parameters only since neo-go 0.78.0.
+// These parameters are positional in the JSON-RPC call, you can't specify limit
+// and not specify start/stop for example.
+func (c *Client) GetUTXOTransfers(address string, start, stop *uint32, limit, page *int) (*result.GetUTXO, error) {
+	params := request.NewRawParams(address)
+	if start != nil {
+		params.Values = append(params.Values, *start)
+		if stop != nil {
+			params.Values = append(params.Values, *stop)
+			if limit != nil {
+				params.Values = append(params.Values, *limit)
+				if page != nil {
+					params.Values = append(params.Values, *page)
+				}
+			} else if page != nil {
+				return nil, errors.New("bad parameters")
+			}
+		} else if limit != nil || page != nil {
+			return nil, errors.New("bad parameters")
+		}
+	} else if stop != nil || limit != nil || page != nil {
+		return nil, errors.New("bad parameters")
+	}
+	resp := new(result.GetUTXO)
+	if err := c.performRequest("getutxotransfers", params, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // GetValidators returns the current NEO consensus nodes information and voting status.
 func (c *Client) GetValidators() ([]result.Validator, error) {
 	var (

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -245,9 +245,31 @@ func (c *Client) GetNEP5Balances(address util.Uint160) (*result.NEP5Balances, er
 	return resp, nil
 }
 
-// GetNEP5Transfers is a wrapper for getnep5transfers RPC.
-func (c *Client) GetNEP5Transfers(address string) (*result.NEP5Transfers, error) {
+// GetNEP5Transfers is a wrapper for getnep5transfers RPC. Address parameter
+// is mandatory, while all the others are optional. Start and stop parameters
+// are supported since neo-go 0.77.0 and limit and page since neo-go 0.78.0.
+// These parameters are positional in the JSON-RPC call, you can't specify limit
+// and not specify start/stop for example.
+func (c *Client) GetNEP5Transfers(address string, start, stop *uint32, limit, page *int) (*result.NEP5Transfers, error) {
 	params := request.NewRawParams(address)
+	if start != nil {
+		params.Values = append(params.Values, *start)
+		if stop != nil {
+			params.Values = append(params.Values, *stop)
+			if limit != nil {
+				params.Values = append(params.Values, *limit)
+				if page != nil {
+					params.Values = append(params.Values, *page)
+				}
+			} else if page != nil {
+				return nil, errors.New("bad parameters")
+			}
+		} else if limit != nil || page != nil {
+			return nil, errors.New("bad parameters")
+		}
+	} else if stop != nil || limit != nil || page != nil {
+		return nil, errors.New("bad parameters")
+	}
 	resp := new(result.NEP5Transfers)
 	if err := c.performRequest("getnep5transfers", params, resp); err != nil {
 		return nil, err

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -28,6 +28,20 @@ func (c *Client) GetAccountState(address string) (*result.AccountState, error) {
 	return resp, nil
 }
 
+// GetAllTransferTx returns all transfer transactions for a given account within
+// specified timestamps (by block time) with specified output limits and page. It
+// only works with neo-go 0.78.0+ servers.
+func (c *Client) GetAllTransferTx(acc util.Uint160, start, end uint32, limit, page int) ([]result.TransferTx, error) {
+	var (
+		params = request.NewRawParams(acc.StringLE(), start, end, limit, page)
+		resp   = new([]result.TransferTx)
+	)
+	if err := c.performRequest("getalltransfertx", params, resp); err != nil {
+		return nil, err
+	}
+	return *resp, nil
+}
+
 // GetApplicationLog returns the contract log based on the specified txid.
 func (c *Client) GetApplicationLog(hash util.Uint256) (*result.ApplicationLog, error) {
 	var (

--- a/pkg/rpc/client/rpc_test.go
+++ b/pkg/rpc/client/rpc_test.go
@@ -481,7 +481,7 @@ var rpcClientTestCases = map[string][]rpcClientTestCase{
 		{
 			name: "positive",
 			invoke: func(c *Client) (interface{}, error) {
-				return c.GetNEP5Transfers("AbHgdBaWEnHkCiLtDZXjhvhaAK2cwFh5pF")
+				return c.GetNEP5Transfers("AbHgdBaWEnHkCiLtDZXjhvhaAK2cwFh5pF", nil, nil, nil, nil)
 			},
 			serverResponse: `{"jsonrpc":"2.0","id":1,"result":{"sent":[],"received":[{"timestamp":1555651816,"asset_hash":"600c4f5200db36177e3e8a09e9f18e2fc7d12a0f","transfer_address":"AYwgBNMepiv5ocGcyNT4mA8zPLTQ8pDBis","amount":"1000000","block_index":436036,"transfer_notify_index":0,"tx_hash":"df7683ece554ecfb85cf41492c5f143215dd43ef9ec61181a28f922da06aba58"}],"address":"AbHgdBaWEnHkCiLtDZXjhvhaAK2cwFh5pF"}}`,
 			result: func(c *Client) interface{} {
@@ -1138,7 +1138,7 @@ var rpcClientErrorCases = map[string][]rpcClientErrorCase{
 		{
 			name: "getnep5transfers_invalid_params_error",
 			invoke: func(c *Client) (interface{}, error) {
-				return c.GetNEP5Transfers("")
+				return c.GetNEP5Transfers("", nil, nil, nil, nil)
 			},
 		},
 		{
@@ -1320,7 +1320,7 @@ var rpcClientErrorCases = map[string][]rpcClientErrorCase{
 		{
 			name: "getnep5transfers_unmarshalling_error",
 			invoke: func(c *Client) (interface{}, error) {
-				return c.GetNEP5Transfers("")
+				return c.GetNEP5Transfers("", nil, nil, nil, nil)
 			},
 		},
 		{

--- a/pkg/rpc/response/result/nep5.go
+++ b/pkg/rpc/response/result/nep5.go
@@ -69,3 +69,24 @@ func (b *NEP5Balance) UnmarshalJSON(data []byte) error {
 	b.LastUpdated = s.LastUpdated
 	return nil
 }
+
+// TransferTx is a type used to represent and element of `getalltransfertx`
+// result. It combines transaction's inputs/outputs with NEP5 events.
+type TransferTx struct {
+	TxID       util.Uint256      `json:"txid"`
+	Timestamp  uint32            `json:"timestamp"`
+	Index      uint32            `json:"block_index"`
+	SystemFee  int64             `json:"sys_fee"`
+	NetworkFee int64             `json:"net_fee"`
+	Elements   []TransferTxEvent `json:"elements,omitempty"`
+	Events     []TransferTxEvent `json:"events,omitempty"`
+}
+
+// TransferTxEvent is an event used for elements or events of TransferTx, it's
+// either a single input/output, or a nep5 transfer.
+type TransferTxEvent struct {
+	Address string `json:"address"`
+	Type    string `json:"type"`
+	Value   string `json:"value"`
+	Asset   string `json:"asset"`
+}

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -74,6 +74,9 @@ const (
 	// treated like subscriber, so technically it's a limit on websocket
 	// connections.
 	maxSubscribers = 64
+
+	// Maximum number of elements for get*transfers requests.
+	maxTransfersLimit = 1000
 )
 
 var rpcHandlers = map[string]func(*Server, request.Params) (interface{}, *response.Error){
@@ -453,6 +456,8 @@ func (s *Server) getVersion(_ request.Params) (interface{}, *response.Error) {
 func getTimestampsAndLimit(ps request.Params, index int) (uint32, uint32, int, int, error) {
 	var start, end uint32
 	var limit, page int
+
+	limit = maxTransfersLimit
 	pStart, pEnd, pLimit, pPage := ps.Value(index), ps.Value(index+1), ps.Value(index+2), ps.Value(index+3)
 	if pPage != nil {
 		p, err := pPage.GetInt()
@@ -471,6 +476,9 @@ func getTimestampsAndLimit(ps request.Params, index int) (uint32, uint32, int, i
 		}
 		if l <= 0 {
 			return 0, 0, 0, 0, errors.New("can't use negative or zero limit")
+		}
+		if l > maxTransfersLimit {
+			return 0, 0, 0, 0, errors.New("too big limit requested")
 		}
 		limit = l
 	}


### PR DESCRIPTION
This adds paging to get*transfers and adds a new getalltransfertx call. It can be updated based on feedback from testing (especially in output types), but in general the logic should be the same --- we're returning transaction-grouped transfers, both NEP5 and UTXO in the same feed.