### PR TITLE
rpc/server: fix "websocket: bad handshake" during testing

### DIFF
--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -974,6 +974,7 @@ func doRPCCallOverWS(rpcCall string, url string, t *testing.T) []byte {
 	c.SetReadDeadline(time.Now().Add(time.Second))
 	_, body, err := c.ReadMessage()
 	require.NoError(t, err)
+	require.NoError(t, c.Close())
 	return bytes.TrimSpace(body)
 }
 


### PR DESCRIPTION
I think it's caused by connection limits server-side, we never close
connection on the client.

