### PR TITLE
Support variables in slice literals.

### DIFF
--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -136,6 +136,18 @@ func (c *funcScope) analyzeVoidCalls(node ast.Node) bool {
 			c.voidCalls[n] = true
 		}
 		return false
+	case *ast.CompositeLit:
+		for _, e := range n.Elts {
+			switch val := e.(type) {
+			case *ast.CallExpr: // slice
+				c.voidCalls[val] = false
+			case *ast.KeyValueExpr: // struct and map
+				ce, ok := val.Value.(*ast.CallExpr)
+				if ok {
+					c.voidCalls[ce] = false
+				}
+			}
+		}
 	}
 	return true
 }

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -310,6 +310,17 @@ var sliceTestCases = []testCase{
 		`,
 		big.NewInt(2),
 	},
+	{
+		"literal byte-slice with variable values",
+		`package foo
+		const sym1 = 's'
+		func Main() []byte {
+			sym2 := byte('t')
+			sym4 := byte('i')
+			return []byte{sym1, sym2, 'r', sym4, 'n', 'g'}
+		}`,
+		[]byte("string"),
+	},
 }
 
 func TestSliceOperations(t *testing.T) {

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -321,6 +321,15 @@ var sliceTestCases = []testCase{
 		}`,
 		[]byte("string"),
 	},
+	{
+		"literal slice with function call",
+		`package foo
+		func fn() byte { return 't' }
+		func Main() []byte {
+			return []byte{'s', fn(), 'r'}
+		}`,
+		[]byte("str"),
+	},
 }
 
 func TestSliceOperations(t *testing.T) {

--- a/pkg/compiler/struct_test.go
+++ b/pkg/compiler/struct_test.go
@@ -30,6 +30,19 @@ var structTestCases = []testCase{
 		big.NewInt(2),
 	},
 	{
+		"struct field from func result",
+		`
+		package foo
+		type S struct { x int }
+		func fn() int { return 2 }
+		func Main() int {
+			t := S{x: fn()}
+			return t.x
+		}
+		`,
+		big.NewInt(2),
+	},
+	{
 		"struct field return",
 		`
 		package foo


### PR DESCRIPTION
1. Support variables in slice-literals.
2. Don't count function invocation inside literal as a void call.

I think, `analyzeVoidCalls` can be somehow rewritten in future, because there were too much bugs with it.