### PR TITLE
core: prevent panic during Oracle.OnPersistEnd

### DIFF
--- a/pkg/core/native/oracle.go
+++ b/pkg/core/native/oracle.go
@@ -100,6 +100,9 @@ func newOracle() *Oracle {
 	o.ContractID = oracleContractID
 	o.Manifest.Features = smartcontract.HasStorage
 
+	o.nodes.Store(keys.PublicKeys(nil))
+	o.nodesChanged.Store(false)
+
 	desc := newDescriptor("request", smartcontract.VoidType,
 		manifest.NewParameter("url", smartcontract.StringType),
 		manifest.NewParameter("filter", smartcontract.StringType),

--- a/pkg/core/native/oracle.go
+++ b/pkg/core/native/oracle.go
@@ -431,7 +431,7 @@ func (o *Oracle) getSerializableFromDAO(d dao.DAO, key []byte, item io.Serializa
 
 // OnPersistEnd updates cached Oracle values if they've been changed
 func (o *Oracle) OnPersistEnd(d dao.DAO) {
-	if !o.nodesChanged.Load().(bool) {
+	if nodesChanged := o.nodesChanged.Load(); nodesChanged != nil && !nodesChanged.(bool) {
 		return
 	}
 


### PR DESCRIPTION
Problem: panic during restoring the node from dump

```
neospcc@neospcc-ThinkPad-T590:~/Documents/GitProjects/nspcc-dev/neo-go$ ./bin/neo-go node -p
2020-09-28T13:09:45.496+0300	INFO	restoring blockchain	{"version": "0.1.0"}
2020-09-28T13:09:45.497+0300	INFO	service is running	{"service": "Prometheus", "endpoint": ":2112"}
2020-09-28T13:09:45.497+0300	INFO	service hasn't started since it's disabled	{"service": "Pprof"}
2020-09-28T13:09:45.497+0300	INFO	starting rpc-server	{"endpoint": ":20331"}
2020-09-28T13:09:45.497+0300	INFO	node started	{"blockHeight": 23, "headerHeight": 23}
2020-09-28T13:09:45.499+0300	INFO	new peer connected	{"addr": "127.0.0.1:20335", "peerCount": 1}
2020-09-28T13:09:45.499+0300	INFO	new peer connected	{"addr": "127.0.0.1:20334", "peerCount": 2}
2020-09-28T13:09:45.499+0300	INFO	started protocol	{"addr": "127.0.0.1:20335", "userAgent": "/NEO-GO:0.91.1-pre-236-gbf3ed109/", "startHeight": 24, "id": 4266619102}
2020-09-28T13:09:45.500+0300	INFO	new peer connected	{"addr": "127.0.0.1:20333", "peerCount": 3}
2020-09-28T13:09:45.500+0300	INFO	new peer connected	{"addr": "127.0.0.1:20336", "peerCount": 4}
2020-09-28T13:09:45.501+0300	INFO	started protocol	{"addr": "127.0.0.1:20334", "userAgent": "/NEO-GO:0.91.1-pre-236-gbf3ed109/", "startHeight": 24, "id": 746755013}
2020-09-28T13:09:45.501+0300	INFO	new peer connected	{"addr": "172.200.0.4:20336", "peerCount": 5}
2020-09-28T13:09:45.502+0300	INFO	started protocol	{"addr": "127.0.0.1:20336", "userAgent": "/NEO-GO:0.91.1-pre-236-gbf3ed109/", "startHeight": 24, "id": 1929236927}
2020-09-28T13:09:45.502+0300	INFO	new peer connected	{"addr": "172.200.0.1:20333", "peerCount": 6}
2020-09-28T13:09:45.502+0300	INFO	new peer connected	{"addr": "192.168.43.26:57144", "peerCount": 7}
2020-09-28T13:09:45.502+0300	WARN	peer disconnected	{"addr": "172.200.0.4:20336", "reason": "unexpected empty payload", "peerCount": 6}
2020-09-28T13:09:45.503+0300	WARN	peer disconnected	{"addr": "172.200.0.1:20333", "reason": "unexpected empty payload", "peerCount": 5}
2020-09-28T13:09:45.503+0300	INFO	new peer connected	{"addr": "172.200.0.4:20336", "peerCount": 6}
2020-09-28T13:09:45.503+0300	INFO	started protocol	{"addr": "127.0.0.1:20333", "userAgent": "/NEO-GO:0.91.1-pre-236-gbf3ed109/", "startHeight": 24, "id": 607684007}
2020-09-28T13:09:45.504+0300	INFO	new peer connected	{"addr": "172.200.0.254:20332", "peerCount": 7}
2020-09-28T13:09:45.505+0300	WARN	peer disconnected	{"addr": "172.200.0.254:20332", "reason": "identical node id", "peerCount": 6}
2020-09-28T13:09:45.507+0300	INFO	new peer connected	{"addr": "172.200.0.2:20334", "peerCount": 7}
2020-09-28T13:09:45.508+0300	WARN	peer disconnected	{"addr": "172.200.0.4:20336", "reason": "unexpected empty payload", "peerCount": 6}
2020-09-28T13:09:45.508+0300	WARN	peer disconnected	{"addr": "192.168.43.26:57144", "reason": "identical node id", "peerCount": 5}
2020-09-28T13:09:45.508+0300	WARN	peer disconnected	{"addr": "172.200.0.2:20334", "reason": "unexpected empty payload", "peerCount": 4}
panic: interface conversion: interface {} is nil, not bool

goroutine 97 [running]:
github.com/nspcc-dev/neo-go/pkg/core/native.(*Oracle).OnPersistEnd(0xc000802f00, 0x1050d00, 0xc0001a3300)
	github.com/nspcc-dev/neo-go/pkg/core/native/oracle.go:434 +0x30d
github.com/nspcc-dev/neo-go/pkg/core.(*Blockchain).storeBlock(0xc0001989c0, 0xc000148000, 0xc000464050, 0x16997f8, 0x1fa4dc9f21e414ae)
	github.com/nspcc-dev/neo-go/pkg/core/blockchain.go:654 +0x1583
github.com/nspcc-dev/neo-go/pkg/core.(*Blockchain).AddBlock(0xc0001989c0, 0xc000148000, 0x0, 0x0)
	github.com/nspcc-dev/neo-go/pkg/core/blockchain.go:443 +0x200
github.com/nspcc-dev/neo-go/pkg/network.(*blockQueue).run(0xc000030ed0)
	github.com/nspcc-dev/neo-go/pkg/network/blockqueue.go:54 +0x14f
created by github.com/nspcc-dev/neo-go/pkg/network.(*Server).Start
	github.com/nspcc-dev/neo-go/pkg/network/server.go:179 +0x2b3
[1]+  Killed                  ./bin/neo-go node -p
```

Solution: nill check. We should be careful while caching values into
native contracts. We set (Oracle).nodesChanged value in the following
methods:
	1) (o *Oracle) Initialize (which is called only when there's no
	   existing dump)
	2) (o *Oracle) SetOracleNodes (which is a separate native
	   contract method and is not called while restoring from dump
	3) (o *Oracle) OnPersistEnd (which is called after
	   o.nodesChanged.Load())

As a result, nodesChanged flag is empty by the moment when we call
(Oracle).OnPersistEnd method during restoring chain from dump.