### PR TITLE
vm: add MaxComparableSize and check reference counter after PACK-UNPACK

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -24,6 +24,7 @@ a dialect of Go rather than a complete port of the language:
     overhead for all contracts. This can easily be mitigated by first storing values
     in variables and returning the result.
  * lambdas are supported, but closures are not.
+ * maps are supported, but valid map keys are booleans, integers and strings with length <= 64
 
 ## VM API (interop layer)
 Compiler translates interop function calls into NEO VM syscalls or (for custom

--- a/pkg/vm/stackitem/item.go
+++ b/pkg/vm/stackitem/item.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"unicode/utf8"
@@ -16,14 +17,17 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/util"
 )
 
-// MaxBigIntegerSizeBits is the maximum size of BigInt item in bits.
-const MaxBigIntegerSizeBits = 32 * 8
-
-// MaxArraySize is the maximum array size allowed in the VM.
-const MaxArraySize = 1024
-
-// MaxSize is the maximum item size allowed in the VM.
-const MaxSize = 1024 * 1024
+const (
+	// MaxBigIntegerSizeBits is the maximum size of BigInt item in bits.
+	MaxBigIntegerSizeBits = 32 * 8
+	// MaxArraySize is the maximum array size allowed in the VM.
+	MaxArraySize = 1024
+	// MaxSize is the maximum item size allowed in the VM.
+	MaxSize = 1024 * 1024
+	// MaxByteArrayComparableSize is the maximum allowed length of ByteArray for Equals method.
+	// It is set to be the maximum uint16 value.
+	MaxByteArrayComparableSize = math.MaxUint16
+)
 
 // Item represents the "real" value that is pushed on the stack.
 type Item interface {
@@ -46,7 +50,10 @@ type Item interface {
 	Convert(Type) (Item, error)
 }
 
-var errInvalidConversion = errors.New("invalid conversion type")
+var (
+	errInvalidConversion          = errors.New("invalid conversion type")
+	errExceedingMaxComparableSize = errors.New("the operand exceeds the maximum comparable size")
+)
 
 // Make tries to make appropriate stack item from provided value.
 // It will panic if it's not possible.
@@ -536,13 +543,22 @@ func (i *ByteArray) TryInteger() (*big.Int, error) {
 
 // Equals implements Item interface.
 func (i *ByteArray) Equals(s Item) bool {
+	if len(i.value) > MaxByteArrayComparableSize {
+		panic(errExceedingMaxComparableSize)
+	}
 	if i == s {
 		return true
 	} else if s == nil {
 		return false
 	}
 	val, ok := s.(*ByteArray)
-	return ok && bytes.Equal(i.value, val.value)
+	if !ok {
+		return false
+	}
+	if len(val.value) > MaxByteArrayComparableSize {
+		panic(errExceedingMaxComparableSize)
+	}
+	return bytes.Equal(i.value, val.value)
 }
 
 // Dup implements Item interface.

--- a/pkg/vm/stackitem/item_test.go
+++ b/pkg/vm/stackitem/item_test.go
@@ -143,6 +143,7 @@ var equalsTestCases = map[string][]struct {
 	item1  Item
 	item2  Item
 	result bool
+	panics bool
 }{
 	"struct": {
 		{
@@ -251,6 +252,21 @@ var equalsTestCases = map[string][]struct {
 			item2:  Make([]byte{1, 2, 3}),
 			result: true,
 		},
+		{
+			item1:  NewByteArray(make([]byte, MaxByteArrayComparableSize+1)),
+			item2:  NewByteArray([]byte{1, 2, 3}),
+			panics: true,
+		},
+		{
+			item1:  NewByteArray([]byte{1, 2, 3}),
+			item2:  NewByteArray(make([]byte, MaxByteArrayComparableSize+1)),
+			panics: true,
+		},
+		{
+			item1:  NewByteArray(make([]byte, MaxByteArrayComparableSize+1)),
+			item2:  NewByteArray(make([]byte, MaxByteArrayComparableSize+1)),
+			panics: true,
+		},
 	},
 	"array": {
 		{
@@ -350,9 +366,15 @@ func TestEquals(t *testing.T) {
 	for name, testBatch := range equalsTestCases {
 		for _, testCase := range testBatch {
 			t.Run(name, func(t *testing.T) {
-				assert.Equal(t, testCase.result, testCase.item1.Equals(testCase.item2))
-				// Reference equals
-				assert.Equal(t, true, testCase.item1.Equals(testCase.item1))
+				if testCase.panics {
+					assert.Panics(t, func() {
+						testCase.item1.Equals(testCase.item2)
+					})
+				} else {
+					assert.Equal(t, testCase.result, testCase.item1.Equals(testCase.item2))
+					// Reference equals
+					assert.Equal(t, true, testCase.item1.Equals(testCase.item1))
+				}
 			})
 		}
 	}

--- a/pkg/vm/stackitem/json.go
+++ b/pkg/vm/stackitem/json.go
@@ -360,8 +360,8 @@ func FromJSONWithTypes(data []byte) (Item, error) {
 			key, err := FromJSONWithTypes(arr[i].Key)
 			if err != nil {
 				return nil, err
-			} else if !IsValidMapKey(key) {
-				return nil, fmt.Errorf("invalid map key of type %s", key.Type())
+			} else if err = IsValidMapKey(key); err != nil {
+				return nil, err
 			}
 			value, err := FromJSONWithTypes(arr[i].Value)
 			if err != nil {

--- a/pkg/vm/stackitem/json_test.go
+++ b/pkg/vm/stackitem/json_test.go
@@ -88,7 +88,7 @@ func TestFromToJSON(t *testing.T) {
 		t.Run("BigNestedArray", getTestDecodeFunc(`[[[[[[[[[[[]]]]]]]]]]]`, nil))
 		t.Run("EncodeRecursive", func(t *testing.T) {
 			// add this item to speed up test a bit
-			item := NewByteArray(make([]byte, MaxSize/100))
+			item := NewByteArray(make([]byte, MaxKeySize))
 			t.Run("Array", func(t *testing.T) {
 				arr := NewArray([]Item{item})
 				arr.Append(arr)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1668,8 +1668,8 @@ func validateMapKey(key *Element) {
 	if key == nil {
 		panic("no key found")
 	}
-	if !stackitem.IsValidMapKey(key.Item()) {
-		panic("key can't be a collection")
+	if err := stackitem.IsValidMapKey(key.Item()); err != nil {
+		panic(err)
 	}
 }
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -531,8 +531,8 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 		v.estack.PushVal(stackitem.Null{})
 
 	case opcode.ISNULL:
-		res := v.estack.Pop().value.Equals(stackitem.Null{})
-		v.estack.PushVal(res)
+		_, ok := v.estack.Pop().value.(stackitem.Null)
+		v.estack.PushVal(ok)
 
 	case opcode.ISTYPE:
 		res := v.estack.Pop().Item()


### PR DESCRIPTION
1. Add MaxComparableSize to restrict the length of comparable ByteArray stack items.
2. Add test to check reference counter after PACK-UNPACK and PACK-UNPACK-PACK scripts. Reference issue: https://github.com/neo-project/neo-vm/pull/370. BTW, there might be a mistake in https://github.com/neo-project/neo-vm/pull/370#issuecomment-699735735 because the following tests are passed by C# node:
```
        [TestMethod]
        public void TestPackUnpack()
        {
            using (var engine = new ExecutionEngine())
            {
                using (var script = new ScriptBuilder())
                {
                    int size = 1000;
                    byte[] args = new BigInteger(size).ToByteArray();
                    for (int i = 0; i < size; i++)
                    {
                        script.Emit(OpCode.PUSH1);
                    }
                    script.Emit(OpCode.PUSHINT16, args);
                    script.Emit(OpCode.PACK);
                    script.Emit(OpCode.UNPACK);
                    engine.LoadScript(script.ToArray());
                    engine.Execute();
                    Assert.AreEqual(1001, engine.ReferenceCounter.Count);
                }
            }
        }

        [TestMethod]
        public void TestPackUnpackPack()
        {
            using (var engine = new ExecutionEngine())
            {
                using (var script = new ScriptBuilder())
                {
                    int size = 1000;
                    byte[] args = new BigInteger(size).ToByteArray();
                    for (int i = 0; i < size; i++)
                    {
                        script.Emit(OpCode.PUSH1);
                    }
                    script.Emit(OpCode.PUSHINT16, args);
                    script.Emit(OpCode.PACK);
                    script.Emit(OpCode.UNPACK);
                    script.Emit(OpCode.PACK);
                    engine.LoadScript(script.ToArray());
                    engine.Execute();
                    Assert.AreEqual(1001, engine.ReferenceCounter.Count);
                }
            }
        }
```