### PR TITLE
core: take into account gasConsumed during tx witnesses verification

### DIFF
--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -215,7 +215,7 @@ func TestVerifyTx(t *testing.T) {
 	bc := newTestChain(t)
 	defer bc.Close()
 
-	accs := make([]*wallet.Account, 3)
+	accs := make([]*wallet.Account, 4)
 	for i := range accs {
 		var err error
 		accs[i], err = wallet.NewAccount()
@@ -324,6 +324,16 @@ func TestVerifyTx(t *testing.T) {
 		tx := bc.newTestTx(h, testScript)
 		require.NoError(t, accs[0].SignTx(tx))
 		tx.Scripts[0].InvocationScript[10] = ^tx.Scripts[0].InvocationScript[10]
+		checkErr(t, ErrVerificationFailed, tx)
+	})
+	t.Run("InsufficientNetworkFeeForSecondWitness", func(t *testing.T) {
+		tx := bc.newTestTx(h, testScript)
+		tx.Signers = append(tx.Signers, transaction.Signer{
+			Account: accs[3].PrivateKey().GetScriptHash(),
+			Scopes:  transaction.Global,
+		})
+		require.NoError(t, accs[0].SignTx(tx))
+		require.NoError(t, accs[3].SignTx(tx))
 		checkErr(t, ErrVerificationFailed, tx)
 	})
 	t.Run("OldTX", func(t *testing.T) {
@@ -490,22 +500,22 @@ func TestVerifyHashAgainstScript(t *testing.T) {
 			newH := cs.ScriptHash()
 			newH[0] = ^newH[0]
 			w := &transaction.Witness{InvocationScript: []byte{byte(opcode.PUSH4)}}
-			err := bc.verifyHashAgainstScript(newH, w, ic, gas)
+			_, err := bc.verifyHashAgainstScript(newH, w, ic, gas)
 			require.True(t, errors.Is(err, ErrUnknownVerificationContract))
 		})
 		t.Run("Invalid", func(t *testing.T) {
 			w := &transaction.Witness{InvocationScript: []byte{byte(opcode.PUSH4)}}
-			err := bc.verifyHashAgainstScript(csInvalid.ScriptHash(), w, ic, gas)
+			_, err := bc.verifyHashAgainstScript(csInvalid.ScriptHash(), w, ic, gas)
 			require.True(t, errors.Is(err, ErrInvalidVerificationContract))
 		})
 		t.Run("ValidSignature", func(t *testing.T) {
 			w := &transaction.Witness{InvocationScript: []byte{byte(opcode.PUSH4)}}
-			err := bc.verifyHashAgainstScript(cs.ScriptHash(), w, ic, gas)
+			_, err := bc.verifyHashAgainstScript(cs.ScriptHash(), w, ic, gas)
 			require.NoError(t, err)
 		})
 		t.Run("InvalidSignature", func(t *testing.T) {
 			w := &transaction.Witness{InvocationScript: []byte{byte(opcode.PUSH3)}}
-			err := bc.verifyHashAgainstScript(cs.ScriptHash(), w, ic, gas)
+			_, err := bc.verifyHashAgainstScript(cs.ScriptHash(), w, ic, gas)
 			require.True(t, errors.Is(err, ErrVerificationFailed))
 		})
 	})
@@ -515,7 +525,7 @@ func TestVerifyHashAgainstScript(t *testing.T) {
 			InvocationScript:   []byte{byte(opcode.NOP)},
 			VerificationScript: verif,
 		}
-		err := bc.verifyHashAgainstScript(hash.Hash160(verif), w, ic, 1)
+		_, err := bc.verifyHashAgainstScript(hash.Hash160(verif), w, ic, 1)
 		require.True(t, errors.Is(err, ErrVerificationFailed))
 	})
 	t.Run("NoResult", func(t *testing.T) {
@@ -524,7 +534,7 @@ func TestVerifyHashAgainstScript(t *testing.T) {
 			InvocationScript:   []byte{byte(opcode.PUSH1)},
 			VerificationScript: verif,
 		}
-		err := bc.verifyHashAgainstScript(hash.Hash160(verif), w, ic, gas)
+		_, err := bc.verifyHashAgainstScript(hash.Hash160(verif), w, ic, gas)
 		require.True(t, errors.Is(err, ErrVerificationFailed))
 	})
 	t.Run("BadResult", func(t *testing.T) {
@@ -535,7 +545,7 @@ func TestVerifyHashAgainstScript(t *testing.T) {
 			InvocationScript:   []byte{byte(opcode.NOP)},
 			VerificationScript: verif,
 		}
-		err := bc.verifyHashAgainstScript(hash.Hash160(verif), w, ic, gas)
+		_, err := bc.verifyHashAgainstScript(hash.Hash160(verif), w, ic, gas)
 		require.True(t, errors.Is(err, ErrVerificationFailed))
 	})
 	t.Run("TooManyResults", func(t *testing.T) {
@@ -544,7 +554,7 @@ func TestVerifyHashAgainstScript(t *testing.T) {
 			InvocationScript:   []byte{byte(opcode.PUSH1), byte(opcode.PUSH1)},
 			VerificationScript: verif,
 		}
-		err := bc.verifyHashAgainstScript(hash.Hash160(verif), w, ic, gas)
+		_, err := bc.verifyHashAgainstScript(hash.Hash160(verif), w, ic, gas)
 		require.True(t, errors.Is(err, ErrVerificationFailed))
 	})
 }

--- a/pkg/core/interop/runtime/witness.go
+++ b/pkg/core/interop/runtime/witness.go
@@ -36,7 +36,7 @@ func checkScope(d dao.DAO, tx *transaction.Transaction, v *vm.VM, hash util.Uint
 			if c.Scopes&transaction.CalledByEntry != 0 {
 				callingScriptHash := v.GetCallingScriptHash()
 				entryScriptHash := v.GetEntryScriptHash()
-				if callingScriptHash == entryScriptHash {
+				if callingScriptHash.Equals(util.Uint160{}) || callingScriptHash == entryScriptHash {
 					return true, nil
 				}
 			}


### PR DESCRIPTION
We should pay attention to the previously consumed gas during tx
witnesses verification.