### PR TITLE
core: fix cache for (NEO).nextValidators and (NEO).committee

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -253,6 +253,11 @@ func (bc *Blockchain) init() error {
 		}
 	}
 
+	err = bc.contracts.NEO.InitializeCache(bc, bc.dao)
+	if err != nil {
+		return fmt.Errorf("can't init cache for NEO native contract: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/core/native/contract.go
+++ b/pkg/core/native/contract.go
@@ -39,8 +39,8 @@ func (cs *Contracts) ByHash(h util.Uint160) interop.Contract {
 func NewContracts() *Contracts {
 	cs := new(Contracts)
 
-	gas := NewGAS()
-	neo := NewNEO()
+	gas := newGAS()
+	neo := newNEO()
 	neo.GAS = gas
 	gas.NEO = neo
 

--- a/pkg/core/native/native_gas.go
+++ b/pkg/core/native/native_gas.go
@@ -24,8 +24,8 @@ const gasContractID = -2
 const GASFactor = NEOTotalSupply
 const initialGAS = 30000000
 
-// NewGAS returns GAS native contract.
-func NewGAS() *GAS {
+// newGAS returns GAS native contract.
+func newGAS() *GAS {
 	g := &GAS{}
 	nep5 := newNEP5Native(gasName)
 	nep5.symbol = "gas"

--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -89,8 +89,8 @@ func makeValidatorKey(key *keys.PublicKey) []byte {
 	return b
 }
 
-// NewNEO returns NEO native contract.
-func NewNEO() *NEO {
+// newNEO returns NEO native contract.
+func newNEO() *NEO {
 	n := &NEO{}
 	nep5 := newNEP5Native(neoName)
 	nep5.symbol = "neo"


### PR DESCRIPTION
### Problem

4-nodes private network is failing after restoring from dump:
```
$ docker logs neo_go_node_one
=> Try to restore blocks before running node
2020-09-30T11:55:49.122Z	INFO	no storage version found! creating genesis block
2020-09-30T11:55:49.124Z	INFO	service hasn't started since it's disabled	{"service": "Pprof"}
2020-09-30T11:55:49.124Z	INFO	service hasn't started since it's disabled	{"service": "Prometheus"}
2020-09-30T11:55:49.124Z	INFO	skipped genesis block	{"hash": "3792eaa22c196399a114666fd491c4b9ac52491d9abb1f633a8036a8ac81e4db"}
2020-09-30T11:55:49.141Z	INFO	shutting down service	{"service": "Pprof", "endpoint": ":30001"}
2020-09-30T11:55:49.141Z	INFO	shutting down service	{"service": "Prometheus", "endpoint": ":40001"}
2020-09-30T11:55:49.141Z	INFO	blockchain persist completed	{"persistedBlocks": 3, "persistedKeys": 146, "headerHeight": 3, "blockHeight": 3, "took": "324.27µs"}
2020-09-30T11:55:49.150Z	INFO	restoring blockchain	{"version": "0.1.0"}
2020-09-30T11:55:49.150Z	INFO	service hasn't started since it's disabled	{"service": "Prometheus"}
2020-09-30T11:55:49.151Z	INFO	service hasn't started since it's disabled	{"service": "Pprof"}
2020-09-30T11:55:49.443Z	INFO	starting rpc-server	{"endpoint": ":30333"}
2020-09-30T11:55:49.443Z	INFO	node started	{"blockHeight": 3, "headerHeight": 3}

    _   ____________        __________
   / | / / ____/ __ \      / ____/ __ \
  /  |/ / __/ / / / /_____/ / __/ / / /
 / /|  / /___/ /_/ /_____/ /_/ / /_/ /
/_/ |_/_____/\____/      \____/\____/

/NEO-GO:/

2020-09-30T11:55:49.444Z	INFO	new peer connected	{"addr": "172.23.0.5:39638", "peerCount": 1}
2020-09-30T11:55:49.444Z	INFO	new peer connected	{"addr": "172.23.0.5:20333", "peerCount": 2}
2020-09-30T11:55:49.444Z	WARN	peer disconnected	{"addr": "172.23.0.5:20333", "reason": "identical node id", "peerCount": 1}
2020-09-30T11:55:49.445Z	WARN	peer disconnected	{"addr": "172.23.0.5:39638", "reason": "identical node id", "peerCount": 0}
2020-09-30T11:55:49.445Z	INFO	new peer connected	{"addr": "172.23.0.3:20335", "peerCount": 1}
2020-09-30T11:55:49.445Z	INFO	new peer connected	{"addr": "172.23.0.2:20334", "peerCount": 2}
2020-09-30T11:55:49.445Z	INFO	started protocol	{"addr": "172.23.0.3:20335", "userAgent": "/NEO-GO:/", "startHeight": 3, "id": 1339919829}
2020-09-30T11:55:49.445Z	INFO	new peer connected	{"addr": "172.23.0.4:20336", "peerCount": 3}
2020-09-30T11:55:49.445Z	INFO	started protocol	{"addr": "172.23.0.4:20336", "userAgent": "/NEO-GO:/", "startHeight": 3, "id": 4036722359}
2020-09-30T11:55:49.445Z	INFO	node reached synchronized state, starting consensus
2020-09-30T11:55:49.445Z	INFO	started protocol	{"addr": "172.23.0.2:20334", "userAgent": "/NEO-GO:/", "startHeight": 3, "id": 1557367037}
panic: runtime error: integer divide by zero

goroutine 132 [running]:
github.com/nspcc-dev/dbft.(*Context).GetPrimaryIndex(...)
	github.com/nspcc-dev/dbft@v0.0.0-20200925163137-8f3b9ab3b720/context.go:83
github.com/nspcc-dev/dbft.(*Context).reset(0xc0000e0780, 0x0)
	github.com/nspcc-dev/dbft@v0.0.0-20200925163137-8f3b9ab3b720/context.go:208 +0x64b
github.com/nspcc-dev/dbft.(*DBFT).InitializeConsensus(0xc0000e0780, 0x964800)
	github.com/nspcc-dev/dbft@v0.0.0-20200925163137-8f3b9ab3b720/dbft.go:87 +0x51
github.com/nspcc-dev/dbft.(*DBFT).Start(0xc0000e0780)
	github.com/nspcc-dev/dbft@v0.0.0-20200925163137-8f3b9ab3b720/dbft.go:81 +0x4b
github.com/nspcc-dev/neo-go/pkg/consensus.(*service).Start(0xc0001a2160)
	github.com/nspcc-dev/neo-go/pkg/consensus/consensus.go:206 +0x56
github.com/nspcc-dev/neo-go/pkg/network.(*Server).tryStartConsensus(0xc0000ec500)
	github.com/nspcc-dev/neo-go/pkg/network/server.go:311 +0xda
github.com/nspcc-dev/neo-go/pkg/network.(*Server).handleMessage(0xc0000ec500, 0x104d800, 0xc000222090, 0xc0000a6f10, 0x0, 0x0)
	github.com/nspcc-dev/neo-go/pkg/network/server.go:781 +0xa7a
github.com/nspcc-dev/neo-go/pkg/network.(*TCPPeer).handleConn(0xc000222090)
	github.com/nspcc-dev/neo-go/pkg/network/tcp_peer.go:162 +0x2e7
created by github.com/nspcc-dev/neo-go/pkg/network.(*TCPTransport).Dial
	github.com/nspcc-dev/neo-go/pkg/network/tcp_transport.go:40 +0x1ac
```