### PR TITLE
rpc: check VM state in (*Client).CreateTXFromScript

### DIFF
--- a/pkg/rpc/client/nep5.go
+++ b/pkg/rpc/client/nep5.go
@@ -155,6 +155,9 @@ func (c *Client) CreateTxFromScript(script []byte, acc *wallet.Account, sysFee, 
 		if err != nil {
 			return nil, fmt.Errorf("can't add system fee to transaction: %w", err)
 		}
+		if result.State != "HALT" {
+			return nil, fmt.Errorf("can't add system fee to transaction: bad vm state: %s", result.State)
+		}
 		sysFee = result.GasConsumed
 	}
 


### PR DESCRIPTION
We should also pay attention to the VM state before adding system fee to
the transaction. We shouldn't allow adding system fee in case if
the transaction script is bad.