### PR TITLE
rpc: getvalidators -> getnextblockvalidators

### DIFF
--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -353,13 +353,13 @@ func (c *Client) GetUnclaimedGas(address string) (result.UnclaimedGas, error) {
 	return resp, nil
 }
 
-// GetValidators returns the current NEO consensus nodes information and voting status.
-func (c *Client) GetValidators() ([]result.Validator, error) {
+// GetNextBlockValidators returns the current NEO consensus nodes information and voting status.
+func (c *Client) GetNextBlockValidators() ([]result.Validator, error) {
 	var (
 		params = request.NewRawParams()
 		resp   = new([]result.Validator)
 	)
-	if err := c.performRequest("getvalidators", params, resp); err != nil {
+	if err := c.performRequest("getnextblockvalidators", params, resp); err != nil {
 		return nil, err
 	}
 	return *resp, nil
@@ -502,7 +502,7 @@ func (c *Client) ValidateAddress(address string) error {
 
 // CalculateValidUntilBlock calculates ValidUntilBlock field for tx as
 // current blockchain height + number of validators. Number of validators
-// is the length of blockchain validators list got from GetValidators()
+// is the length of blockchain validators list got from GetNextBlockValidators()
 // method. Validators count is being cached and updated every 100 blocks.
 func (c *Client) CalculateValidUntilBlock() (uint32, error) {
 	var (
@@ -517,7 +517,7 @@ func (c *Client) CalculateValidUntilBlock() (uint32, error) {
 	if c.cache.calculateValidUntilBlock.expiresAt > blockCount {
 		validatorsCount = c.cache.calculateValidUntilBlock.validatorsCount
 	} else {
-		validators, err := c.GetValidators()
+		validators, err := c.GetNextBlockValidators()
 		if err != nil {
 			return result, fmt.Errorf("can't get validators: %w", err)
 		}

--- a/pkg/rpc/client/rpc_test.go
+++ b/pkg/rpc/client/rpc_test.go
@@ -614,7 +614,7 @@ var rpcClientTestCases = map[string][]rpcClientTestCase{
 		{
 			name: "positive",
 			invoke: func(c *Client) (interface{}, error) {
-				return c.GetValidators()
+				return c.GetNextBlockValidators()
 			},
 			serverResponse: `{"id":1,"jsonrpc":"2.0","result":[{"publickey":"02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2","votes":"0","active":true},{"publickey":"02103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e","votes":"0","active":true},{"publickey":"03d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee699","votes":"0","active":true},{"publickey":"02a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd62","votes":"0","active":true}]}`,
 			result:         func(c *Client) interface{} { return []result.Validator{} },
@@ -1189,7 +1189,7 @@ var rpcClientErrorCases = map[string][]rpcClientErrorCase{
 		{
 			name: "getvalidators_unmarshalling_error",
 			invoke: func(c *Client) (interface{}, error) {
-				return c.GetValidators()
+				return c.GetNextBlockValidators()
 			},
 		},
 		{
@@ -1354,7 +1354,7 @@ func TestCalculateValidUntilBlock(t *testing.T) {
 		case "getblockcount":
 			getBlockCountCalled++
 			response = `{"jsonrpc":"2.0","id":1,"result":50}`
-		case "getvalidators":
+		case "getnextblockvalidators":
 			getValidatorsCalled++
 			response = `{"id":1,"jsonrpc":"2.0","result":[{"publickey":"02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2","votes":"0","active":true},{"publickey":"02103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e","votes":"0","active":true},{"publickey":"03d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee699","votes":"0","active":true},{"publickey":"02a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd62","votes":"0","active":true}]}`
 		default:

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -83,31 +83,31 @@ const (
 )
 
 var rpcHandlers = map[string]func(*Server, request.Params) (interface{}, *response.Error){
-	"getapplicationlog":    (*Server).getApplicationLog,
-	"getbestblockhash":     (*Server).getBestBlockHash,
-	"getblock":             (*Server).getBlock,
-	"getblockcount":        (*Server).getBlockCount,
-	"getblockhash":         (*Server).getBlockHash,
-	"getblockheader":       (*Server).getBlockHeader,
-	"getblocksysfee":       (*Server).getBlockSysFee,
-	"getcommittee":         (*Server).getCommittee,
-	"getconnectioncount":   (*Server).getConnectionCount,
-	"getcontractstate":     (*Server).getContractState,
-	"getnep5balances":      (*Server).getNEP5Balances,
-	"getnep5transfers":     (*Server).getNEP5Transfers,
-	"getpeers":             (*Server).getPeers,
-	"getrawmempool":        (*Server).getRawMempool,
-	"getrawtransaction":    (*Server).getrawtransaction,
-	"getstorage":           (*Server).getStorage,
-	"gettransactionheight": (*Server).getTransactionHeight,
-	"getunclaimedgas":      (*Server).getUnclaimedGas,
-	"getvalidators":        (*Server).getValidators,
-	"getversion":           (*Server).getVersion,
-	"invokefunction":       (*Server).invokeFunction,
-	"invokescript":         (*Server).invokescript,
-	"sendrawtransaction":   (*Server).sendrawtransaction,
-	"submitblock":          (*Server).submitBlock,
-	"validateaddress":      (*Server).validateAddress,
+	"getapplicationlog":      (*Server).getApplicationLog,
+	"getbestblockhash":       (*Server).getBestBlockHash,
+	"getblock":               (*Server).getBlock,
+	"getblockcount":          (*Server).getBlockCount,
+	"getblockhash":           (*Server).getBlockHash,
+	"getblockheader":         (*Server).getBlockHeader,
+	"getblocksysfee":         (*Server).getBlockSysFee,
+	"getcommittee":           (*Server).getCommittee,
+	"getconnectioncount":     (*Server).getConnectionCount,
+	"getcontractstate":       (*Server).getContractState,
+	"getnep5balances":        (*Server).getNEP5Balances,
+	"getnep5transfers":       (*Server).getNEP5Transfers,
+	"getpeers":               (*Server).getPeers,
+	"getrawmempool":          (*Server).getRawMempool,
+	"getrawtransaction":      (*Server).getrawtransaction,
+	"getstorage":             (*Server).getStorage,
+	"gettransactionheight":   (*Server).getTransactionHeight,
+	"getunclaimedgas":        (*Server).getUnclaimedGas,
+	"getnextblockvalidators": (*Server).getNextBlockValidators,
+	"getversion":             (*Server).getVersion,
+	"invokefunction":         (*Server).invokeFunction,
+	"invokescript":           (*Server).invokescript,
+	"sendrawtransaction":     (*Server).sendrawtransaction,
+	"submitblock":            (*Server).submitBlock,
+	"validateaddress":        (*Server).validateAddress,
 }
 
 var rpcWsHandlers = map[string]func(*Server, request.Params, *subscriber) (interface{}, *response.Error){
@@ -906,13 +906,13 @@ func (s *Server) getUnclaimedGas(ps request.Params) (interface{}, *response.Erro
 	}, nil
 }
 
-// getValidators returns the current NEO consensus nodes information and voting status.
-func (s *Server) getValidators(_ request.Params) (interface{}, *response.Error) {
+// getNextBlockValidators returns validators for the next block with voting status.
+func (s *Server) getNextBlockValidators(_ request.Params) (interface{}, *response.Error) {
 	var validators keys.PublicKeys
 
-	validators, err := s.chain.GetValidators()
+	validators, err := s.chain.GetNextBlockValidators()
 	if err != nil {
-		return nil, response.NewRPCError("can't get validators", "", err)
+		return nil, response.NewRPCError("can't get next block validators", "", err)
 	}
 	enrollments, err := s.chain.GetEnrollments()
 	if err != nil {

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -491,7 +491,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 			},
 		},
 	},
-	"getvalidators": {
+	"getnextblockvalidators": {
 		{
 			params: "[]",
 			result: func(*executor) interface{} {


### PR DESCRIPTION
We don't have `getvalidators` RPS call, there's only
`getnextblockvalidators` in the reference implementation.