### PR TITLE
transaction: rename FeeOnly to None

### DIFF
--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -159,7 +159,7 @@ func NewCommands() []cli.Command {
 				UsageText: "neo-go contract invokefunction -r endpoint -w wallet [-a address] [-g gas] scripthash [method] [arguments...] [--] [signers...]",
 				Description: `Executes given (as a script hash) deployed script with the given method,
    arguments and signers. Sender is included in the list of signers by default
-   with FeeOnly witness scope. If you'd like to change default sender's scope, 
+   with None witness scope. If you'd like to change default sender's scope, 
    specify it via signers parameter. See testinvokefunction documentation for 
    the details about parameters. It differs from testinvokefunction in that this
    command sends an invocation transaction to the network.
@@ -247,9 +247,8 @@ func NewCommands() []cli.Command {
     * 'signer' is hex-encoded 160 bit (20 byte) LE value of signer's address,
                  which could have '0x' prefix.
     * 'scope' is a comma-separated set of cosigner's scopes, which could be:
-        - 'FeeOnly' - marks transaction's sender and can be used only for the
-                      sender. Signer with this scope can't be used during the
-                      script execution and only pays fees for the transaction.
+        - 'None' - default witness scope which may be used for the sender
+			       to only pay fee for the transaction.
         - 'Global' - allows this witness in all contexts. This cannot be combined
                      with other flags.
         - 'CalledByEntry' - means that this condition must hold: EntryScriptHash 

--- a/cli/smartcontract/smart_contract_test.go
+++ b/cli/smartcontract/smart_contract_test.go
@@ -97,9 +97,9 @@ func TestParseCosigner(t *testing.T) {
 			Account: acc,
 			Scopes:  transaction.CalledByEntry,
 		},
-		acc.StringLE() + ":FeeOnly": {
+		acc.StringLE() + ":None": {
 			Account: acc,
-			Scopes:  transaction.FeeOnly,
+			Scopes:  transaction.None,
 		},
 		acc.StringLE() + ":CalledByEntry,CustomContracts": {
 			Account: acc,
@@ -115,7 +115,7 @@ func TestParseCosigner(t *testing.T) {
 		acc.StringLE() + "0",
 		acc.StringLE() + ":Unknown",
 		acc.StringLE() + ":Global,CustomContracts",
-		acc.StringLE() + ":Global,FeeOnly",
+		acc.StringLE() + ":Global,None",
 	}
 	for _, s := range errorCases {
 		_, err := parseCosigner(s)

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1259,7 +1259,7 @@ func (bc *Blockchain) verifyTxAttributes(tx *transaction.Transaction) error {
 			}
 			hasOracle := false
 			for i := range tx.Signers {
-				if tx.Signers[i].Scopes != transaction.FeeOnly {
+				if tx.Signers[i].Scopes != transaction.None {
 					return fmt.Errorf("%w: oracle tx has invalid signer scope", ErrInvalidAttribute)
 				}
 				if tx.Signers[i].Account.Equals(h) {

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -127,7 +127,7 @@ func TestAddBadBlock(t *testing.T) {
 	tx := transaction.New(netmode.UnitTestNet, []byte{byte(opcode.PUSH1)}, 0)
 	tx.Signers = []transaction.Signer{{
 		Account: testchain.MultisigScriptHash(),
-		Scopes:  transaction.FeeOnly,
+		Scopes:  transaction.None,
 	}}
 	require.NoError(t, signTx(bc, tx))
 	b1 := bc.newBlock(tx)
@@ -147,7 +147,7 @@ func TestAddBadBlock(t *testing.T) {
 	tx.ValidUntilBlock = 128
 	tx.Signers = []transaction.Signer{{
 		Account: testchain.MultisigScriptHash(),
-		Scopes:  transaction.FeeOnly,
+		Scopes:  transaction.None,
 	}}
 	require.NoError(t, signTx(bc, tx))
 	require.NoError(t, bc.PoolTx(tx))
@@ -378,7 +378,7 @@ func TestVerifyTx(t *testing.T) {
 			tx.NetworkFee += 4_000_000 // multisig check
 			tx.Signers = []transaction.Signer{{
 				Account: testchain.CommitteeScriptHash(),
-				Scopes:  transaction.FeeOnly,
+				Scopes:  transaction.None,
 			}}
 			rawScript := testchain.CommitteeVerificationScript()
 			require.NoError(t, err)
@@ -419,7 +419,7 @@ func TestVerifyTx(t *testing.T) {
 				tx.SystemFee = int64(req.GasForResponse - uint64(tx.NetworkFee))
 				tx.Signers = []transaction.Signer{{
 					Account: oracleHash,
-					Scopes:  transaction.FeeOnly,
+					Scopes:  transaction.None,
 				}}
 				size := io.GetVarSize(tx)
 				netFee, sizeDelta := CalculateNetworkFee(oracleScript)

--- a/pkg/core/transaction/signer.go
+++ b/pkg/core/transaction/signer.go
@@ -35,7 +35,7 @@ func (c *Signer) EncodeBinary(bw *io.BinWriter) {
 func (c *Signer) DecodeBinary(br *io.BinReader) {
 	br.ReadBytes(c.Account[:])
 	c.Scopes = WitnessScope(br.ReadB())
-	if c.Scopes & ^(Global|CalledByEntry|CustomContracts|CustomGroups|FeeOnly) != 0 {
+	if c.Scopes & ^(Global|CalledByEntry|CustomContracts|CustomGroups|None) != 0 {
 		br.Err = errors.New("unknown witness scope")
 		return
 	}

--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -348,7 +348,6 @@ var (
 	ErrNegativeNetworkFee = errors.New("negative network fee")
 	ErrTooBigFees         = errors.New("too big fees: int64 overflow")
 	ErrEmptySigners       = errors.New("signers array should contain sender")
-	ErrInvalidScope       = errors.New("FeeOnly scope can be used only for sender")
 	ErrNonUniqueSigners   = errors.New("transaction signers should be unique")
 	ErrInvalidAttribute   = errors.New("invalid attribute")
 	ErrEmptyScript        = errors.New("no script")
@@ -372,9 +371,6 @@ func (t *Transaction) isValid() error {
 		return ErrEmptySigners
 	}
 	for i := 0; i < len(t.Signers); i++ {
-		if i > 0 && t.Signers[i].Scopes == FeeOnly {
-			return ErrInvalidScope
-		}
 		for j := i + 1; j < len(t.Signers); j++ {
 			if t.Signers[i].Account.Equals(t.Signers[j].Account) {
 				return ErrNonUniqueSigners

--- a/pkg/core/transaction/transaction_test.go
+++ b/pkg/core/transaction/transaction_test.go
@@ -188,11 +188,6 @@ func TestTransaction_isValid(t *testing.T) {
 		tx.Signers = tx.Signers[:0]
 		require.True(t, errors.Is(tx.isValid(), ErrEmptySigners))
 	})
-	t.Run("InvalidScope", func(t *testing.T) {
-		tx := newTx()
-		tx.Signers[1].Scopes = FeeOnly
-		require.True(t, errors.Is(tx.isValid(), ErrInvalidScope))
-	})
 	t.Run("NonUniqueSigners", func(t *testing.T) {
 		tx := newTx()
 		tx.Signers[1].Account = tx.Signers[0].Account

--- a/pkg/core/transaction/witness_scope.go
+++ b/pkg/core/transaction/witness_scope.go
@@ -11,8 +11,8 @@ import (
 type WitnessScope byte
 
 const (
-	// FeeOnly is only valid for a sender, it can't be used during the execution.
-	FeeOnly WitnessScope = 0
+	// None specifies that no contract was witnessed. Only sign the transaction.
+	None WitnessScope = 0
 	// CalledByEntry means that this condition must hold: EntryScriptHash == CallingScriptHash.
 	// No params is needed, as the witness/permission/signature given on first invocation will
 	// automatically expire if entering deeper internal invokes. This can be default safe
@@ -42,7 +42,7 @@ func ScopesFromString(s string) (WitnessScope, error) {
 		CalledByEntry.String():   CalledByEntry,
 		CustomContracts.String(): CustomContracts,
 		CustomGroups.String():    CustomGroups,
-		FeeOnly.String():         FeeOnly,
+		None.String():            None,
 	}
 	var isGlobal bool
 	for _, scopeStr := range scopes {
@@ -64,7 +64,7 @@ func ScopesFromString(s string) (WitnessScope, error) {
 // scopesToString converts witness scope to it's string representation. It uses
 // `, ` to separate scope names.
 func scopesToString(scopes WitnessScope) string {
-	if scopes&Global != 0 || scopes == FeeOnly {
+	if scopes&Global != 0 || scopes == None {
 		return scopes.String()
 	}
 	var res string

--- a/pkg/core/transaction/witness_scope_string.go
+++ b/pkg/core/transaction/witness_scope_string.go
@@ -8,7 +8,7 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[FeeOnly-0]
+	_ = x[None-0]
 	_ = x[CalledByEntry-1]
 	_ = x[CustomContracts-16]
 	_ = x[CustomGroups-32]
@@ -16,14 +16,14 @@ func _() {
 }
 
 const (
-	_WitnessScope_name_0 = "FeeOnlyCalledByEntry"
+	_WitnessScope_name_0 = "NoneCalledByEntry"
 	_WitnessScope_name_1 = "CustomContracts"
 	_WitnessScope_name_2 = "CustomGroups"
 	_WitnessScope_name_3 = "Global"
 )
 
 var (
-	_WitnessScope_index_0 = [...]uint8{0, 7, 20}
+	_WitnessScope_index_0 = [...]uint8{0, 4, 17}
 )
 
 func (i WitnessScope) String() string {

--- a/pkg/core/util.go
+++ b/pkg/core/util.go
@@ -80,7 +80,7 @@ func deployNativeContracts(magic netmode.Magic) *transaction.Transaction {
 	tx.Signers = []transaction.Signer{
 		{
 			Account: hash.Hash160([]byte{byte(opcode.PUSH1)}),
-			Scopes:  transaction.FeeOnly,
+			Scopes:  transaction.None,
 		},
 	}
 	tx.Scripts = []transaction.Witness{

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -469,7 +469,7 @@ func (c *Client) SignAndPushInvocationTx(script []byte, acc *wallet.Account, sys
 func getSigners(sender util.Uint160, cosigners []transaction.Signer) []transaction.Signer {
 	s := transaction.Signer{
 		Account: sender,
-		Scopes:  transaction.FeeOnly,
+		Scopes:  transaction.None,
 	}
 	for i, c := range cosigners {
 		if c.Account == sender {

--- a/pkg/rpc/request/param_test.go
+++ b/pkg/rpc/request/param_test.go
@@ -107,7 +107,7 @@ func TestParam_UnmarshalJSON(t *testing.T) {
 			Type: Signer,
 			Value: transaction.Signer{
 				Account: accountHash,
-				Scopes:  transaction.FeeOnly,
+				Scopes:  transaction.None,
 			},
 		},
 		{

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -955,7 +955,7 @@ func (s *Server) invokeFunction(reqParams request.Params) (interface{}, *respons
 		checkWitnessHashesIndex--
 	}
 	if len(tx.Signers) == 0 {
-		tx.Signers = []transaction.Signer{{Account: util.Uint160{}, Scopes: transaction.FeeOnly}}
+		tx.Signers = []transaction.Signer{{Account: util.Uint160{}, Scopes: transaction.None}}
 	}
 	script, err := request.CreateFunctionInvocationScript(scriptHash, reqParams[1:checkWitnessHashesIndex])
 	if err != nil {
@@ -985,7 +985,7 @@ func (s *Server) invokescript(reqParams request.Params) (interface{}, *response.
 		tx.Signers = signers
 	}
 	if len(tx.Signers) == 0 {
-		tx.Signers = []transaction.Signer{{Account: util.Uint160{}, Scopes: transaction.FeeOnly}}
+		tx.Signers = []transaction.Signer{{Account: util.Uint160{}, Scopes: transaction.None}}
 	}
 	tx.Script = script
 	return s.runScriptInVM(script, tx), nil


### PR DESCRIPTION
Follow missed change from neo-project/neo#1816 .
`None` may be used for any signer. Currently it is used
for sender to only pay fees, or to sign tx attributes.
