### PR TITLE
Support `_deploy` method

### DIFF
--- a/cli/contract_test.go
+++ b/cli/contract_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/config"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/nef"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComlileAndInvokeFunction(t *testing.T) {
+	e := newExecutor(t, true)
+	defer e.Close(t)
+
+	// For proper nef generation.
+	config.Version = "0.90.0-test"
+
+	tmpDir := os.TempDir()
+	nefName := path.Join(tmpDir, "deploy.nef")
+	manifestName := path.Join(tmpDir, "deploy.manifest.json")
+	e.Run(t, "neo-go", "contract", "compile",
+		"--in", "testdata/deploy/main.go", // compile single file
+		"--config", "testdata/deploy/neo-go.yml",
+		"--out", nefName, "--manifest", manifestName)
+
+	defer func() {
+		os.Remove(nefName)
+		os.Remove(manifestName)
+	}()
+
+	e.In.WriteString("one\r")
+	e.Run(t, "neo-go", "contract", "deploy",
+		"--unittest", "--rpc-endpoint", "http://"+e.RPC.Addr,
+		"--wallet", validatorWallet, "--address", validatorAddr,
+		"--in", nefName, "--manifest", manifestName)
+
+	line, err := e.Out.ReadString('\n')
+	require.NoError(t, err)
+	line = strings.TrimSpace(strings.TrimPrefix(line, "Contract: "))
+	h, err := util.Uint160DecodeStringLE(line)
+	require.NoError(t, err)
+	e.checkTxPersisted(t)
+
+	e.In.WriteString("one\r")
+	e.Run(t, "neo-go", "contract", "testinvokefunction",
+		"--unittest", "--rpc-endpoint", "http://"+e.RPC.Addr,
+		h.StringLE(), "getValue")
+
+	res := new(result.Invoke)
+	require.NoError(t, json.Unmarshal(e.Out.Bytes(), res))
+	require.Equal(t, vm.HaltState.String(), res.State)
+	require.Len(t, res.Stack, 1)
+	require.Equal(t, []byte("on create|sub create"), res.Stack[0].Value())
+
+	t.Run("Update", func(t *testing.T) {
+		nefName := path.Join(tmpDir, "updated.nef")
+		manifestName := path.Join(tmpDir, "updated.manifest.json")
+		e.Run(t, "neo-go", "contract", "compile",
+			"--config", "testdata/deploy/neo-go.yml",
+			"--in", "testdata/deploy/", // compile all files in dir
+			"--out", nefName, "--manifest", manifestName)
+
+		defer func() {
+			os.Remove(nefName)
+			os.Remove(manifestName)
+		}()
+
+		rawNef, err := ioutil.ReadFile(nefName)
+		require.NoError(t, err)
+		realNef, err := nef.FileFromBytes(rawNef)
+		require.NoError(t, err)
+		rawManifest, err := ioutil.ReadFile(manifestName)
+		require.NoError(t, err)
+
+		e.In.WriteString("one\r")
+		e.Run(t, "neo-go", "contract", "invokefunction",
+			"--unittest", "--rpc-endpoint", "http://"+e.RPC.Addr,
+			"--wallet", validatorWallet, "--address", validatorAddr,
+			h.StringLE(), "update",
+			"bytes:"+hex.EncodeToString(realNef.Script),
+			"bytes:"+hex.EncodeToString(rawManifest),
+		)
+		e.checkTxPersisted(t, "Sent invocation transaction ")
+
+		e.In.WriteString("one\r")
+		e.Run(t, "neo-go", "contract", "testinvokefunction",
+			"--unittest", "--rpc-endpoint", "http://"+e.RPC.Addr,
+			hash.Hash160(realNef.Script).StringLE(), "getValue")
+
+		res := new(result.Invoke)
+		require.NoError(t, json.Unmarshal(e.Out.Bytes(), res))
+		require.Equal(t, vm.HaltState.String(), res.State)
+		require.Len(t, res.Stack, 1)
+		require.Equal(t, []byte("on update|sub update"), res.Stack[0].Value())
+	})
+}

--- a/cli/executor_test.go
+++ b/cli/executor_test.go
@@ -185,11 +185,14 @@ func (e *executor) run(args ...string) error {
 	return e.CLI.Run(args)
 }
 
-func (e *executor) checkTxPersisted(t *testing.T) (*transaction.Transaction, uint32) {
+func (e *executor) checkTxPersisted(t *testing.T, prefix ...string) (*transaction.Transaction, uint32) {
 	line, err := e.Out.ReadString('\n')
 	require.NoError(t, err)
 
 	line = strings.TrimSpace(line)
+	if len(prefix) > 0 {
+		line = strings.TrimPrefix(line, prefix[0])
+	}
 	h, err := util.Uint256DecodeStringLE(line)
 	require.NoError(t, err, "can't decode tx hash: %s", line)
 

--- a/cli/testdata/deploy/main.go
+++ b/cli/testdata/deploy/main.go
@@ -1,0 +1,31 @@
+package deploy
+
+import (
+	"github.com/nspcc-dev/neo-go/cli/testdata/deploy/sub"
+	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
+	"github.com/nspcc-dev/neo-go/pkg/interop/storage"
+)
+
+var key = "key"
+
+func _deploy(isUpdate bool) {
+	ctx := storage.GetContext()
+	value := "on create"
+	if isUpdate {
+		value = "on update"
+	}
+	storage.Put(ctx, key, value)
+}
+
+// Update updates contract with the new one.
+func Update(script, manifest []byte) {
+	contract.Update(script, manifest)
+}
+
+// GetValue returns stored value.
+func GetValue() string {
+	ctx := storage.GetReadOnlyContext()
+	val1 := storage.Get(ctx, key)
+	val2 := storage.Get(ctx, sub.Key)
+	return val1.(string) + "|" + val2.(string)
+}

--- a/cli/testdata/deploy/neo-go.yml
+++ b/cli/testdata/deploy/neo-go.yml
@@ -1,0 +1,1 @@
+hasstorage: true

--- a/cli/testdata/deploy/sub/put.go
+++ b/cli/testdata/deploy/sub/put.go
@@ -1,0 +1,14 @@
+package sub
+
+import "github.com/nspcc-dev/neo-go/pkg/interop/storage"
+
+var Key = "sub"
+
+func _deploy(isUpdate bool) {
+	ctx := storage.GetContext()
+	value := "sub create"
+	if isUpdate {
+		value = "sub update"
+	}
+	storage.Put(ctx, Key, value)
+}

--- a/cli/testdata/deploy/updated.go
+++ b/cli/testdata/deploy/updated.go
@@ -1,0 +1,6 @@
+package deploy
+
+// NewMethod in updated contract.
+func NewMethod() int {
+	return 42
+}

--- a/cli/wallet/validator.go
+++ b/cli/wallet/validator.go
@@ -102,7 +102,7 @@ func handleCandidate(ctx *cli.Context, method string) error {
 	gas := flags.Fixed8FromContext(ctx, "gas")
 	w := io.NewBufBinWriter()
 	emit.AppCallWithOperationAndArgs(w.BinWriter, client.NeoContractHash, method, acc.PrivateKey().PublicKey().Bytes())
-	emit.Opcode(w.BinWriter, opcode.ASSERT)
+	emit.Opcodes(w.BinWriter, opcode.ASSERT)
 	tx, err := c.CreateTxFromScript(w.Bytes(), acc, -1, int64(gas), transaction.Signer{
 		Account: acc.Contract.ScriptHash(),
 		Scopes:  transaction.CalledByEntry,
@@ -160,7 +160,7 @@ func handleVote(ctx *cli.Context) error {
 	gas := flags.Fixed8FromContext(ctx, "gas")
 	w := io.NewBufBinWriter()
 	emit.AppCallWithOperationAndArgs(w.BinWriter, client.NeoContractHash, "vote", addr.BytesBE(), pubArg)
-	emit.Opcode(w.BinWriter, opcode.ASSERT)
+	emit.Opcodes(w.BinWriter, opcode.ASSERT)
 
 	tx, err := c.CreateTxFromScript(w.Bytes(), acc, -1, int64(gas), transaction.Signer{
 		Account: acc.Contract.ScriptHash(),

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -36,6 +36,10 @@ functionality as Neo .net Framework library.
 Compiler provides some helpful builtins in `util` and `convert` packages.
 Refer to them for detailed documentation. 
 
+`_deploy()` function has a special meaning and is executed when contract is deployed.
+It should return no value and accept single bool argument which will be true on contract update.
+`_deploy()` functions are called for every imported package in the same order as `init()`. 
+
 ## Quick start
 
 ### Compiling

--- a/pkg/compiler/debug.go
+++ b/pkg/compiler/debug.go
@@ -134,6 +134,27 @@ func (c *codegen) emitDebugInfo(contract []byte) *DebugInfo {
 			SeqPoints:  c.sequencePoints["init"],
 		})
 	}
+	if c.deployEndOffset >= 0 {
+		d.Methods = append(d.Methods, MethodDebugInfo{
+			ID: manifest.MethodDeploy,
+			Name: DebugMethodName{
+				Name:      manifest.MethodDeploy,
+				Namespace: c.mainPkg.Pkg.Name(),
+			},
+			IsExported: true,
+			IsFunction: true,
+			Range: DebugRange{
+				Start: uint16(c.initEndOffset + 1),
+				End:   uint16(c.deployEndOffset),
+			},
+			Parameters: []DebugParam{{
+				Name: "isUpdate",
+				Type: "Boolean",
+			}},
+			ReturnType: "Void",
+			SeqPoints:  c.sequencePoints[manifest.MethodDeploy],
+		})
+	}
 	for name, scope := range c.funcs {
 		m := c.methodInfoFromScope(name, scope)
 		if m.Range.Start == m.Range.End {

--- a/pkg/compiler/debug_test.go
+++ b/pkg/compiler/debug_test.go
@@ -55,6 +55,7 @@ func MethodParams(addr interop.Hash160, h interop.Hash256,
 type MyStruct struct {}
 func (ms MyStruct) MethodOnStruct() { }
 func (ms *MyStruct) MethodOnPointerToStruct() { }
+func _deploy(isUpdate bool) {}
 `
 
 	info, err := getBuildInfo("foo.go", src)
@@ -83,6 +84,7 @@ func (ms *MyStruct) MethodOnPointerToStruct() { }
 			"MethodOnStruct":          "Void",
 			"MethodOnPointerToStruct": "Void",
 			"MethodParams":            "Boolean",
+			"_deploy":                 "Void",
 		}
 		for i := range d.Methods {
 			name := d.Methods[i].ID
@@ -104,6 +106,10 @@ func (ms *MyStruct) MethodOnPointerToStruct() { }
 
 	t.Run("param types", func(t *testing.T) {
 		paramTypes := map[string][]DebugParam{
+			"_deploy": {{
+				Name: "isUpdate",
+				Type: "Boolean",
+			}},
 			"MethodInt": {{
 				Name: "a",
 				Type: "String",
@@ -151,8 +157,16 @@ func (ms *MyStruct) MethodOnPointerToStruct() { }
 				Hash: hash.Hash160(buf),
 				Methods: []manifest.Method{
 					{
-						Name:   "main",
+						Name:   "_deploy",
 						Offset: 0,
+						Parameters: []manifest.Parameter{
+							manifest.NewParameter("isUpdate", smartcontract.BoolType),
+						},
+						ReturnType: smartcontract.VoidType,
+					},
+					{
+						Name:   "main",
+						Offset: 4,
 						Parameters: []manifest.Parameter{
 							manifest.NewParameter("op", smartcontract.StringType),
 						},
@@ -160,7 +174,7 @@ func (ms *MyStruct) MethodOnPointerToStruct() { }
 					},
 					{
 						Name:   "methodInt",
-						Offset: 66,
+						Offset: 70,
 						Parameters: []manifest.Parameter{
 							{
 								Name: "a",
@@ -171,31 +185,31 @@ func (ms *MyStruct) MethodOnPointerToStruct() { }
 					},
 					{
 						Name:       "methodString",
-						Offset:     97,
+						Offset:     101,
 						Parameters: []manifest.Parameter{},
 						ReturnType: smartcontract.StringType,
 					},
 					{
 						Name:       "methodByteArray",
-						Offset:     103,
+						Offset:     107,
 						Parameters: []manifest.Parameter{},
 						ReturnType: smartcontract.ByteArrayType,
 					},
 					{
 						Name:       "methodArray",
-						Offset:     108,
+						Offset:     112,
 						Parameters: []manifest.Parameter{},
 						ReturnType: smartcontract.ArrayType,
 					},
 					{
 						Name:       "methodStruct",
-						Offset:     113,
+						Offset:     117,
 						Parameters: []manifest.Parameter{},
 						ReturnType: smartcontract.ArrayType,
 					},
 					{
 						Name:   "methodConcat",
-						Offset: 88,
+						Offset: 92,
 						Parameters: []manifest.Parameter{
 							{
 								Name: "a",
@@ -214,7 +228,7 @@ func (ms *MyStruct) MethodOnPointerToStruct() { }
 					},
 					{
 						Name:   "methodParams",
-						Offset: 125,
+						Offset: 129,
 						Parameters: []manifest.Parameter{
 							manifest.NewParameter("addr", smartcontract.Hash160Type),
 							manifest.NewParameter("h", smartcontract.Hash256Type),

--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -152,10 +152,10 @@ func (c *funcScope) analyzeVoidCalls(node ast.Node) bool {
 	return true
 }
 
-func (c *funcScope) countLocals() int {
+func countLocals(decl *ast.FuncDecl) (int, bool) {
 	size := 0
 	hasDefer := false
-	ast.Inspect(c.decl, func(n ast.Node) bool {
+	ast.Inspect(decl, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.FuncType:
 			num := n.Results.NumFields()
@@ -186,6 +186,11 @@ func (c *funcScope) countLocals() int {
 		}
 		return true
 	})
+	return size, hasDefer
+}
+
+func (c *funcScope) countLocals() int {
+	size, hasDefer := countLocals(c.decl)
 	if hasDefer {
 		c.finallyProcessedIndex = size
 		size++

--- a/pkg/compiler/init_test.go
+++ b/pkg/compiler/init_test.go
@@ -24,11 +24,13 @@ func TestInit(t *testing.T) {
 		var m = map[int]int{}
 		var a = 2
 		func init() {
-			m[1] = 11
+			b := 11
+			m[1] = b
 		}
 		func init() {
 			a = 1
-			m[3] = 30
+			var b int
+			m[3] = 30 + b
 		}
 		func Main() int {
 			return m[1] + m[3] + a

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -237,12 +237,12 @@ func TestVerifyTx(t *testing.T) {
 			}
 			emit.AppCallWithOperationAndArgs(w.BinWriter, sc, "transfer",
 				neoOwner, a.Contract.ScriptHash(), amount)
-			emit.Opcode(w.BinWriter, opcode.ASSERT)
+			emit.Opcodes(w.BinWriter, opcode.ASSERT)
 		}
 	}
 	emit.AppCallWithOperationAndArgs(w.BinWriter, gasHash, "transfer",
 		neoOwner, testchain.CommitteeScriptHash(), int64(1_000_000_000))
-	emit.Opcode(w.BinWriter, opcode.ASSERT)
+	emit.Opcodes(w.BinWriter, opcode.ASSERT)
 	require.NoError(t, w.Err)
 
 	txMove := bc.newTestTx(neoOwner, w.Bytes())
@@ -782,7 +782,7 @@ func TestSubscriptions(t *testing.T) {
 	script = io.NewBufBinWriter()
 	emit.Bytes(script.BinWriter, []byte("nay!"))
 	emit.Syscall(script.BinWriter, interopnames.SystemRuntimeNotify)
-	emit.Opcode(script.BinWriter, opcode.THROW)
+	emit.Opcodes(script.BinWriter, opcode.THROW)
 	require.NoError(t, script.Err)
 	txBad := transaction.New(netmode.UnitTestNet, script.Bytes(), 0)
 	txBad.Signers = []transaction.Signer{{Account: neoOwner}}

--- a/pkg/core/helper_test.go
+++ b/pkg/core/helper_test.go
@@ -361,7 +361,7 @@ func TestCreateBasicChain(t *testing.T) {
 func newNEP5Transfer(sc, from, to util.Uint160, amount int64) *transaction.Transaction {
 	w := io.NewBufBinWriter()
 	emit.AppCallWithOperationAndArgs(w.BinWriter, sc, "transfer", from, to, amount)
-	emit.Opcode(w.BinWriter, opcode.ASSERT)
+	emit.Opcodes(w.BinWriter, opcode.ASSERT)
 
 	script := w.Bytes()
 	return transaction.New(testchain.Network(), script, 10000000)

--- a/pkg/core/interop_neo.go
+++ b/pkg/core/interop_neo.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neo-go/pkg/core/interop"
+	"github.com/nspcc-dev/neo-go/pkg/core/interop/contract"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
 	"github.com/nspcc-dev/neo-go/pkg/vm"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
@@ -109,7 +111,7 @@ func contractCreate(ic *interop.Context) error {
 		return fmt.Errorf("cannot convert contract to stack item: %w", err)
 	}
 	ic.VM.Estack().PushVal(cs)
-	return nil
+	return callDeploy(ic, newcontract, false)
 }
 
 // contractUpdate migrates a contract. This method assumes that Manifest and Script
@@ -183,6 +185,15 @@ func contractUpdate(ic *interop.Context) error {
 		}
 	}
 
+	return callDeploy(ic, contract, true)
+}
+
+func callDeploy(ic *interop.Context, cs *state.Contract, isUpdate bool) error {
+	md := cs.Manifest.ABI.GetMethod(manifest.MethodDeploy)
+	if md != nil {
+		return contract.CallExInternal(ic, cs, manifest.MethodDeploy,
+			[]stackitem.Item{stackitem.NewBool(isUpdate)}, smartcontract.All)
+	}
 	return nil
 }
 

--- a/pkg/core/native/contract.go
+++ b/pkg/core/native/contract.go
@@ -83,10 +83,10 @@ func (cs *Contracts) GetPersistScript() []byte {
 			continue
 		}
 		emit.Int(w.BinWriter, 0)
-		emit.Opcode(w.BinWriter, opcode.NEWARRAY)
+		emit.Opcodes(w.BinWriter, opcode.NEWARRAY)
 		emit.String(w.BinWriter, "onPersist")
 		emit.AppCall(w.BinWriter, md.Hash)
-		emit.Opcode(w.BinWriter, opcode.DROP)
+		emit.Opcodes(w.BinWriter, opcode.DROP)
 	}
 	cs.persistScript = w.Bytes()
 	return cs.persistScript
@@ -106,10 +106,10 @@ func (cs *Contracts) GetPostPersistScript() []byte {
 			continue
 		}
 		emit.Int(w.BinWriter, 0)
-		emit.Opcode(w.BinWriter, opcode.NEWARRAY)
+		emit.Opcodes(w.BinWriter, opcode.NEWARRAY)
 		emit.String(w.BinWriter, "postPersist")
 		emit.AppCall(w.BinWriter, md.Hash)
-		emit.Opcode(w.BinWriter, opcode.DROP)
+		emit.Opcodes(w.BinWriter, opcode.DROP)
 	}
 	cs.postPersistScript = w.Bytes()
 	return cs.postPersistScript

--- a/pkg/core/native/oracle.go
+++ b/pkg/core/native/oracle.go
@@ -56,7 +56,7 @@ func init() {
 
 	w.Reset()
 	emit.Int(w.BinWriter, 0)
-	emit.Opcode(w.BinWriter, opcode.NEWARRAY)
+	emit.Opcodes(w.BinWriter, opcode.NEWARRAY)
 	emit.String(w.BinWriter, "finish")
 	emit.Bytes(w.BinWriter, h.BytesBE())
 	emit.Syscall(w.BinWriter, interopnames.SystemContractCall)

--- a/pkg/core/native_designate_test.go
+++ b/pkg/core/native_designate_test.go
@@ -23,10 +23,10 @@ func (bc *Blockchain) setNodesByRole(t *testing.T, ok bool, r native.Role, nodes
 		emit.Bytes(w.BinWriter, pub.Bytes())
 	}
 	emit.Int(w.BinWriter, int64(len(nodes)))
-	emit.Opcode(w.BinWriter, opcode.PACK)
+	emit.Opcodes(w.BinWriter, opcode.PACK)
 	emit.Int(w.BinWriter, int64(r))
 	emit.Int(w.BinWriter, 2)
-	emit.Opcode(w.BinWriter, opcode.PACK)
+	emit.Opcodes(w.BinWriter, opcode.PACK)
 	emit.String(w.BinWriter, "designateAsRole")
 	emit.AppCall(w.BinWriter, bc.contracts.Designate.Hash)
 	require.NoError(t, w.Err)

--- a/pkg/core/native_oracle_test.go
+++ b/pkg/core/native_oracle_test.go
@@ -27,26 +27,26 @@ import (
 func getOracleContractState(h util.Uint160) *state.Contract {
 	w := io.NewBufBinWriter()
 	emit.Int(w.BinWriter, 5)
-	emit.Opcode(w.BinWriter, opcode.PACK)
+	emit.Opcodes(w.BinWriter, opcode.PACK)
 	emit.String(w.BinWriter, "request")
 	emit.Bytes(w.BinWriter, h.BytesBE())
 	emit.Syscall(w.BinWriter, interopnames.SystemContractCall)
-	emit.Opcode(w.BinWriter, opcode.RET)
+	emit.Opcodes(w.BinWriter, opcode.RET)
 
 	// `handle` method aborts if len(userData) == 2
 	offset := w.Len()
-	emit.Opcode(w.BinWriter, opcode.OVER)
-	emit.Opcode(w.BinWriter, opcode.SIZE)
+	emit.Opcodes(w.BinWriter, opcode.OVER)
+	emit.Opcodes(w.BinWriter, opcode.SIZE)
 	emit.Int(w.BinWriter, 2)
 	emit.Instruction(w.BinWriter, opcode.JMPNE, []byte{3})
-	emit.Opcode(w.BinWriter, opcode.ABORT)
+	emit.Opcodes(w.BinWriter, opcode.ABORT)
 	emit.Int(w.BinWriter, 4) // url, userData, code, result
-	emit.Opcode(w.BinWriter, opcode.PACK)
+	emit.Opcodes(w.BinWriter, opcode.PACK)
 	emit.Syscall(w.BinWriter, interopnames.SystemBinarySerialize)
 	emit.String(w.BinWriter, "lastOracleResponse")
 	emit.Syscall(w.BinWriter, interopnames.SystemStorageGetContext)
 	emit.Syscall(w.BinWriter, interopnames.SystemStoragePut)
-	emit.Opcode(w.BinWriter, opcode.RET)
+	emit.Opcodes(w.BinWriter, opcode.RET)
 
 	m := manifest.NewManifest(h)
 	m.Features = smartcontract.HasStorage

--- a/pkg/crypto/keys/publickey.go
+++ b/pkg/crypto/keys/publickey.go
@@ -314,7 +314,7 @@ func (p *PublicKey) GetVerificationScript() []byte {
 		return buf.Bytes()
 	}
 	emit.Bytes(buf.BinWriter, b)
-	emit.Opcode(buf.BinWriter, opcode.PUSHNULL)
+	emit.Opcodes(buf.BinWriter, opcode.PUSHNULL)
 	emit.Syscall(buf.BinWriter, interopnames.NeoCryptoVerifyWithECDsaSecp256r1)
 
 	return buf.Bytes()

--- a/pkg/rpc/client/nep5.go
+++ b/pkg/rpc/client/nep5.go
@@ -132,7 +132,7 @@ func (c *Client) CreateNEP5MultiTransferTx(acc *wallet.Account, gas int64, recip
 	for i := range recipients {
 		emit.AppCallWithOperationAndArgs(w.BinWriter, recipients[i].Token, "transfer", from,
 			recipients[i].Address, recipients[i].Amount)
-		emit.Opcode(w.BinWriter, opcode.ASSERT)
+		emit.Opcodes(w.BinWriter, opcode.ASSERT)
 	}
 	return c.CreateTxFromScript(w.Bytes(), acc, -1, gas, transaction.Signer{
 		Account: acc.Contract.ScriptHash(),

--- a/pkg/rpc/request/txBuilder.go
+++ b/pkg/rpc/request/txBuilder.go
@@ -107,7 +107,7 @@ func expandArrayIntoScript(script *io.BinWriter, slice []Param) error {
 				return err
 			}
 			emit.Int(script, int64(len(val)))
-			emit.Opcode(script, opcode.PACK)
+			emit.Opcodes(script, opcode.PACK)
 		default:
 			return fmt.Errorf("parameter type %v is not supported", fp.Type)
 		}
@@ -139,7 +139,7 @@ func CreateFunctionInvocationScript(contract util.Uint160, params Params) ([]byt
 				return nil, err
 			}
 			emit.Int(script.BinWriter, int64(len(slice)))
-			emit.Opcode(script.BinWriter, opcode.PACK)
+			emit.Opcodes(script.BinWriter, opcode.PACK)
 		}
 	}
 

--- a/pkg/smartcontract/contract.go
+++ b/pkg/smartcontract/contract.go
@@ -31,7 +31,7 @@ func CreateMultiSigRedeemScript(m int, publicKeys keys.PublicKeys) ([]byte, erro
 		emit.Bytes(buf.BinWriter, pubKey.Bytes())
 	}
 	emit.Int(buf.BinWriter, int64(len(publicKeys)))
-	emit.Opcode(buf.BinWriter, opcode.PUSHNULL)
+	emit.Opcodes(buf.BinWriter, opcode.PUSHNULL)
 	emit.Syscall(buf.BinWriter, interopnames.NeoCryptoCheckMultisigWithECDsaSecp256r1)
 
 	return buf.Bytes(), nil

--- a/pkg/smartcontract/manifest/manifest.go
+++ b/pkg/smartcontract/manifest/manifest.go
@@ -15,6 +15,9 @@ const (
 	// MethodInit is a name for default initialization method.
 	MethodInit = "_initialize"
 
+	// MethodDeploy is a name for default method called during contract deployment.
+	MethodDeploy = "_deploy"
+
 	// MethodVerify is a name for default verification method.
 	MethodVerify = "verify"
 

--- a/pkg/vm/emit/emit_test.go
+++ b/pkg/vm/emit/emit_test.go
@@ -181,6 +181,13 @@ func TestEmitBool(t *testing.T) {
 	assert.Equal(t, opcode.Opcode(result[1]), opcode.PUSH0)
 }
 
+func TestEmitOpcode(t *testing.T) {
+	w := io.NewBufBinWriter()
+	Opcodes(w.BinWriter, opcode.PUSH1, opcode.NEWMAP)
+	result := w.Bytes()
+	assert.Equal(t, result, []byte{byte(opcode.PUSH1), byte(opcode.NEWMAP)})
+}
+
 func TestEmitString(t *testing.T) {
 	buf := io.NewBufBinWriter()
 	str := "City Of Zion"

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -39,7 +39,7 @@ func TestInteropHook(t *testing.T) {
 
 	buf := io.NewBufBinWriter()
 	emit.Syscall(buf.BinWriter, "foo")
-	emit.Opcode(buf.BinWriter, opcode.RET)
+	emit.Opcodes(buf.BinWriter, opcode.RET)
 	v.Load(buf.Bytes())
 	runVM(t, v)
 	assert.Equal(t, 1, v.estack.Len())
@@ -773,11 +773,11 @@ func TestSerializeMapCompat(t *testing.T) {
 
 	// Create a map, push key and value, add KV to map, serialize.
 	buf := io.NewBufBinWriter()
-	emit.Opcode(buf.BinWriter, opcode.NEWMAP)
-	emit.Opcode(buf.BinWriter, opcode.DUP)
+	emit.Opcodes(buf.BinWriter, opcode.NEWMAP)
+	emit.Opcodes(buf.BinWriter, opcode.DUP)
 	emit.Bytes(buf.BinWriter, []byte("key"))
 	emit.Bytes(buf.BinWriter, []byte("value"))
-	emit.Opcode(buf.BinWriter, opcode.SETITEM)
+	emit.Opcodes(buf.BinWriter, opcode.SETITEM)
 	emit.Syscall(buf.BinWriter, interopnames.SystemBinarySerialize)
 	require.NoError(t, buf.Err)
 
@@ -1654,12 +1654,12 @@ func TestSIGN(t *testing.T) {
 func TestSimpleCall(t *testing.T) {
 	buf := io.NewBufBinWriter()
 	w := buf.BinWriter
-	emit.Opcode(w, opcode.PUSH2)
+	emit.Opcodes(w, opcode.PUSH2)
 	emit.Instruction(w, opcode.CALL, []byte{03})
-	emit.Opcode(w, opcode.RET)
-	emit.Opcode(w, opcode.PUSH10)
-	emit.Opcode(w, opcode.ADD)
-	emit.Opcode(w, opcode.RET)
+	emit.Opcodes(w, opcode.RET)
+	emit.Opcodes(w, opcode.PUSH10)
+	emit.Opcodes(w, opcode.ADD)
+	emit.Opcodes(w, opcode.RET)
 
 	result := 12
 	vm := load(buf.Bytes())


### PR DESCRIPTION
Close #1443 .

1. Add support in interops and compiler.
2. Add CLI tests with full contract lifecycle (compile, deploy, testinvoke, invoke and update). 