### PR TITLE
cli: allow to send multisig deploy/invoke tx

### DIFF
--- a/cli/paramcontext/context.go
+++ b/cli/paramcontext/context.go
@@ -1,0 +1,53 @@
+package paramcontext
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/context"
+	"github.com/nspcc-dev/neo-go/pkg/wallet"
+)
+
+// validUntilBlockIncrement is the number of extra blocks to add to an exported transaction
+const validUntilBlockIncrement = 50
+
+// InitAndSave creates incompletely signed transaction which can used
+// as input to `multisig sign`.
+func InitAndSave(tx *transaction.Transaction, acc *wallet.Account, filename string) error {
+	// avoid fast transaction expiration
+	tx.ValidUntilBlock += validUntilBlockIncrement
+	priv := acc.PrivateKey()
+	pub := priv.PublicKey()
+	sign := priv.Sign(tx.GetSignedPart())
+	scCtx := context.NewParameterContext("Neo.Core.ContractTransaction", tx)
+	if err := scCtx.AddSignature(acc.Contract, pub, sign); err != nil {
+		return fmt.Errorf("can't add signature: %w", err)
+	}
+	return Save(scCtx, filename)
+}
+
+// Read reads parameter context from file.
+func Read(filename string) (*context.ParameterContext, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("can't read input file: %w", err)
+	}
+
+	c := new(context.ParameterContext)
+	if err := json.Unmarshal(data, c); err != nil {
+		return nil, fmt.Errorf("can't parse transaction: %w", err)
+	}
+	return c, nil
+}
+
+// Save writes parameter context to file.
+func Save(c *context.ParameterContext, filename string) error {
+	if data, err := json.Marshal(c); err != nil {
+		return fmt.Errorf("can't marshal transaction: %w", err)
+	} else if err := ioutil.WriteFile(filename, data, 0644); err != nil {
+		return fmt.Errorf("can't write transaction to file: %w", err)
+	}
+	return nil
+}

--- a/cli/wallet/multisig.go
+++ b/cli/wallet/multisig.go
@@ -1,14 +1,12 @@
 package wallet
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/nspcc-dev/neo-go/cli/options"
+	"github.com/nspcc-dev/neo-go/cli/paramcontext"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
-	"github.com/nspcc-dev/neo-go/pkg/smartcontract/context"
 	"github.com/urfave/cli"
 )
 
@@ -41,7 +39,7 @@ func signMultisig(ctx *cli.Context) error {
 	}
 	defer wall.Close()
 
-	c, err := readParameterContext(ctx.String("in"))
+	c, err := paramcontext.Read(ctx.String("in"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
@@ -66,7 +64,7 @@ func signMultisig(ctx *cli.Context) error {
 		return cli.NewExitError(fmt.Errorf("can't add signature: %w", err), 1)
 	}
 	if out := ctx.String("out"); out != "" {
-		if err := writeParameterContext(c, out); err != nil {
+		if err := paramcontext.Save(c, out); err != nil {
 			return cli.NewExitError(err, 1)
 		}
 	}
@@ -93,27 +91,5 @@ func signMultisig(ctx *cli.Context) error {
 	}
 
 	fmt.Fprintln(ctx.App.Writer, tx.Hash().StringLE())
-	return nil
-}
-
-func readParameterContext(filename string) (*context.ParameterContext, error) {
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, fmt.Errorf("can't read input file: %w", err)
-	}
-
-	c := new(context.ParameterContext)
-	if err := json.Unmarshal(data, c); err != nil {
-		return nil, fmt.Errorf("can't parse transaction: %w", err)
-	}
-	return c, nil
-}
-
-func writeParameterContext(c *context.ParameterContext, filename string) error {
-	if data, err := json.Marshal(c); err != nil {
-		return fmt.Errorf("can't marshal transaction: %w", err)
-	} else if err := ioutil.WriteFile(filename, data, 0644); err != nil {
-		return fmt.Errorf("can't write transaction to file: %w", err)
-	}
 	return nil
 }


### PR DESCRIPTION
It allows to invoke native contracts as committee
from CLI in privnet, e.g. to set new oracle nodes.

Also don't require `--out` flag in `multisig sign` if tx is to be pushed.