### PR TITLE
server: don't always Sprintf params for logger

### DIFF
--- a/pkg/rpc/request/params.go
+++ b/pkg/rpc/request/params.go
@@ -1,5 +1,7 @@
 package request
 
+import "fmt"
+
 type (
 	// Params represents the JSON-RPC params.
 	Params []Param
@@ -22,4 +24,8 @@ func (p Params) ValueWithType(index int, valType paramType) *Param {
 		return val
 	}
 	return nil
+}
+
+func (p Params) String() string {
+	return fmt.Sprintf("%v", []Param(p))
 }

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -291,7 +291,7 @@ func (s *Server) handleRequest(req *request.In, sub *subscriber) response.Abstra
 
 	s.log.Debug("processing rpc request",
 		zap.String("method", req.Method),
-		zap.String("params", fmt.Sprintf("%v", reqParams)))
+		zap.Stringer("params", reqParams))
 
 	incCounter(req.Method)
 


### PR DESCRIPTION
Add Stringer to Params, if we're not printing Debug messages (which usually is
the case), it won't be called at all. Micro-optimization.
