### PR TITLE
core: copy storage item key in simple.GetStorageItems

### DIFF
--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -627,7 +627,9 @@ func (dao *Simple) GetStorageItems(hash util.Uint160, prefix []byte) ([]StorageI
 		}
 
 		// Cut prefix and hash.
-		s.Key = k[21:]
+		// Must copy here, #1468.
+		s.Key = make([]byte, len(k[21:]))
+		copy(s.Key, k[21:])
 		res = append(res, s)
 	}
 	dao.Store.Seek(makeStorageItemKey(hash, prefix), saveToMap)

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -42,6 +42,8 @@ type (
 		Get([]byte) ([]byte, error)
 		Put(k, v []byte) error
 		PutBatch(Batch) error
+		// Seek can guarantee that provided key (k) and value (v) are the only valid until the next call to f.
+		// Key and value slices should not be modified.
 		Seek(k []byte, f func(k, v []byte))
 		Close() error
 	}


### PR DESCRIPTION
Close #1468.

We should copy the key to avoid bytes substitution. Otherwise, there's a
chance that at the end of dao.Store.Seek(...) execution some keys won't
be the same as the original keys found inside saveToMap function.