### PR TITLE
native: provide `name` method for all contracts

### DIFF
--- a/pkg/core/native/designate.go
+++ b/pkg/core/native/designate.go
@@ -67,6 +67,10 @@ func newDesignate() *Designate {
 	md = newMethodAndPrice(s.designateAsRole, 0, smartcontract.AllowModifyStates)
 	s.AddMethod(md, desc, false)
 
+	desc = newDescriptor("name", smartcontract.StringType)
+	md = newMethodAndPrice(nameMethod(designateName), 0, smartcontract.NoneFlag)
+	s.AddMethod(md, desc, true)
+
 	return s
 }
 

--- a/pkg/core/native/native_nep5.go
+++ b/pkg/core/native/native_nep5.go
@@ -53,7 +53,7 @@ func newNEP5Native(name string) *nep5TokenNative {
 	n.Manifest.SupportedStandards = []string{manifest.NEP5StandardName}
 
 	desc := newDescriptor("name", smartcontract.StringType)
-	md := newMethodAndPrice(n.Name, 0, smartcontract.NoneFlag)
+	md := newMethodAndPrice(nameMethod(name), 0, smartcontract.NoneFlag)
 	n.AddMethod(md, desc, true)
 
 	desc = newDescriptor("symbol", smartcontract.StringType)
@@ -96,10 +96,6 @@ func newNEP5Native(name string) *nep5TokenNative {
 
 func (c *nep5TokenNative) Initialize(_ *interop.Context) error {
 	return nil
-}
-
-func (c *nep5TokenNative) Name(_ *interop.Context, _ []stackitem.Item) stackitem.Item {
-	return stackitem.NewByteArray([]byte(c.ContractMD.Name))
 }
 
 func (c *nep5TokenNative) Symbol(_ *interop.Context, _ []stackitem.Item) stackitem.Item {

--- a/pkg/core/native/oracle.go
+++ b/pkg/core/native/oracle.go
@@ -111,6 +111,10 @@ func newOracle() *Oracle {
 	md := newMethodAndPrice(o.request, oracleRequestPrice, smartcontract.AllowModifyStates)
 	o.AddMethod(md, desc, false)
 
+	desc = newDescriptor("name", smartcontract.StringType)
+	md = newMethodAndPrice(nameMethod(oracleName), 0, smartcontract.NoneFlag)
+	o.AddMethod(md, desc, true)
+
 	desc = newDescriptor("finish", smartcontract.VoidType)
 	md = newMethodAndPrice(o.finish, 0, smartcontract.AllowModifyStates)
 	o.AddMethod(md, desc, false)

--- a/pkg/core/native/policy.go
+++ b/pkg/core/native/policy.go
@@ -126,6 +126,10 @@ func newPolicy() *Policy {
 	md = newMethodAndPrice(p.unblockAccount, 3000000, smartcontract.AllowModifyStates)
 	p.AddMethod(md, desc, false)
 
+	desc = newDescriptor("name", smartcontract.StringType)
+	md = newMethodAndPrice(nameMethod(policyName), 0, smartcontract.NoneFlag)
+	p.AddMethod(md, desc, true)
+
 	desc = newDescriptor("onPersist", smartcontract.VoidType)
 	md = newMethodAndPrice(getOnPersistWrapper(p.OnPersist), 0, smartcontract.AllowModifyStates)
 	p.AddMethod(md, desc, false)

--- a/pkg/core/native/util.go
+++ b/pkg/core/native/util.go
@@ -2,8 +2,10 @@ package native
 
 import (
 	"github.com/nspcc-dev/neo-go/pkg/core/dao"
+	"github.com/nspcc-dev/neo-go/pkg/core/interop"
 	"github.com/nspcc-dev/neo-go/pkg/core/storage"
 	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
 func getSerializableFromDAO(id int32, d dao.DAO, key []byte, item io.Serializable) error {
@@ -14,4 +16,10 @@ func getSerializableFromDAO(id int32, d dao.DAO, key []byte, item io.Serializabl
 	r := io.NewBinReaderFromBuf(si.Value)
 	item.DecodeBinary(r)
 	return r.Err
+}
+
+func nameMethod(name string) interop.Method {
+	return func(_ *interop.Context, _ []stackitem.Item) stackitem.Item {
+		return stackitem.NewByteArray([]byte(name))
+	}
 }


### PR DESCRIPTION
As it should be.