### PR TITLE
core: copy storage item key in simple.GetStorageItems

### DIFF
--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -413,7 +413,10 @@ func (dao *Simple) GetStorageItemsWithPrefix(id int32, prefix []byte) (map[strin
 		}
 
 		// Cut prefix and hash.
-		siMap[string(k[len(lookupKey):])] = si
+		// Must copy here, #1468.
+		key := make([]byte, len(k[len(lookupKey):]))
+		copy(key, k[len(lookupKey):])
+		siMap[string(key)] = si
 	}
 	dao.Store.Seek(lookupKey, saveToMap)
 	if err != nil {

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -38,6 +38,8 @@ type (
 		Get([]byte) ([]byte, error)
 		Put(k, v []byte) error
 		PutBatch(Batch) error
+		// Seek can guarantee that provided key (k) and value (v) are the only valid until the next call to f.
+		// Key and value slices should not be modified.
 		Seek(k []byte, f func(k, v []byte))
 		Close() error
 	}


### PR DESCRIPTION
Related to #1468, ported from #1475.

We should copy the key to avoid bytes substitution. Otherwise there's a
chance that at the end of dao.Store.Seek(...) execution some keys won't
be the same as the original keys found inside saveToMap function because
storage.Seek can guarantee that provided key and value are only valid
until the next `f` call.
