### PR TITLE
compiler: fix manifest method offset

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -1951,18 +1951,21 @@ func (c *codegen) writeJumps(b []byte) ([]byte, error) {
 	// Correct function ip range.
 	// Note: indices are sorted in increasing order.
 	for _, f := range c.funcs {
+		start, end := f.rng.Start, f.rng.End
 	loop:
 		for _, ind := range offsets {
 			switch {
 			case ind > int(f.rng.End):
 				break loop
 			case ind < int(f.rng.Start):
-				f.rng.Start -= longToShortRemoveCount
-				f.rng.End -= longToShortRemoveCount
+				start -= longToShortRemoveCount
+				end -= longToShortRemoveCount
 			case ind >= int(f.rng.Start):
-				f.rng.End -= longToShortRemoveCount
+				end -= longToShortRemoveCount
 			}
 		}
+		f.rng.Start = start
+		f.rng.End = end
 	}
 	return shortenJumps(b, offsets), nil
 }

--- a/pkg/compiler/function_call_test.go
+++ b/pkg/compiler/function_call_test.go
@@ -3,7 +3,12 @@ package compiler_test
 import (
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/compiler"
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleFunctionCall(t *testing.T) {
@@ -268,4 +273,20 @@ func TestVariadicMethod(t *testing.T) {
 		return x.someFunc(10, 1, 2, 3)
 	}`
 	eval(t, src, big.NewInt(42))
+}
+
+func TestJumpOptimize(t *testing.T) {
+	src := `package foo
+	func Get1() int { return 1 }
+	func Get2() int { Get1(); Get1(); Get1(); Get1(); return Get1() }
+	func Get3() int { return Get2() }
+	func Main() int {
+		return Get3()
+	}`
+	b, di, err := compiler.CompileWithDebugInfo("", strings.NewReader(src))
+	require.NoError(t, err)
+	for _, mi := range di.Methods {
+		require.Equal(t, b[mi.Range.Start], byte(opcode.INITSLOT))
+		require.Equal(t, b[mi.Range.End], byte(opcode.RET))
+	}
 }


### PR DESCRIPTION
While optimizing jumps (done in cfa62e7) old offsets should be compared
with the method offset before optimization, not with
the constantly changing value.