### PR TITLE
compiler: refactor void calls processing

### DIFF
--- a/pkg/compiler/function_call_test.go
+++ b/pkg/compiler/function_call_test.go
@@ -86,6 +86,15 @@ func TestNotAssignedFunctionCall(t *testing.T) {
 		}`
 		eval(t, src, big.NewInt(42))
 	})
+	t.Run("VarDecl", func(t *testing.T) {
+		src := `package foo
+		func foo() []int { return []int{1} }
+		func Main() int {
+			var x = foo()
+			return len(x)
+		}`
+		eval(t, src, big.NewInt(1))
+	})
 }
 
 func TestMultipleFunctionCalls(t *testing.T) {


### PR DESCRIPTION
Call result is not used only if it occurs inside a `ExprStmt`.
Otherwise (`IfStmt`, `BinExpr`...) it is used.

Fix #1495.