### PR TITLE
rpc: fix Matches and marshalling for notification events

### DIFF
--- a/pkg/core/state/notification_event.go
+++ b/pkg/core/state/notification_event.go
@@ -93,7 +93,7 @@ type notificationEventAux struct {
 }
 
 // MarshalJSON implements implements json.Marshaler interface.
-func (ne *NotificationEvent) MarshalJSON() ([]byte, error) {
+func (ne NotificationEvent) MarshalJSON() ([]byte, error) {
 	item, err := stackitem.ToJSONWithTypes(ne.Item)
 	if err != nil {
 		item = []byte(`"error: recursive reference"`)

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -1244,7 +1244,7 @@ chloop:
 			resp.Payload[0] = execution
 		case notification := <-s.notificationCh:
 			resp.Event = response.NotificationEventID
-			resp.Payload[0] = *notification
+			resp.Payload[0] = notification
 		case tx := <-s.transactionCh:
 			resp.Event = response.TransactionEventID
 			resp.Payload[0] = tx

--- a/pkg/rpc/server/subscription.go
+++ b/pkg/rpc/server/subscription.go
@@ -72,7 +72,7 @@ func (f *feed) Matches(r *response.Notification) bool {
 		return senderOK && signerOK
 	case response.NotificationEventID:
 		filt := f.filter.(request.NotificationFilter)
-		notification := r.Payload[0].(state.NotificationEvent)
+		notification := r.Payload[0].(*state.NotificationEvent)
 		hashOk := filt.Contract == nil || notification.ScriptHash.Equals(*filt.Contract)
 		nameOk := filt.Name == nil || notification.Name == *filt.Name
 		return hashOk && nameOk


### PR DESCRIPTION
Close #1494. Marshalling went wrong due to the incorrect pointers usage.
Reproduced and fixed.