### PR TITLE
cli: fixed removed network arguments

### DIFF
--- a/cli/options/options.go
+++ b/cli/options/options.go
@@ -22,7 +22,12 @@ const RPCEndpointFlag = "rpc-endpoint"
 
 // Network is a set of flags for choosing the network to operate on
 // (privnet/mainnet/testnet).
-var Network = RPC[2:]
+var Network = []cli.Flag{
+	cli.BoolFlag{Name: "privnet, p"},
+	cli.BoolFlag{Name: "mainnet, m"},
+	cli.BoolFlag{Name: "testnet, t"},
+	cli.BoolFlag{Name: "unittest", Hidden: true},
+}
 
 // RPC is a set of flags used for RPC connections (endpoint and timeout).
 var RPC = []cli.Flag{


### PR DESCRIPTION
Should be done in 590be7a. I removed
network flags from RPC, but we still need them for server-related
cli commands.