### PR TITLE
Implement reference counting in MPT

### DIFF
--- a/pkg/config/protocol_config.go
+++ b/pkg/config/protocol_config.go
@@ -22,6 +22,10 @@ type (
 		AddressVersion byte `yaml:"AddressVersion"`
 		// EnableStateRoot specifies if exchange of state roots should be enabled.
 		EnableStateRoot bool `yaml:"EnableStateRoot"`
+		// KeepOnlyLatestState specifies if MPT should only store latest state.
+		// If true, DB size will be smaller, but older roots won't be accessible.
+		// This value should remain the same for the same database.
+		KeepOnlyLatestState bool `yaml:"KeepOnlyLatestState"`
 		// FeePerExtraByte sets the expected per-byte fee for
 		// transactions exceeding the MaxFreeTransactionSize.
 		FeePerExtraByte float64 `yaml:"FeePerExtraByte"`

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -210,7 +210,7 @@ func (bc *Blockchain) init() error {
 			return err
 		}
 		if bc.config.EnableStateRoot {
-			if err := bc.dao.InitMPT(0); err != nil {
+			if err := bc.dao.InitMPT(0, bc.config.KeepOnlyLatestState); err != nil {
 				return err
 			}
 		}
@@ -232,7 +232,7 @@ func (bc *Blockchain) init() error {
 	bc.blockHeight = bHeight
 	bc.persistedHeight = bHeight
 	if bc.config.EnableStateRoot {
-		if err = bc.dao.InitMPT(bHeight); err != nil {
+		if err = bc.dao.InitMPT(bHeight, bc.config.KeepOnlyLatestState); err != nil {
 			return errors.Wrapf(err, "can't init MPT at height %d", bHeight)
 		}
 	}
@@ -563,7 +563,7 @@ func (bc *Blockchain) GetStateProof(root util.Uint256, key []byte) ([][]byte, er
 	if !bc.config.EnableStateRoot {
 		return nil, errors.New("state root feature is not enabled")
 	}
-	tr := mpt.NewTrie(mpt.NewHashNode(root), storage.NewMemCachedStore(bc.dao.Store))
+	tr := mpt.NewTrie(mpt.NewHashNode(root), bc.config.KeepOnlyLatestState, storage.NewMemCachedStore(bc.dao.Store))
 	return tr.GetProof(key)
 }
 

--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -510,16 +510,28 @@ func makeStateRootKey(height uint32) []byte {
 }
 
 // InitMPT initializes MPT at the given height.
-func (dao *Simple) InitMPT(height uint32) error {
+func (dao *Simple) InitMPT(height uint32, enableRefCount bool) error {
+	var gcKey = []byte{byte(storage.DataMPT), 1}
 	if height == 0 {
-		dao.MPT = mpt.NewTrie(nil, dao.Store)
-		return nil
+		dao.MPT = mpt.NewTrie(nil, enableRefCount, dao.Store)
+		var val byte
+		if enableRefCount {
+			val = 1
+		}
+		return dao.Store.Put(gcKey, []byte{val})
+	}
+	var hasRefCount bool
+	if v, err := dao.Store.Get(gcKey); err == nil {
+		hasRefCount = v[0] != 0
+	}
+	if hasRefCount != enableRefCount {
+		return fmt.Errorf("KeepOnlyLatestState setting mismatch: old=%v, new=%v", hasRefCount, enableRefCount)
 	}
 	r, err := dao.GetStateRoot(height)
 	if err != nil {
 		return err
 	}
-	dao.MPT = mpt.NewTrie(mpt.NewHashNode(r.Root), dao.Store)
+	dao.MPT = mpt.NewTrie(mpt.NewHashNode(r.Root), enableRefCount, dao.Store)
 	return nil
 }
 

--- a/pkg/core/mpt/base.go
+++ b/pkg/core/mpt/base.go
@@ -1,6 +1,8 @@
 package mpt
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -81,4 +83,24 @@ func (b *BaseNode) SetFlushed() {
 func encodeNodeWithType(n Node, w *io.BinWriter) {
 	w.WriteB(byte(n.Type()))
 	n.EncodeBinary(w)
+}
+
+// DecodeNodeWithType decodes node together with it's type.
+func DecodeNodeWithType(r *io.BinReader) Node {
+	var n Node
+	switch typ := NodeType(r.ReadB()); typ {
+	case BranchT:
+		n = new(BranchNode)
+	case ExtensionT:
+		n = new(ExtensionNode)
+	case HashT:
+		n = new(HashNode)
+	case LeafT:
+		n = new(LeafNode)
+	default:
+		r.Err = fmt.Errorf("invalid node type: %x", typ)
+		return nil
+	}
+	n.DecodeBinary(r)
+	return n
 }

--- a/pkg/core/mpt/base.go
+++ b/pkg/core/mpt/base.go
@@ -29,6 +29,18 @@ type BaseNodeIface interface {
 	SetFlushed()
 }
 
+type flushedNode interface {
+	setCache([]byte, util.Uint256)
+}
+
+func (b *BaseNode) setCache(bs []byte, h util.Uint256) {
+	b.bytes = bs
+	b.hash = h
+	b.bytesValid = true
+	b.hashValid = true
+	b.isFlushed = true
+}
+
 // getHash returns a hash of this BaseNode.
 func (b *BaseNode) getHash(n Node) util.Uint256 {
 	if !b.hashValid {

--- a/pkg/core/mpt/base.go
+++ b/pkg/core/mpt/base.go
@@ -16,8 +16,6 @@ type BaseNode struct {
 	bytes      []byte
 	hashValid  bool
 	bytesValid bool
-
-	isFlushed bool
 }
 
 // BaseNodeIface abstracts away basic Node functions.
@@ -25,8 +23,6 @@ type BaseNodeIface interface {
 	Hash() util.Uint256
 	Type() NodeType
 	Bytes() []byte
-	IsFlushed() bool
-	SetFlushed()
 }
 
 type flushedNode interface {
@@ -38,7 +34,6 @@ func (b *BaseNode) setCache(bs []byte, h util.Uint256) {
 	b.hash = h
 	b.bytesValid = true
 	b.hashValid = true
-	b.isFlushed = true
 }
 
 // getHash returns a hash of this BaseNode.
@@ -78,17 +73,6 @@ func (b *BaseNode) updateBytes(n Node) {
 func (b *BaseNode) invalidateCache() {
 	b.bytesValid = false
 	b.hashValid = false
-	b.isFlushed = false
-}
-
-// IsFlushed checks for node flush status.
-func (b *BaseNode) IsFlushed() bool {
-	return b.isFlushed
-}
-
-// SetFlushed sets 'flushed' flag to true for this node.
-func (b *BaseNode) SetFlushed() {
-	b.isFlushed = true
 }
 
 // encodeNodeWithType encodes node together with it's type.
@@ -99,6 +83,9 @@ func encodeNodeWithType(n Node, w *io.BinWriter) {
 
 // DecodeNodeWithType decodes node together with it's type.
 func DecodeNodeWithType(r *io.BinReader) Node {
+	if r.Err != nil {
+		return nil
+	}
 	var n Node
 	switch typ := NodeType(r.ReadB()); typ {
 	case BranchT:

--- a/pkg/core/mpt/node.go
+++ b/pkg/core/mpt/node.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -43,21 +42,7 @@ func (n NodeObject) EncodeBinary(w *io.BinWriter) {
 
 // DecodeBinary implements io.Serializable.
 func (n *NodeObject) DecodeBinary(r *io.BinReader) {
-	typ := NodeType(r.ReadB())
-	switch typ {
-	case BranchT:
-		n.Node = new(BranchNode)
-	case ExtensionT:
-		n.Node = new(ExtensionNode)
-	case HashT:
-		n.Node = new(HashNode)
-	case LeafT:
-		n.Node = new(LeafNode)
-	default:
-		r.Err = fmt.Errorf("invalid node type: %x", typ)
-		return
-	}
-	n.Node.DecodeBinary(r)
+	n.Node = DecodeNodeWithType(r)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/pkg/core/mpt/node_test.go
+++ b/pkg/core/mpt/node_test.go
@@ -92,7 +92,7 @@ func TestNode_Serializable(t *testing.T) {
 
 // https://github.com/neo-project/neo/blob/neox-2.x/neo.UnitTests/UT_MPTTrie.cs#L198
 func TestJSONSharp(t *testing.T) {
-	tr := NewTrie(nil, newTestStore())
+	tr := NewTrie(nil, false, newTestStore())
 	require.NoError(t, tr.Put([]byte{0xac, 0x11}, []byte{0xac, 0x11}))
 	require.NoError(t, tr.Put([]byte{0xac, 0x22}, []byte{0xac, 0x22}))
 	require.NoError(t, tr.Put([]byte{0xac}, []byte{0xac}))

--- a/pkg/core/mpt/proof.go
+++ b/pkg/core/mpt/proof.go
@@ -63,7 +63,7 @@ func (t *Trie) getProof(curr Node, path []byte, proofs *[][]byte) (Node, error) 
 // It also returns value for the key.
 func VerifyProof(rh util.Uint256, key []byte, proofs [][]byte) ([]byte, bool) {
 	path := toNibbles(key)
-	tr := NewTrie(NewHashNode(rh), storage.NewMemCachedStore(storage.NewMemoryStore()))
+	tr := NewTrie(NewHashNode(rh), false, storage.NewMemCachedStore(storage.NewMemoryStore()))
 	for i := range proofs {
 		h := hash.DoubleSha256(proofs[i])
 		// no errors in Put to memory store

--- a/pkg/core/mpt/proof_test.go
+++ b/pkg/core/mpt/proof_test.go
@@ -15,7 +15,7 @@ func newProofTrie(t *testing.T) *Trie {
 	b.Children[4] = NewHashNode(e.Hash())
 	b.Children[5] = e2
 
-	tr := NewTrie(b, newTestStore())
+	tr := NewTrie(b, false, newTestStore())
 	require.NoError(t, tr.Put([]byte{0x12, 0x31}, []byte("value1")))
 	require.NoError(t, tr.Put([]byte{0x12, 0x32}, []byte("value2")))
 	tr.putToStore(l)

--- a/pkg/core/mpt/trie.go
+++ b/pkg/core/mpt/trie.go
@@ -354,6 +354,7 @@ func (t *Trie) getFromStore(h util.Uint256) (Node, error) {
 	if r.Err != nil {
 		return nil, r.Err
 	}
+	n.Node.(flushedNode).setCache(data, h)
 	return n.Node, nil
 }
 

--- a/pkg/core/mpt/trie.go
+++ b/pkg/core/mpt/trie.go
@@ -2,7 +2,9 @@ package mpt
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
+	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/storage"
 	"github.com/nspcc-dev/neo-go/pkg/io"
@@ -13,7 +15,15 @@ import (
 type Trie struct {
 	Store *storage.MemCachedStore
 
-	root Node
+	root            Node
+	refcountEnabled bool
+	refcount        map[util.Uint256]*cachedNode
+}
+
+type cachedNode struct {
+	bytes    []byte
+	initial  int32
+	refcount int32
 }
 
 // ErrNotFound is returned when requested trie item is missing.
@@ -22,7 +32,7 @@ var ErrNotFound = errors.New("item not found")
 // NewTrie returns new MPT trie. It accepts a MemCachedStore to decouple storage errors from logic errors
 // so that all storage errors are processed during `store.Persist()` at the caller.
 // This also has the benefit, that every `Put` can be considered an atomic operation.
-func NewTrie(root Node, store *storage.MemCachedStore) *Trie {
+func NewTrie(root Node, enableRefCount bool, store *storage.MemCachedStore) *Trie {
 	if root == nil {
 		root = new(HashNode)
 	}
@@ -30,6 +40,9 @@ func NewTrie(root Node, store *storage.MemCachedStore) *Trie {
 	return &Trie{
 		Store: store,
 		root:  root,
+
+		refcountEnabled: enableRefCount,
+		refcount:        make(map[util.Uint256]*cachedNode),
 	}
 }
 
@@ -107,12 +120,15 @@ func (t *Trie) Put(key, value []byte) error {
 func (t *Trie) putIntoLeaf(curr *LeafNode, path []byte, val Node) (Node, error) {
 	v := val.(*LeafNode)
 	if len(path) == 0 {
+		t.removeRef(curr.Hash(), curr.bytes)
+		t.addRef(val.Hash(), val.Bytes())
 		return v, nil
 	}
 
 	b := NewBranchNode()
-	b.Children[path[0]] = newSubTrie(path[1:], v)
+	b.Children[path[0]] = t.newSubTrie(path[1:], v, true)
 	b.Children[lastChild] = curr
+	t.addRef(b.Hash(), b.bytes)
 	return b, nil
 }
 
@@ -120,18 +136,21 @@ func (t *Trie) putIntoLeaf(curr *LeafNode, path []byte, val Node) (Node, error) 
 // It returns Node if curr needs to be replaced and error if any.
 func (t *Trie) putIntoBranch(curr *BranchNode, path []byte, val Node) (Node, error) {
 	i, path := splitPath(path)
+	t.removeRef(curr.Hash(), curr.bytes)
 	r, err := t.putIntoNode(curr.Children[i], path, val)
 	if err != nil {
 		return nil, err
 	}
 	curr.Children[i] = r
 	curr.invalidateCache()
+	t.addRef(curr.Hash(), curr.bytes)
 	return curr, nil
 }
 
 // putIntoExtension puts val to trie if current node is an Extension.
 // It returns Node if curr needs to be replaced and error if any.
 func (t *Trie) putIntoExtension(curr *ExtensionNode, path []byte, val Node) (Node, error) {
+	t.removeRef(curr.Hash(), curr.bytes)
 	if bytes.HasPrefix(path, curr.key) {
 		r, err := t.putIntoNode(curr.next, path[len(curr.key):], val)
 		if err != nil {
@@ -139,6 +158,7 @@ func (t *Trie) putIntoExtension(curr *ExtensionNode, path []byte, val Node) (Nod
 		}
 		curr.next = r
 		curr.invalidateCache()
+		t.addRef(curr.Hash(), curr.bytes)
 		return curr, nil
 	}
 
@@ -147,16 +167,19 @@ func (t *Trie) putIntoExtension(curr *ExtensionNode, path []byte, val Node) (Nod
 	keyTail := curr.key[lp:]
 	pathTail := path[lp:]
 
-	s1 := newSubTrie(keyTail[1:], curr.next)
+	s1 := t.newSubTrie(keyTail[1:], curr.next, false)
 	b := NewBranchNode()
 	b.Children[keyTail[0]] = s1
 
 	i, pathTail := splitPath(pathTail)
-	s2 := newSubTrie(pathTail, val)
+	s2 := t.newSubTrie(pathTail, val, true)
 	b.Children[i] = s2
 
+	t.addRef(b.Hash(), b.bytes)
 	if lp > 0 {
-		return NewExtensionNode(copySlice(pref), b), nil
+		e := NewExtensionNode(copySlice(pref), b)
+		t.addRef(e.Hash(), e.bytes)
+		return e, nil
 	}
 	return b, nil
 }
@@ -165,7 +188,8 @@ func (t *Trie) putIntoExtension(curr *ExtensionNode, path []byte, val Node) (Nod
 // It returns Node if curr needs to be replaced and error if any.
 func (t *Trie) putIntoHash(curr *HashNode, path []byte, val Node) (Node, error) {
 	if curr.IsEmpty() {
-		return newSubTrie(path, val), nil
+		hn := t.newSubTrie(path, val, true)
+		return hn, nil
 	}
 
 	result, err := t.getFromStore(curr.hash)
@@ -176,13 +200,20 @@ func (t *Trie) putIntoHash(curr *HashNode, path []byte, val Node) (Node, error) 
 }
 
 // newSubTrie create new trie containing node at provided path.
-func newSubTrie(path []byte, val Node) Node {
+func (t *Trie) newSubTrie(path []byte, val Node, newVal bool) Node {
+	if newVal {
+		t.addRef(val.Hash(), val.Bytes())
+	}
 	if len(path) == 0 {
 		return val
 	}
-	return NewExtensionNode(path, val)
+	e := NewExtensionNode(path, val)
+	t.addRef(e.Hash(), e.bytes)
+	return e
 }
 
+// putIntoNode puts val with provided path inside curr and returns updated node.
+// Reference counters are updated for both curr and returned value.
 func (t *Trie) putIntoNode(curr Node, path []byte, val Node) (Node, error) {
 	switch n := curr.(type) {
 	case *LeafNode:
@@ -212,10 +243,13 @@ func (t *Trie) Delete(key []byte) error {
 
 func (t *Trie) deleteFromBranch(b *BranchNode, path []byte) (Node, error) {
 	i, path := splitPath(path)
+	h := b.Hash()
+	bs := b.bytes
 	r, err := t.deleteFromNode(b.Children[i], path)
 	if err != nil {
 		return nil, err
 	}
+	t.removeRef(h, bs)
 	b.Children[i] = r
 	b.invalidateCache()
 	var count, index int
@@ -228,6 +262,7 @@ func (t *Trie) deleteFromBranch(b *BranchNode, path []byte) (Node, error) {
 	}
 	// count is >= 1 because branch node had at least 2 children before deletion.
 	if count > 1 {
+		t.addRef(b.Hash(), b.bytes)
 		return b, nil
 	}
 	c := b.Children[index]
@@ -241,24 +276,32 @@ func (t *Trie) deleteFromBranch(b *BranchNode, path []byte) (Node, error) {
 		}
 	}
 	if e, ok := c.(*ExtensionNode); ok {
+		t.removeRef(e.Hash(), e.bytes)
 		e.key = append([]byte{byte(index)}, e.key...)
 		e.invalidateCache()
+		t.addRef(e.Hash(), e.bytes)
 		return e, nil
 	}
 
-	return NewExtensionNode([]byte{byte(index)}, c), nil
+	e := NewExtensionNode([]byte{byte(index)}, c)
+	t.addRef(e.Hash(), e.bytes)
+	return e, nil
 }
 
 func (t *Trie) deleteFromExtension(n *ExtensionNode, path []byte) (Node, error) {
 	if !bytes.HasPrefix(path, n.key) {
 		return nil, ErrNotFound
 	}
+	h := n.Hash()
+	bs := n.bytes
 	r, err := t.deleteFromNode(n.next, path[len(n.key):])
 	if err != nil {
 		return nil, err
 	}
+	t.removeRef(h, bs)
 	switch nxt := r.(type) {
 	case *ExtensionNode:
+		t.removeRef(nxt.Hash(), nxt.bytes)
 		n.key = append(n.key, nxt.key...)
 		n.next = nxt.next
 	case *HashNode:
@@ -269,13 +312,17 @@ func (t *Trie) deleteFromExtension(n *ExtensionNode, path []byte) (Node, error) 
 		n.next = r
 	}
 	n.invalidateCache()
+	t.addRef(n.Hash(), n.bytes)
 	return n, nil
 }
 
+// deleteFromNode removes value with provided path from curr and returns an updated node.
+// Reference counters are updated for both curr and returned value.
 func (t *Trie) deleteFromNode(curr Node, path []byte) (Node, error) {
 	switch n := curr.(type) {
 	case *LeafNode:
 		if len(path) == 0 {
+			t.removeRef(curr.Hash(), curr.Bytes())
 			return new(HashNode), nil
 		}
 		return nil, ErrNotFound
@@ -314,32 +361,88 @@ func makeStorageKey(mptKey []byte) []byte {
 // new node to storage. Normally, flush should be called with every StateRoot persist, i.e.
 // after every block.
 func (t *Trie) Flush() {
-	t.flush(t.root)
-}
-
-func (t *Trie) flush(node Node) {
-	if node.IsFlushed() {
-		return
-	}
-	switch n := node.(type) {
-	case *BranchNode:
-		for i := range n.Children {
-			t.flush(n.Children[i])
+	for h, node := range t.refcount {
+		if node.refcount != 0 {
+			if node.bytes == nil {
+				panic("item not in trie")
+			}
+			if t.refcountEnabled {
+				node.initial = t.updateRefCount(h)
+				if node.initial == 0 {
+					delete(t.refcount, h)
+				}
+			} else if node.refcount > 0 {
+				_ = t.Store.Put(makeStorageKey(h.BytesBE()), node.bytes)
+			}
+			node.refcount = 0
+		} else {
+			delete(t.refcount, h)
 		}
-	case *ExtensionNode:
-		t.flush(n.next)
-	case *HashNode:
-		return
 	}
-	t.putToStore(node)
 }
 
-func (t *Trie) putToStore(n Node) {
-	if n.Type() == HashT {
-		panic("can't put hash node in trie")
+// updateRefCount should be called only when refcounting is enabled.
+func (t *Trie) updateRefCount(h util.Uint256) int32 {
+	if !t.refcountEnabled {
+		panic("`updateRefCount` is called, but GC is disabled")
 	}
-	_ = t.Store.Put(makeStorageKey(n.Hash().BytesBE()), n.Bytes()) // put in MemCached returns no errors
-	n.SetFlushed()
+	var data []byte
+	key := makeStorageKey(h.BytesBE())
+	node := t.refcount[h]
+	cnt := node.initial
+	if cnt == 0 {
+		// A newly created item which may be in store.
+		var err error
+		data, err = t.Store.Get(key)
+		if err == nil {
+			cnt = int32(binary.LittleEndian.Uint32(data[len(data)-4:]))
+		}
+	}
+	if len(data) == 0 {
+		data = append(node.bytes, 0, 0, 0, 0)
+	}
+	cnt += node.refcount
+	switch {
+	case cnt < 0:
+		// BUG: negative reference count
+		panic(fmt.Sprintf("negative reference count: %s new %d, upd %d", h.StringBE(), cnt, t.refcount[h]))
+	case cnt == 0:
+		_ = t.Store.Delete(key)
+	default:
+		binary.LittleEndian.PutUint32(data[len(data)-4:], uint32(cnt))
+		_ = t.Store.Put(key, data)
+	}
+	return cnt
+}
+
+func (t *Trie) addRef(h util.Uint256, bs []byte) {
+	node := t.refcount[h]
+	if node == nil {
+		t.refcount[h] = &cachedNode{
+			refcount: 1,
+			bytes:    bs,
+		}
+		return
+	}
+	node.refcount++
+	if node.bytes == nil {
+		node.bytes = bs
+	}
+}
+
+func (t *Trie) removeRef(h util.Uint256, bs []byte) {
+	node := t.refcount[h]
+	if node == nil {
+		t.refcount[h] = &cachedNode{
+			refcount: -1,
+			bytes:    bs,
+		}
+		return
+	}
+	node.refcount--
+	if node.bytes == nil {
+		node.bytes = bs
+	}
 }
 
 func (t *Trie) getFromStore(h util.Uint256) (Node, error) {
@@ -354,6 +457,15 @@ func (t *Trie) getFromStore(h util.Uint256) (Node, error) {
 	if r.Err != nil {
 		return nil, r.Err
 	}
+
+	if t.refcountEnabled {
+		data = data[:len(data)-4]
+		node := t.refcount[h]
+		if node != nil {
+			node.bytes = data
+			node.initial = int32(r.ReadU32LE())
+		}
+	}
 	n.Node.(flushedNode).setCache(data, h)
 	return n.Node, nil
 }
@@ -366,6 +478,7 @@ func (t *Trie) Collapse(depth int) {
 		panic("negative depth")
 	}
 	t.root = collapse(depth, t.root)
+	t.refcount = make(map[util.Uint256]*cachedNode)
 }
 
 func collapse(depth int, node Node) Node {

--- a/pkg/rpc/response/result/mpt_test.go
+++ b/pkg/rpc/response/result/mpt_test.go
@@ -41,10 +41,9 @@ func TestGetProof_MarshalJSON(t *testing.T) {
 		require.Equal(t, 8, len(p.Result.Proof))
 		for i := range p.Result.Proof { // smoke test that every chunk is correctly encoded node
 			r := io.NewBinReaderFromBuf(p.Result.Proof[i])
-			var n mpt.NodeObject
-			n.DecodeBinary(r)
+			n := mpt.DecodeNodeWithType(r)
 			require.NoError(t, r.Err)
-			require.NotNil(t, n.Node)
+			require.NotNil(t, n)
 		}
 	})
 }


### PR DESCRIPTION
Results for a full testnet dump (5003730 blocks):
```
# Master-2.x
real    106m36,227s
user    192m32,855s
sys     14m45,739s
13G     .

# Refcount
real    121m10,446s
user    231m6,476s
sys     17m0,014s
9,0G    .

# Generation GC (note: GC hadn't been finished when restore was completed)
real    123m35,329s
user    284m21,860s
sys     22m32,090s
9,5G    .
```

First 2M mainnet blocks (will publish 2M-3M later). Note, generation GC starts every 200k blocks, so not all garbage was collected).
```
# Generation GC
real    46m31,497s
user    76m51,146s
sys     5m52,001s
12G     .

# Master-2.x
real    44m28,469s
user    74m43,983s
sys     5m20,414s
13G     .

# Refcount
real    44m22,258s
user    74m16,260s
sys     5m5,966s
11G     .
```

First 3M mainnet blocks (same note for generational GC):
```
# Master-2.x
real    644m50,778s
user    1223m8,365s
sys     69m23,930s
56G     chains

# Generational
real    698m50,998s
user    1019m11,077s
sys     85m33,651s
46G     chains

# Refcount
real    510m3,492s
user    1167m14,155s
sys     40m38,908s
28G     chains
```

This can be used for benchmark, though `VerifyBlocks: false` must be set manually. https://gist.github.com/fyrchik/df3733df056cdf9c0ab6b39dfc6d759d

UPDATE:
Results for optimized refcount version (boltdb was used, leveldb TBD):
```
# Refcount (stored at the end of node, no optimizations)
real    106m48,438s
user    151m50,943s
sys     6m56,261s
16G     chains

# Master
real    117m21,565s
user    145m42,361s
sys     10m26,123s
22G     chains

# Refcount + flush only changed
real    106m49,477s
user    150m45,168s
sys     6m54,792s
16G     chains

# Refcount + flush only changed + cache refcount of nodes read from store
real    107m5,384s
user    151m29,465s
sys     6m59,464s
16G     chains
```

UPDATE:
Results for leveldb+testnet with config switch
```
# Master, no GC
real    106m4,500s
user   193m19,865s
sys     14m41,085s
12G chains

# GC disabled in config
real   108m51,511s
user  199m24,728s
sys    14m56,655s
12G	chains

# GC enabled
real    119m48,806s
user   229m39,195s
sys    16m48,748s
8,3G	chains
```