### PR TITLE
WIP Generational GC for MPT

### DIFF
--- a/config/protocol.testnet.yml
+++ b/config/protocol.testnet.yml
@@ -30,7 +30,7 @@ ProtocolConfiguration:
     IssueTransaction: 5
     PublishTransaction: 5
     RegisterTransaction: 100
-  VerifyBlocks: true
+  VerifyBlocks: false
   VerifyTransactions: false
   FreeGasLimit: {0: 10.0, 4840000: 50.0}
   MaxTransactionsPerBlock: {0: 500, 4840000: 200}

--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -520,6 +520,7 @@ func (dao *Simple) InitMPT(height uint32) error {
 		return err
 	}
 	dao.MPT = mpt.NewTrie(mpt.NewHashNode(r.Root), dao.Store)
+	dao.MPT.SetGeneration(height / mpt.GenerationSpan)
 	return nil
 }
 

--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -525,7 +525,7 @@ func (dao *Simple) InitMPT(height uint32) error {
 
 // GetCurrentStateRootHeight returns current state root height.
 func (dao *Simple) GetCurrentStateRootHeight() (uint32, error) {
-	key := []byte{byte(storage.DataMPT)}
+	key := []byte{byte(storage.DataMPTHeight)}
 	val, err := dao.Store.Get(key)
 	if err != nil {
 		if err == storage.ErrKeyNotFound {
@@ -538,7 +538,7 @@ func (dao *Simple) GetCurrentStateRootHeight() (uint32, error) {
 
 // PutCurrentStateRootHeight updates current state root height.
 func (dao *Simple) PutCurrentStateRootHeight(height uint32) error {
-	key := []byte{byte(storage.DataMPT)}
+	key := []byte{byte(storage.DataMPTHeight)}
 	val := make([]byte, 4)
 	binary.LittleEndian.PutUint32(val, height)
 	return dao.Store.Put(key, val)

--- a/pkg/core/mpt/base.go
+++ b/pkg/core/mpt/base.go
@@ -1,6 +1,8 @@
 package mpt
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -81,4 +83,24 @@ func (b *BaseNode) SetFlushed() {
 func encodeNodeWithType(n Node, w *io.BinWriter) {
 	w.WriteB(byte(n.Type()))
 	n.EncodeBinary(w)
+}
+
+// DecodeNodeWithType decodes node together with it's type.
+func DecodeNodeWithType(r *io.BinReader) Node {
+	var n Node
+	switch typ := NodeType(r.ReadB()); typ {
+	case BranchT:
+		n = new(BranchNode)
+	case ExtensionT:
+		n = new(ExtensionNode)
+	case HashT:
+		n = new(HashNode)
+	case LeafT:
+		n = new(LeafNode)
+	default:
+		r.Err = fmt.Errorf("invalid node type: %x", typ)
+		return nil
+	}
+	n.DecodeBinary(r)
+	return n
 }

--- a/pkg/core/mpt/base.go
+++ b/pkg/core/mpt/base.go
@@ -29,6 +29,18 @@ type BaseNodeIface interface {
 	SetFlushed()
 }
 
+type flushedNode interface {
+	setCache([]byte, util.Uint256)
+}
+
+func (b *BaseNode) setCache(bs []byte, h util.Uint256) {
+	b.bytes = bs
+	b.hash = h
+	b.bytesValid = true
+	b.hashValid = true
+	b.isFlushed = true
+}
+
 // getHash returns a hash of this BaseNode.
 func (b *BaseNode) getHash(n Node) util.Uint256 {
 	if !b.hashValid {

--- a/pkg/core/mpt/node.go
+++ b/pkg/core/mpt/node.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -43,21 +42,7 @@ func (n NodeObject) EncodeBinary(w *io.BinWriter) {
 
 // DecodeBinary implements io.Serializable.
 func (n *NodeObject) DecodeBinary(r *io.BinReader) {
-	typ := NodeType(r.ReadB())
-	switch typ {
-	case BranchT:
-		n.Node = new(BranchNode)
-	case ExtensionT:
-		n.Node = new(ExtensionNode)
-	case HashT:
-		n.Node = new(HashNode)
-	case LeafT:
-		n.Node = new(LeafNode)
-	default:
-		r.Err = fmt.Errorf("invalid node type: %x", typ)
-		return
-	}
-	n.Node.DecodeBinary(r)
+	n.Node = DecodeNodeWithType(r)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/pkg/core/mpt/node.go
+++ b/pkg/core/mpt/node.go
@@ -25,6 +25,7 @@ const (
 // is also expected.
 type NodeObject struct {
 	Node
+	Generation uint32
 }
 
 // Node represents common interface of all MPT nodes.
@@ -37,11 +38,13 @@ type Node interface {
 
 // EncodeBinary implements io.Serializable.
 func (n NodeObject) EncodeBinary(w *io.BinWriter) {
+	w.WriteU32LE(n.Generation)
 	encodeNodeWithType(n.Node, w)
 }
 
 // DecodeBinary implements io.Serializable.
 func (n *NodeObject) DecodeBinary(r *io.BinReader) {
+	n.Generation = r.ReadU32LE()
 	n.Node = DecodeNodeWithType(r)
 }
 

--- a/pkg/core/mpt/node_test.go
+++ b/pkg/core/mpt/node_test.go
@@ -45,7 +45,7 @@ func TestNode_Serializable(t *testing.T) {
 		t.Run("Good", func(t *testing.T) {
 			l := NewLeafNode(random.Bytes(123))
 			t.Run("Raw", getTestFuncEncode(true, l, new(LeafNode)))
-			t.Run("WithType", getTestFuncEncode(true, &NodeObject{l}, new(NodeObject)))
+			t.Run("WithType", getTestFuncEncode(true, &NodeObject{l, 1}, new(NodeObject)))
 		})
 		t.Run("BigValue", getTestFuncEncode(false,
 			NewLeafNode(random.Bytes(MaxValueLength+1)), new(LeafNode)))
@@ -55,7 +55,7 @@ func TestNode_Serializable(t *testing.T) {
 		t.Run("Good", func(t *testing.T) {
 			e := NewExtensionNode(random.Bytes(42), NewLeafNode(random.Bytes(10)))
 			t.Run("Raw", getTestFuncEncode(true, e, new(ExtensionNode)))
-			t.Run("WithType", getTestFuncEncode(true, &NodeObject{e}, new(NodeObject)))
+			t.Run("WithType", getTestFuncEncode(true, &NodeObject{e, 2}, new(NodeObject)))
 		})
 		t.Run("BigKey", getTestFuncEncode(false,
 			NewExtensionNode(random.Bytes(MaxKeyLength+1), NewLeafNode(random.Bytes(10))), new(ExtensionNode)))
@@ -66,14 +66,14 @@ func TestNode_Serializable(t *testing.T) {
 		b.Children[0] = NewLeafNode(random.Bytes(10))
 		b.Children[lastChild] = NewHashNode(random.Uint256())
 		t.Run("Raw", getTestFuncEncode(true, b, new(BranchNode)))
-		t.Run("WithType", getTestFuncEncode(true, &NodeObject{b}, new(NodeObject)))
+		t.Run("WithType", getTestFuncEncode(true, &NodeObject{b, 0}, new(NodeObject)))
 	})
 
 	t.Run("Hash", func(t *testing.T) {
 		t.Run("Good", func(t *testing.T) {
 			h := NewHashNode(random.Uint256())
 			t.Run("Raw", getTestFuncEncode(true, h, new(HashNode)))
-			t.Run("WithType", getTestFuncEncode(true, &NodeObject{h}, new(NodeObject)))
+			t.Run("WithType", getTestFuncEncode(true, &NodeObject{h, 3}, new(NodeObject)))
 		})
 		t.Run("Empty", func(t *testing.T) { // compare nodes, not hashes
 			testserdes.EncodeDecodeBinary(t, new(HashNode), new(HashNode))

--- a/pkg/core/mpt/proof.go
+++ b/pkg/core/mpt/proof.go
@@ -67,7 +67,7 @@ func VerifyProof(rh util.Uint256, key []byte, proofs [][]byte) ([]byte, bool) {
 	for i := range proofs {
 		h := hash.DoubleSha256(proofs[i])
 		// no errors in Put to memory store
-		_ = tr.Store.Put(makeStorageKey(h[:]), proofs[i])
+		_ = tr.Store.Put(makeStorageKey(h[:]), append([]byte{0, 0, 0, 0}, proofs[i]...))
 	}
 	_, bs, err := tr.getWithPath(tr.root, path)
 	return bs, err == nil

--- a/pkg/core/mpt/trie.go
+++ b/pkg/core/mpt/trie.go
@@ -354,6 +354,7 @@ func (t *Trie) getFromStore(h util.Uint256) (Node, error) {
 	if r.Err != nil {
 		return nil, r.Err
 	}
+	n.Node.(flushedNode).setCache(data, h)
 	return n.Node, nil
 }
 

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -10,6 +10,7 @@ const (
 	DataBlock         KeyPrefix = 0x01
 	DataTransaction   KeyPrefix = 0x02
 	DataMPT           KeyPrefix = 0x03
+	DataMPTHeight     KeyPrefix = 0x04
 	STAccount         KeyPrefix = 0x40
 	STCoin            KeyPrefix = 0x44
 	STSpentCoin       KeyPrefix = 0x45

--- a/pkg/rpc/response/result/mpt_test.go
+++ b/pkg/rpc/response/result/mpt_test.go
@@ -41,10 +41,9 @@ func TestGetProof_MarshalJSON(t *testing.T) {
 		require.Equal(t, 8, len(p.Result.Proof))
 		for i := range p.Result.Proof { // smoke test that every chunk is correctly encoded node
 			r := io.NewBinReaderFromBuf(p.Result.Proof[i])
-			var n mpt.NodeObject
-			n.DecodeBinary(r)
+			n := mpt.DecodeNodeWithType(r)
 			require.NoError(t, r.Err)
-			require.NotNil(t, n.Node)
+			require.NotNil(t, n)
 		}
 	})
 }


### PR DESCRIPTION
Close #1359 .

```
# Without GC
./neogo db restore -t --in ../chains/testnet2.acc  13934,51s user 1277,15s system 191% cpu 2:12:43,72 total
12G     chains/testnet

# Generation
./neogo db restore -t --in ../chains/testnet2.acc  13389,47s user 1120,03s system 201% cpu 1:59:59,13 total
11G     chains/testnet
```

Difference in time can be explained, because workload on my PC was different.
Regarding space (compare with #1503), there is either a bug or GC hasn't finished working after restore was completed. Will test it with restore to 3M and then running node to sync from network.