### PR TITLE
native: decode storage item in `Seek`

### DIFF
--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/bigint"
+	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -336,13 +337,19 @@ func (n *NEO) PostPersist(ic *interop.Context) error {
 func (n *NEO) getGASPerVote(d dao.DAO, key []byte, index ...uint32) []big.Int {
 	var max = make([]uint32, len(index))
 	var reward = make([]big.Int, len(index))
+	var si state.StorageItem
 	d.Seek(n.ContractID, key, func(k, v []byte) {
 		if len(k) == 4 {
 			num := binary.BigEndian.Uint32(k)
 			for i, ind := range index {
 				if max[i] < num && num <= ind {
 					max[i] = num
-					reward[i] = *bigint.FromBytes(v)
+					r := io.NewBinReaderFromBuf(v)
+					si.DecodeBinary(r)
+					if r.Err != nil {
+						return
+					}
+					reward[i] = *bigint.FromBytes(si.Value)
 				}
 			}
 		}


### PR DESCRIPTION
This lead to incorrect calculations.