### PR TITLE
mempool: correctly handle tx with oracle response

### DIFF
--- a/pkg/core/native/oracle.go
+++ b/pkg/core/native/oracle.go
@@ -153,7 +153,7 @@ func (o *Oracle) PostPersist(ic *interop.Context) error {
 		reqKey := makeRequestKey(resp.ID)
 		req := new(state.OracleRequest)
 		if err := o.getSerializableFromDAO(ic.DAO, reqKey, req); err != nil {
-			return err
+			continue
 		}
 		if err := ic.DAO.DeleteStorageItem(o.ContractID, reqKey); err != nil {
 			return err


### PR DESCRIPTION
If tx with the same oracle response ID is already in mempool,
replace it if network fee of added transaction is higher and
return error otherwise.

Close #1569 .
