### PR TITLE
native: call `onPayment` only during `transfer`

### DIFF
--- a/pkg/core/native/native_gas.go
+++ b/pkg/core/native/native_gas.go
@@ -75,7 +75,7 @@ func (g *GAS) Initialize(ic *interop.Context) error {
 	if err != nil {
 		return err
 	}
-	g.mint(ic, h, big.NewInt(initialGAS*GASFactor))
+	g.mint(ic, h, big.NewInt(initialGAS*GASFactor), false)
 	return nil
 }
 
@@ -94,7 +94,7 @@ func (g *GAS) OnPersist(ic *interop.Context) error {
 	for _, tx := range ic.Block.Transactions {
 		netFee += tx.NetworkFee
 	}
-	g.mint(ic, primary, big.NewInt(int64(netFee)))
+	g.mint(ic, primary, big.NewInt(int64(netFee)), false)
 	return nil
 }
 

--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -189,7 +189,7 @@ func (n *NEO) Initialize(ic *interop.Context) error {
 	if err != nil {
 		return err
 	}
-	n.mint(ic, h, big.NewInt(NEOTotalSupply))
+	n.mint(ic, h, big.NewInt(NEOTotalSupply), false)
 
 	var index uint32 = 0
 	value := big.NewInt(5 * GASFactor)
@@ -294,7 +294,7 @@ func (n *NEO) PostPersist(ic *interop.Context) error {
 	committeeSize := len(ic.Chain.GetConfig().StandbyCommittee)
 	index := int(ic.Block.Index) % committeeSize
 	committeeReward := new(big.Int).Mul(gas, big.NewInt(committeeRewardRatio))
-	n.GAS.mint(ic, pubs[index].GetScriptHash(), committeeReward.Div(committeeReward, big.NewInt(100)))
+	n.GAS.mint(ic, pubs[index].GetScriptHash(), committeeReward.Div(committeeReward, big.NewInt(100)), false)
 
 	if ShouldUpdateCommittee(ic.Block.Index, ic.Chain) {
 		var voterReward = big.NewInt(voterRewardRatio)
@@ -410,7 +410,7 @@ func (n *NEO) distributeGas(ic *interop.Context, h util.Uint160, acc *state.NEOB
 		return err
 	}
 	acc.BalanceHeight = ic.Block.Index
-	n.GAS.mint(ic, h, gen)
+	n.GAS.mint(ic, h, gen, true)
 	return nil
 }
 

--- a/pkg/core/native/notary.go
+++ b/pkg/core/native/notary.go
@@ -136,7 +136,7 @@ func (n *Notary) OnPersist(ic *interop.Context) error {
 	}
 	singleReward := calculateNotaryReward(nFees, len(notaries))
 	for _, notary := range notaries {
-		n.GAS.mint(ic, notary.GetScriptHash(), singleReward)
+		n.GAS.mint(ic, notary.GetScriptHash(), singleReward, false)
 	}
 	return nil
 }


### PR DESCRIPTION
OnPayment method should be called during GAS distribution
and NEO transfer.

Close #1571 .