### PR TITLE
network: add tests for most of the commands

### DIFF
--- a/pkg/network/blockqueue_test.go
+++ b/pkg/network/blockqueue_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBlockQueue(t *testing.T) {
-	chain := &testChain{}
+	chain := newTestChain()
 	// notice, it's not yet running
 	bq := newBlockQueue(0, chain, zaptest.NewLogger(t), nil)
 	blocks := make([]*block.Block, 11)

--- a/pkg/network/discovery.go
+++ b/pkg/network/discovery.go
@@ -67,6 +67,10 @@ func NewDefaultDiscovery(addrs []string, dt time.Duration, ts Transporter) *Defa
 	return d
 }
 
+func newDefaultDiscovery(addrs []string, dt time.Duration, ts Transporter) Discoverer {
+	return NewDefaultDiscovery(addrs, dt, ts)
+}
+
 // BackFill implements the Discoverer interface and will backfill the
 // the pool with the given addresses.
 func (d *DefaultDiscovery) BackFill(addrs ...string) {

--- a/pkg/network/message_test.go
+++ b/pkg/network/message_test.go
@@ -128,10 +128,10 @@ func TestEncodeDecodeAddr(t *testing.T) {
 
 func TestEncodeDecodeBlock(t *testing.T) {
 	t.Run("good", func(t *testing.T) {
-		testEncodeDecode(t, CMDBlock, newDummyBlock(1))
+		testEncodeDecode(t, CMDBlock, newDummyBlock(12, 1))
 	})
 	t.Run("invalid state root enabled setting", func(t *testing.T) {
-		expected := NewMessage(CMDBlock, newDummyBlock(1))
+		expected := NewMessage(CMDBlock, newDummyBlock(31, 1))
 		expected.Network = netmode.UnitTestNet
 		data, err := testserdes.Encode(expected)
 		require.NoError(t, err)
@@ -270,7 +270,7 @@ func TestInvalidMessages(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("trimmed payload", func(t *testing.T) {
-		m := NewMessage(CMDBlock, newDummyBlock(0))
+		m := NewMessage(CMDBlock, newDummyBlock(1, 0))
 		data, err := testserdes.Encode(m)
 		require.NoError(t, err)
 		data = data[:len(data)-1]
@@ -288,8 +288,9 @@ func (f failSer) EncodeBinary(r *io.BinWriter) {
 
 func (failSer) DecodeBinary(w *io.BinReader) {}
 
-func newDummyBlock(txCount int) *block.Block {
+func newDummyBlock(height uint32, txCount int) *block.Block {
 	b := block.New(netmode.UnitTestNet, false)
+	b.Index = height
 	b.PrevHash = random.Uint256()
 	b.Timestamp = rand.Uint64()
 	b.Script.InvocationScript = random.Bytes(2)
@@ -303,7 +304,7 @@ func newDummyBlock(txCount int) *block.Block {
 }
 
 func newDummyTx() *transaction.Transaction {
-	tx := transaction.New(netmode.UnitTestNet, random.Bytes(100), int64(rand.Uint64()>>1))
+	tx := transaction.New(netmode.UnitTestNet, random.Bytes(100), 123)
 	tx.Signers = []transaction.Signer{{Account: random.Uint160()}}
 	tx.Size()
 	tx.Hash()

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -595,7 +595,7 @@ func (s *Server) handleGetBlocksCmd(p Peer, gb *payload.GetBlocks) error {
 		return err
 	}
 	blockHashes := make([]util.Uint256, 0)
-	for i := start.Index + 1; i < start.Index+uint32(count); i++ {
+	for i := start.Index + 1; i <= start.Index+uint32(count); i++ {
 		hash := s.chain.GetHeaderHash(int(i))
 		if hash.Equals(util.Uint256{}) {
 			break

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -839,11 +839,14 @@ func (s *Server) requestTx(hashes ...util.Uint256) {
 		return
 	}
 
-	for i := 0; i < len(hashes)/payload.MaxHashesCount; i++ {
+	for i := 0; i <= len(hashes)/payload.MaxHashesCount; i++ {
 		start := i * payload.MaxHashesCount
 		stop := (i + 1) * payload.MaxHashesCount
-		if stop < len(hashes) {
+		if stop > len(hashes) {
 			stop = len(hashes)
+		}
+		if start == stop {
+			break
 		}
 		msg := NewMessage(CMDGetData, payload.NewInventory(payload.TXType, hashes[start:stop]))
 		// It's high priority because it directly affects consensus process,


### PR DESCRIPTION
Fixed 3 bugs:
1.  `GetBlocks` should sent exactly `Count` blocks.
2. `requestTx` couldn't didn't send anything if amount of hashes was small.
3. `requestTx` could panic, but luckily (or unluckily) (2) made this event rather unprobable.

`network.testChain` is rather ugly now, this should be fixed in #1472 . Now there are more specific requirements on what we could do with testchain in tests.