### PR TITLE
compiler: save both VM and smartcontract types

### DIFF
--- a/examples/events/events.go
+++ b/examples/events/events.go
@@ -1,0 +1,30 @@
+package events
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
+)
+
+// NotifySomeBytes emits notification with ByteArray.
+func NotifySomeBytes(arg []byte) {
+	runtime.Notify("SomeBytes", arg)
+}
+
+// NotifySomeInteger emits notification with Integer.
+func NotifySomeInteger(arg int) {
+	runtime.Notify("SomeInteger", arg)
+}
+
+// NotifySomeString emits notification with String.
+func NotifySomeString(arg string) {
+	runtime.Notify("SomeString", arg)
+}
+
+// NotifySomeMap emits notification with Map.
+func NotifySomeMap(arg map[string]int) {
+	runtime.Notify("SomeMap", arg)
+}
+
+// NotifySomeArray emits notification with Array.
+func NotifySomeArray(arg []int) {
+	runtime.Notify("SomeArray", arg)
+}

--- a/examples/events/events.yml
+++ b/examples/events/events.yml
@@ -1,0 +1,23 @@
+name: "Event types example"
+supportedstandards: []
+events:
+  - name: SomeBytes
+    parameters:
+      - name: bytes
+        type: ByteArray
+  - name: SomeInteger
+    parameters:
+      - name: int
+        type: Integer
+  - name: SomeString
+    parameters:
+      - name: str
+        type: String
+  - name: SomeMap
+    parameters:
+      - name: m
+        type: Map
+  - name: SomeArray
+    parameters:
+      - name: a
+        type: Array

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -877,7 +877,8 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 				tv := c.typeAndValueOf(n.Args[0])
 				params := make([]string, 0, len(n.Args[1:]))
 				for _, p := range n.Args[1:] {
-					params = append(params, c.scTypeFromExpr(p))
+					st, _ := c.scAndVMTypeFromExpr(p)
+					params = append(params, st.String())
 				}
 				// Sometimes event name is stored in a var.
 				// Skip in this case.

--- a/pkg/compiler/debug_test.go
+++ b/pkg/compiler/debug_test.go
@@ -71,8 +71,8 @@ func _deploy(isUpdate bool) {}
 	t.Run("return types", func(t *testing.T) {
 		returnTypes := map[string]string{
 			"MethodInt":    "Integer",
-			"MethodConcat": "String",
-			"MethodString": "String", "MethodByteArray": "ByteString",
+			"MethodConcat": "ByteString",
+			"MethodString": "ByteString", "MethodByteArray": "ByteString",
 			"MethodArray": "Array", "MethodStruct": "Struct",
 			"Main":                    "Boolean",
 			"unexportedMethod":        "Integer",
@@ -89,7 +89,7 @@ func _deploy(isUpdate bool) {}
 
 	t.Run("variables", func(t *testing.T) {
 		vars := map[string][]string{
-			"Main": {"s,String", "res,Integer"},
+			"Main": {"s,ByteString", "res,Integer"},
 		}
 		for i := range d.Methods {
 			v, ok := vars[d.Methods[i].ID]
@@ -102,30 +102,36 @@ func _deploy(isUpdate bool) {}
 	t.Run("param types", func(t *testing.T) {
 		paramTypes := map[string][]DebugParam{
 			"_deploy": {{
-				Name: "isUpdate",
-				Type: "Boolean",
+				Name:   "isUpdate",
+				Type:   "Boolean",
+				TypeSC: smartcontract.BoolType,
 			}},
 			"MethodInt": {{
-				Name: "a",
-				Type: "String",
+				Name:   "a",
+				Type:   "ByteString",
+				TypeSC: smartcontract.StringType,
 			}},
 			"MethodConcat": {
 				{
-					Name: "a",
-					Type: "String",
+					Name:   "a",
+					Type:   "ByteString",
+					TypeSC: smartcontract.StringType,
 				},
 				{
-					Name: "b",
-					Type: "String",
+					Name:   "b",
+					Type:   "ByteString",
+					TypeSC: smartcontract.StringType,
 				},
 				{
-					Name: "c",
-					Type: "String",
+					Name:   "c",
+					Type:   "ByteString",
+					TypeSC: smartcontract.StringType,
 				},
 			},
 			"Main": {{
-				Name: "op",
-				Type: "String",
+				Name:   "op",
+				Type:   "ByteString",
+				TypeSC: smartcontract.StringType,
 			}},
 		}
 		for i := range d.Methods {
@@ -307,8 +313,8 @@ func TestDebugInfo_MarshalJSON(t *testing.T) {
 				},
 				Range: DebugRange{Start: 10, End: 20},
 				Parameters: []DebugParam{
-					{"param1", "Integer"},
-					{"ok", "Boolean"},
+					{Name: "param1", Type: "Integer"},
+					{Name: "ok", Type: "Boolean"},
 				},
 				ReturnType: "ByteString",
 				Variables:  []string{},


### PR DESCRIPTION
Distinguish between VM types which are used in debugger and smartcontract ones which are used in
manifest. We can't save only one of them, because conversion in either
side is lossy:
1. VM has `Array` and `Struct` but smartcontract only has `Array`.
2. Smartcontract has `Hash160` etc, which are all `ByteString` or
`Buffer` in VM.

And to spice things a bit more, return type in debugger can be `Void`,
which corresponds to no real stackitem type (as it must exist).