### PR TITLE
vmcli/test: run shell after providing input

### DIFF
--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -61,13 +61,13 @@ func TestCompiler(t *testing.T) {
 				require.NoError(t, err)
 				err = os.MkdirAll(exampleSavePath, os.ModePerm)
 				require.NoError(t, err)
-				outfile := exampleSavePath + "/test.nef"
-				_, err = compiler.CompileAndSave(exampleCompilePath+"/"+infos[0].Name(), &compiler.Options{Outfile: outfile})
-				require.NoError(t, err)
 				defer func() {
 					err := os.RemoveAll(exampleSavePath)
 					require.NoError(t, err)
 				}()
+				outfile := exampleSavePath + "/test.nef"
+				_, err = compiler.CompileAndSave(exampleCompilePath+"/"+infos[0].Name(), &compiler.Options{Outfile: outfile})
+				require.NoError(t, err)
 			},
 		},
 	}

--- a/pkg/vm/cli/cli_test.go
+++ b/pkg/vm/cli/cli_test.go
@@ -75,16 +75,16 @@ func newTestVMCLIWithLogo(t *testing.T, printLogo bool) *executor {
 			Stdin:  e.in,
 			Stdout: e.out,
 		})
-	go func() {
-		require.NoError(t, e.cli.Run())
-		close(e.ch)
-	}()
 	return e
 }
 
 func (e *executor) runProg(t *testing.T, commands ...string) {
 	cmd := strings.Join(commands, "\n") + "\n"
 	e.in.WriteString(cmd + "\n")
+	go func() {
+		require.NoError(t, e.cli.Run())
+		close(e.ch)
+	}()
 	select {
 	case <-e.ch:
 	case <-time.After(time.Second):


### PR DESCRIPTION
In some cases, `Run()` can read from input before we have written
anything to it.

Close #1601.

Can be reproduced with `time.Sleep` between `newTestVMCLI` and `runProg`.
Also fix a bug in compiler tests.