### PR TITLE
core: fix bug with mempool.verifiedMap

### DIFF
--- a/pkg/core/mempool/mem_pool.go
+++ b/pkg/core/mempool/mem_pool.go
@@ -216,7 +216,6 @@ func (mp *Pool) Add(t *transaction.Transaction, fee Feer, data ...interface{}) e
 		mp.oracleResp[id] = t.Hash()
 	}
 
-	mp.verifiedMap[t.Hash()] = t
 	if fee.P2PSigExtensionsEnabled() {
 		// Remove conflicting transactions.
 		for _, conflictingTx := range conflictsToBeRemoved {
@@ -254,6 +253,7 @@ func (mp *Pool) Add(t *transaction.Transaction, fee Feer, data ...interface{}) e
 		copy(mp.verifiedTxes[n+1:], mp.verifiedTxes[n:])
 		mp.verifiedTxes[n] = pItem
 	}
+	mp.verifiedMap[t.Hash()] = t
 	if fee.P2PSigExtensionsEnabled() {
 		// Add conflicting hashes to the mp.conflicts list.
 		for _, attr := range t.GetAttributes(transaction.ConflictsT) {

--- a/pkg/core/mempool/mem_pool_test.go
+++ b/pkg/core/mempool/mem_pool_test.go
@@ -148,6 +148,9 @@ func TestOverCapacity(t *testing.T) {
 	txcnt++
 	require.Error(t, mp.Add(tx, fs))
 	require.Equal(t, mempoolSize, mp.Count())
+	require.Equal(t, mempoolSize, len(mp.verifiedMap))
+	require.Equal(t, mempoolSize, len(mp.verifiedTxes))
+	require.False(t, mp.containsKey(tx.Hash()))
 	require.Equal(t, true, sort.IsSorted(sort.Reverse(mp.verifiedTxes)))
 
 	// Low net fee, but higher per-byte fee is still a better combination.


### PR DESCRIPTION
Transaction is added to verifiedMap before OOM check, so we may have a
case when OOM occurs during tx1 pooling, but mp.containsKey(tx1)
returns `true` after this. Fixed.