### PR TITLE
network: support non-blocking broadcast

### DIFF
--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -415,18 +415,18 @@ func (p *localPeer) EnqueueMessage(msg *Message) error {
 	if err != nil {
 		return err
 	}
-	return p.EnqueuePacket(b)
+	return p.EnqueuePacket(true, b)
 }
-func (p *localPeer) EnqueuePacket(m []byte) error {
-	return p.EnqueueHPPacket(m)
+func (p *localPeer) EnqueuePacket(block bool, m []byte) error {
+	return p.EnqueueHPPacket(block, m)
 }
 func (p *localPeer) EnqueueP2PMessage(msg *Message) error {
 	return p.EnqueueMessage(msg)
 }
 func (p *localPeer) EnqueueP2PPacket(m []byte) error {
-	return p.EnqueueHPPacket(m)
+	return p.EnqueueHPPacket(true, m)
 }
-func (p *localPeer) EnqueueHPPacket(m []byte) error {
+func (p *localPeer) EnqueueHPPacket(_ bool, m []byte) error {
 	msg := &Message{Network: netmode.UnitTestNet}
 	r := io.NewBinReaderFromBuf(m)
 	err := msg.Decode(r)

--- a/pkg/network/message.go
+++ b/pkg/network/message.go
@@ -216,7 +216,7 @@ func (m *Message) tryCompressPayload() error {
 	compressedPayload := buf.Bytes()
 	if m.Flags&Compressed == 0 {
 		switch m.Payload.(type) {
-		case *payload.Headers, *payload.MerkleBlock, *payload.NullPayload,
+		case *payload.Headers, *payload.MerkleBlock, payload.NullPayload,
 			*payload.Inventory:
 			break
 		default:

--- a/pkg/network/peer.go
+++ b/pkg/network/peer.go
@@ -28,7 +28,7 @@ type Peer interface {
 	// can be shared with other queues (so that message marshalling can be
 	// done once for all peers). Does nothing is the peer is not yet
 	// completed handshaking.
-	EnqueuePacket([]byte) error
+	EnqueuePacket(bool, []byte) error
 
 	// EnqueueP2PMessage is a temporary wrapper that sends a message via
 	// EnqueueP2PPacket if there is no error in serializing it.
@@ -47,7 +47,7 @@ type Peer interface {
 	// EnqueueHPPacket is a blocking high priority packet enqueuer, it
 	// doesn't return until it puts given packet into the high-priority
 	// queue.
-	EnqueueHPPacket([]byte) error
+	EnqueueHPPacket(bool, []byte) error
 	Version() *payload.Version
 	LastBlockIndex() uint32
 	Handshaked() bool

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -474,7 +474,7 @@ func (s *Server) handleVersionCmd(p Peer, version *payload.Version) error {
 		}
 	}
 	s.lock.RUnlock()
-	return p.SendVersionAck(NewMessage(CMDVerack, nil))
+	return p.SendVersionAck(NewMessage(CMDVerack, payload.NewNullPayload()))
 }
 
 // handleBlockCmd processes the received block received from its peer.

--- a/pkg/network/tcp_peer.go
+++ b/pkg/network/tcp_peer.go
@@ -195,6 +195,7 @@ func (p *TCPPeer) handleQueues() {
 	var p2pSkipCounter uint32
 	const p2pSkipDivisor = 4
 
+	var writeTimeout = time.Duration(p.server.chain.GetConfig().SecondsPerBlock) * time.Second
 	for {
 		var msg []byte
 
@@ -227,6 +228,10 @@ func (p *TCPPeer) handleQueues() {
 			case msg = <-p.p2pSendQ:
 			case msg = <-p.sendQ:
 			}
+		}
+		err = p.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+		if err != nil {
+			break
 		}
 		_, err = p.conn.Write(msg)
 		if err != nil {

--- a/pkg/network/tcp_peer.go
+++ b/pkg/network/tcp_peer.go
@@ -30,6 +30,7 @@ const (
 
 var (
 	errGone           = errors.New("the peer is gone already")
+	errBusy           = errors.New("peer is busy")
 	errStateMismatch  = errors.New("tried to send protocol message before handshake completed")
 	errPingPong       = errors.New("ping/pong timeout")
 	errUnexpectedPong = errors.New("pong message wasn't expected")
@@ -81,21 +82,31 @@ func NewTCPPeer(conn net.Conn, s *Server) *TCPPeer {
 
 // putPacketIntoQueue puts given message into the given queue if the peer has
 // done handshaking.
-func (p *TCPPeer) putPacketIntoQueue(queue chan<- []byte, msg []byte) error {
+func (p *TCPPeer) putPacketIntoQueue(queue chan<- []byte, block bool, msg []byte) error {
 	if !p.Handshaked() {
 		return errStateMismatch
 	}
-	select {
-	case queue <- msg:
-	case <-p.done:
-		return errGone
+	if block {
+		select {
+		case queue <- msg:
+		case <-p.done:
+			return errGone
+		}
+	} else {
+		select {
+		case queue <- msg:
+		case <-p.done:
+			return errGone
+		default:
+			return errBusy
+		}
 	}
 	return nil
 }
 
 // EnqueuePacket implements the Peer interface.
-func (p *TCPPeer) EnqueuePacket(msg []byte) error {
-	return p.putPacketIntoQueue(p.sendQ, msg)
+func (p *TCPPeer) EnqueuePacket(block bool, msg []byte) error {
+	return p.putPacketIntoQueue(p.sendQ, block, msg)
 }
 
 // putMessageIntoQueue serializes given Message and puts it into given queue if
@@ -105,7 +116,7 @@ func (p *TCPPeer) putMsgIntoQueue(queue chan<- []byte, msg *Message) error {
 	if err != nil {
 		return err
 	}
-	return p.putPacketIntoQueue(queue, b)
+	return p.putPacketIntoQueue(queue, true, b)
 }
 
 // EnqueueMessage is a temporary wrapper that sends a message via
@@ -116,7 +127,7 @@ func (p *TCPPeer) EnqueueMessage(msg *Message) error {
 
 // EnqueueP2PPacket implements the Peer interface.
 func (p *TCPPeer) EnqueueP2PPacket(msg []byte) error {
-	return p.putPacketIntoQueue(p.p2pSendQ, msg)
+	return p.putPacketIntoQueue(p.p2pSendQ, true, msg)
 }
 
 // EnqueueP2PMessage implements the Peer interface.
@@ -126,8 +137,8 @@ func (p *TCPPeer) EnqueueP2PMessage(msg *Message) error {
 
 // EnqueueHPPacket implements the Peer interface. It the peer is not yet
 // handshaked it's a noop.
-func (p *TCPPeer) EnqueueHPPacket(msg []byte) error {
-	return p.putPacketIntoQueue(p.hpSendQ, msg)
+func (p *TCPPeer) EnqueueHPPacket(block bool, msg []byte) error {
+	return p.putPacketIntoQueue(p.hpSendQ, block, msg)
 }
 
 func (p *TCPPeer) writeMsg(msg *Message) error {


### PR DESCRIPTION
Right now a single slow peer can slow down whole network.
Do broadcast in 2 parts:
1. Perform non-blocking send to all peers if possible.
2. Perform blocking sends until message is sent to 2/3 of good peers.

Note that this is only about local queues, so in practice (1) will be the most common thing, unless we have a very slow neighbour. I am only concerned about the situation when messages are created faster than they can be send but as shown by benchmarks, this is rarely the case.

Related #1629.
