### PR TITLE
mpt: do not allocate new buffer when updating dirty node

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -687,7 +687,12 @@ func (bc *Blockchain) storeBlock(block *block.Block, txpool *mempool.Pool) error
 	}
 	writeBuf.Reset()
 
-	root := bc.dao.MPT.StateRoot()
+	d := cache.DAO.(*dao.Simple)
+	if err := d.UpdateMPT(); err != nil {
+		return fmt.Errorf("error while trying to apply MPT changes: %w", err)
+	}
+
+	root := d.MPT.StateRoot()
 	var prevHash util.Uint256
 	if block.Index > 0 {
 		prev, err := bc.dao.GetStateRoot(block.Index - 1)

--- a/pkg/core/mpt/base.go
+++ b/pkg/core/mpt/base.go
@@ -63,7 +63,7 @@ func (b *BaseNode) updateHash(n Node) {
 
 // updateCache updates hash and bytes fields for this BaseNode.
 func (b *BaseNode) updateBytes(n Node) {
-	buf := io.NewBufBinWriter()
+	buf := io.NewBufBinWriterPreAlloc(b.bytes)
 	encodeNodeWithType(n, buf.BinWriter)
 	b.bytes = buf.Bytes()
 	b.bytesValid = true

--- a/pkg/core/mpt/trie.go
+++ b/pkg/core/mpt/trie.go
@@ -418,31 +418,29 @@ func (t *Trie) updateRefCount(h util.Uint256) int32 {
 func (t *Trie) addRef(h util.Uint256, bs []byte) {
 	node := t.refcount[h]
 	if node == nil {
+		data := make([]byte, len(bs))
+		copy(data, bs)
 		t.refcount[h] = &cachedNode{
 			refcount: 1,
-			bytes:    bs,
+			bytes:    data,
 		}
 		return
 	}
 	node.refcount++
-	if node.bytes == nil {
-		node.bytes = bs
-	}
 }
 
 func (t *Trie) removeRef(h util.Uint256, bs []byte) {
 	node := t.refcount[h]
 	if node == nil {
+		data := make([]byte, len(bs))
+		copy(data, bs)
 		t.refcount[h] = &cachedNode{
 			refcount: -1,
-			bytes:    bs,
+			bytes:    data,
 		}
 		return
 	}
 	node.refcount--
-	if node.bytes == nil {
-		node.bytes = bs
-	}
 }
 
 func (t *Trie) getFromStore(h util.Uint256) (Node, error) {
@@ -462,7 +460,8 @@ func (t *Trie) getFromStore(h util.Uint256) (Node, error) {
 		data = data[:len(data)-4]
 		node := t.refcount[h]
 		if node != nil {
-			node.bytes = data
+			node.bytes = make([]byte, len(data))
+			copy(node.bytes, data)
 			node.initial = int32(r.ReadU32LE())
 		}
 	}

--- a/pkg/core/native_management_test.go
+++ b/pkg/core/native_management_test.go
@@ -440,6 +440,7 @@ func TestContractDestroy(t *testing.T) {
 	require.NoError(t, err)
 	err = bc.dao.PutStorageItem(cs1.ID, []byte{1, 2, 3}, &state.StorageItem{Value: []byte{3, 2, 1}})
 	require.NoError(t, err)
+	require.NoError(t, bc.dao.UpdateMPT())
 
 	t.Run("no contract", func(t *testing.T) {
 		res, err := invokeContractMethod(bc, 1_00000000, mgmtHash, "destroy")

--- a/pkg/core/storage/memory_store.go
+++ b/pkg/core/storage/memory_store.go
@@ -102,6 +102,23 @@ func (s *MemoryStore) Seek(key []byte, f func(k, v []byte)) {
 	s.mut.RUnlock()
 }
 
+// SeekAll is like seek but also iterates over deleted items.
+func (s *MemoryStore) SeekAll(key []byte, f func(k, v []byte)) {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+	sk := string(key)
+	for k, v := range s.mem {
+		if strings.HasPrefix(k, sk) {
+			f([]byte(k), v)
+		}
+	}
+	for k := range s.del {
+		if strings.HasPrefix(k, sk) {
+			f([]byte(k), nil)
+		}
+	}
+}
+
 // seek is an internal unlocked implementation of Seek.
 func (s *MemoryStore) seek(key []byte, f func(k, v []byte)) {
 	for k, v := range s.mem {

--- a/pkg/io/binaryBufWriter.go
+++ b/pkg/io/binaryBufWriter.go
@@ -19,6 +19,12 @@ func NewBufBinWriter() *BufBinWriter {
 	return &BufBinWriter{BinWriter: NewBinWriterFromIO(b), buf: b}
 }
 
+// NewBufBinWriterPreAlloc makes a BufBinWriter using preallocated buffer.
+func NewBufBinWriterPreAlloc(buf []byte) *BufBinWriter {
+	b := bytes.NewBuffer(buf[:0])
+	return &BufBinWriter{BinWriter: NewBinWriterFromIO(b), buf: b}
+}
+
 // Len returns the number of bytes of the unread portion of the buffer.
 func (bw *BufBinWriter) Len() int {
 	return bw.buf.Len()


### PR DESCRIPTION
I had concerns about copying when refcount is enabled, but it still seems to be better under high load and roughly the same on average. I think refcount needs more care later (e.g. using `sync.Pool` or even local `Trie` pool specially for slices contained in refcount map).

According to pprof most memory is consumed in `HashNode.EncodeBinary`. This is most likely due to expansion of `Branch` or `Extension` nodes during `Trie` update. Optimization done here is the only one which gives consistent improvements in terms of both running time and memory usage.

Other things which I tested:
1. Preallocate slice for hash nodes -- no noticeable improvements.
2. Implement `Size() int` for all nodes and preallocate -- better than master, but slower than this PR irregardless of other optimizations.

I think this should be post-preview4, to test it more together with further improvements.

Some benchmark results (inmemory db) for restore on generated dump and stats reported via `runtime.ReadMemStats` at the end. The actual gain is bigger due to statistics reported for all application, not only a `Trie`.

```
# commit, refcount enabled, blocks x tx per block
# PR, no refcount, 50x10000
TotalAlloc (MiB): 21300
Mallocs: 316552557
Frees: 301643724
PauseTotalNs: 3563883
GCCPUFraction:: 0.03032
./neogo db restore --unittest --in ./chain50x10000.acc  91,80s user 1,02s system 177% cpu 52,389 total

# master, no refcount, 50x10000
TotalAlloc (MiB): 23271
Mallocs: 325117505
Frees: 311644299
PauseTotalNs: 3783016
GCCPUFraction:: 0.03183
./neogo db restore --unittest --in ./chain50x10000.acc  95,03s user 1,10s system 179% cpu 53,671 total

# PR, with refcount, 50x10000
TotalAlloc (MiB): 21837
Mallocs: 324453766
Frees: 309332521
PauseTotalNs: 3770270
GCCPUFraction:: 0.03062
./neogo db restore --unittest --in ./chain50x10000.acc  94,84s user 0,99s system 174% cpu 55,039 total

# master, with refcount, 50x10000
TotalAlloc (MiB): 23338
Mallocs: 331209938
Frees: 312070104
PauseTotalNs: 7886987
GCCPUFraction:: 0.03189
./neogo db restore --unittest --in ./chain50x10000.acc  96,85s user 0,99s system 176% cpu 55,376 total

# PR, with refcount, 10000x50
TotalAlloc (MiB): 24814
Mallocs: 371539786
Frees: 350836724
PauseTotalNs: 6344485
GCCPUFraction:: 0.03215
./neogo db restore --unittest --in ./chain10000x50.acc  107,46s user 1,36s system 178% cpu 1:00,99 total

# master, with refcount, 10000x50
TotalAlloc (MiB): 24847
Mallocs: 377009923
Frees: 356592687
PauseTotalNs: 6340990
GCCPUFraction:: 0.03230
./neogo db restore --unittest --in ./chain10000x50.acc  107,53s user 1,28s system 180% cpu 1:00,44 total
```