### PR TITLE
Hotfixes for testnet

### DIFF
--- a/pkg/core/mpt/base.go
+++ b/pkg/core/mpt/base.go
@@ -63,7 +63,7 @@ func (b *BaseNode) updateHash(n Node) {
 
 // updateCache updates hash and bytes fields for this BaseNode.
 func (b *BaseNode) updateBytes(n Node) {
-	buf := io.NewBufBinWriterPreAlloc(b.bytes)
+	buf := io.NewBufBinWriter()
 	encodeNodeWithType(n, buf.BinWriter)
 	b.bytes = buf.Bytes()
 	b.bytesValid = true

--- a/pkg/core/mpt/trie.go
+++ b/pkg/core/mpt/trie.go
@@ -418,29 +418,31 @@ func (t *Trie) updateRefCount(h util.Uint256) int32 {
 func (t *Trie) addRef(h util.Uint256, bs []byte) {
 	node := t.refcount[h]
 	if node == nil {
-		data := make([]byte, len(bs))
-		copy(data, bs)
 		t.refcount[h] = &cachedNode{
 			refcount: 1,
-			bytes:    data,
+			bytes:    bs,
 		}
 		return
 	}
 	node.refcount++
+	if node.bytes == nil {
+		node.bytes = bs
+	}
 }
 
 func (t *Trie) removeRef(h util.Uint256, bs []byte) {
 	node := t.refcount[h]
 	if node == nil {
-		data := make([]byte, len(bs))
-		copy(data, bs)
 		t.refcount[h] = &cachedNode{
 			refcount: -1,
-			bytes:    data,
+			bytes:    bs,
 		}
 		return
 	}
 	node.refcount--
+	if node.bytes == nil {
+		node.bytes = bs
+	}
 }
 
 func (t *Trie) getFromStore(h util.Uint256) (Node, error) {
@@ -460,8 +462,7 @@ func (t *Trie) getFromStore(h util.Uint256) (Node, error) {
 		data = data[:len(data)-4]
 		node := t.refcount[h]
 		if node != nil {
-			node.bytes = make([]byte, len(data))
-			copy(node.bytes, data)
+			node.bytes = data
 			node.initial = int32(r.ReadU32LE())
 		}
 	}

--- a/pkg/io/binaryBufWriter.go
+++ b/pkg/io/binaryBufWriter.go
@@ -19,12 +19,6 @@ func NewBufBinWriter() *BufBinWriter {
 	return &BufBinWriter{BinWriter: NewBinWriterFromIO(b), buf: b}
 }
 
-// NewBufBinWriterPreAlloc makes a BufBinWriter using preallocated buffer.
-func NewBufBinWriterPreAlloc(buf []byte) *BufBinWriter {
-	b := bytes.NewBuffer(buf[:0])
-	return &BufBinWriter{BinWriter: NewBinWriterFromIO(b), buf: b}
-}
-
 // Len returns the number of bytes of the unread portion of the buffer.
 func (bw *BufBinWriter) Len() int {
 	return bw.buf.Len()


### PR DESCRIPTION
Revert commit with cache reuse. It causes problems and doesn't add much compared to the second optimisation.
