### PR TITLE
native: swap oracle and role management init

### DIFF
--- a/pkg/core/native/contract.go
+++ b/pkg/core/native/contract.go
@@ -73,17 +73,17 @@ func NewContracts(p2pSigExtensionsEnabled bool) *Contracts {
 	cs.Policy = policy
 	cs.Contracts = append(cs.Contracts, policy)
 
-	oracle := newOracle()
-	oracle.GAS = gas
-	oracle.NEO = neo
-	cs.Oracle = oracle
-	cs.Contracts = append(cs.Contracts, oracle)
-
 	desig := newDesignate(p2pSigExtensionsEnabled)
 	desig.NEO = neo
 	cs.Designate = desig
-	cs.Oracle.Desig = desig
 	cs.Contracts = append(cs.Contracts, desig)
+
+	oracle := newOracle()
+	oracle.GAS = gas
+	oracle.NEO = neo
+	oracle.Desig = desig
+	cs.Oracle = oracle
+	cs.Contracts = append(cs.Contracts, oracle)
 
 	if p2pSigExtensionsEnabled {
 		notary := newNotary()

--- a/pkg/core/native/designate.go
+++ b/pkg/core/native/designate.go
@@ -40,7 +40,7 @@ type oraclesData struct {
 }
 
 const (
-	designateContractID = -5
+	designateContractID = -4
 
 	// maxNodeCount is the maximum number of nodes to set the role for.
 	maxNodeCount = 32

--- a/pkg/core/native/oracle.go
+++ b/pkg/core/native/oracle.go
@@ -38,7 +38,7 @@ type Oracle struct {
 }
 
 const (
-	oracleContractID  = -4
+	oracleContractID  = -5
 	maxURLLength      = 256
 	maxFilterLength   = 128
 	maxCallbackLength = 32


### PR DESCRIPTION
Role management doesn't need oracles, but oracles do need role management. See neo-project/neo#2187.
