### PR TITLE
network: don't register addresses before version handshake

### DIFF
--- a/pkg/network/discovery.go
+++ b/pkg/network/discovery.go
@@ -192,8 +192,6 @@ func (d *DefaultDiscovery) tryAddress(addr string) {
 	if err := d.transport.Dial(addr, d.dialTimeout); err != nil {
 		d.RegisterBadAddr(addr)
 		d.RequestRemote(1)
-	} else {
-		d.RegisterConnectedAddr(addr)
 	}
 }
 

--- a/pkg/network/discovery_test.go
+++ b/pkg/network/discovery_test.go
@@ -81,6 +81,7 @@ func TestDefaultDiscoverer(t *testing.T) {
 		select {
 		case a := <-ts.dialCh:
 			dialled = append(dialled, a)
+			d.RegisterConnectedAddr(a)
 		case <-time.After(time.Second):
 			t.Fatalf("timeout expecting for transport dial")
 		}


### PR DESCRIPTION
1) It duplicates registration in `version` message handler and no valid
   connection can work without version exchange.
2) On public networks we have seed nodes defined by names, so we register
   connections to them using these names, but then if connection is dropped we
   delist them by IP:PORT combinations which can lead to zero PeerCount() with
   all seeds still being registered as connected in the discovery subsystem
   and thus no reconnection attempts being made.