### PR TITLE
Fix transaction fee marshalling

### DIFF
--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -307,8 +307,8 @@ type transactionJSON struct {
 	Version         uint8         `json:"version"`
 	Nonce           uint32        `json:"nonce"`
 	Sender          string        `json:"sender"`
-	SystemFee       fixedn.Fixed8 `json:"sysfee,string"`
-	NetworkFee      fixedn.Fixed8 `json:"netfee,string"`
+	SystemFee       fixedn.Fixed8 `json:"sysfee"`
+	NetworkFee      fixedn.Fixed8 `json:"netfee"`
 	ValidUntilBlock uint32        `json:"validuntilblock"`
 	Attributes      []Attribute   `json:"attributes"`
 	Signers         []Signer      `json:"signers"`

--- a/pkg/core/transaction/transaction_test.go
+++ b/pkg/core/transaction/transaction_test.go
@@ -3,6 +3,7 @@ package transaction
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"math"
 	"testing"
@@ -111,6 +112,37 @@ func TestDecodingTXWithNoScript(t *testing.T) {
 	require.NoError(t, err)
 	err = testserdes.DecodeBinary(txBin, new(Transaction))
 	require.Error(t, err)
+}
+
+func TestUnmarshalNeoFSTX(t *testing.T) {
+	txjson := []byte(`
+{
+  "hash": "0x635a3624bbe6cf99aee70e9cbd6473d913b6712cad6e717647f3ddf0fd13bfbb",
+  "size": 232,
+  "version": 0,
+  "nonce": 737880259,
+  "sender": "NiRqSd5MtRZT5yUhgWd7oG11brkDG76Jim",
+  "sysfee": "2.2371942",
+  "netfee": "0.0121555",
+  "validuntilblock": 1931,
+  "attributes": [],
+  "signers": [
+    {
+      "account": "0x8f0ecd714c31c5624b6647e5fd661e5031c8f8f6",
+      "scopes": "Global"
+    }
+  ],
+  "script": "DCECs2Ir9AF73+MXxYrtX0x1PyBrfbiWBG+n13S7xL9/jcIRwBESwAwEdm90ZQwUo4Hyc4fSGC6JbZtdrGb9LBbtWJtBYn1bUg==",
+  "witnesses": [
+    {
+      "invocation": "DEDr2gA/8T/wxQvgOZVfCdkbj6uGrprkDgJvpOJCcbl+tvlKZkZytCZEWm6NoZhJyIlEI3VQSLtU3AHuJfShAT5L",
+      "verification": "DCEDAS1H52IQrsc745qz0YbgpA/o2Gv6PU+r/aV7oTuI+WoLQZVEDXg="
+    }
+  ]
+}`)
+	tx := new(Transaction)
+	tx.Network = 56753
+	require.NoError(t, json.Unmarshal(txjson, tx))
 }
 
 func TestMarshalUnmarshalJSONInvocationTX(t *testing.T) {

--- a/pkg/encoding/fixedn/fixed8.go
+++ b/pkg/encoding/fixedn/fixed8.go
@@ -1,7 +1,6 @@
 package fixedn
 
 import (
-	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
@@ -80,34 +79,30 @@ func Fixed8FromString(s string) (Fixed8, error) {
 
 // UnmarshalJSON implements the json unmarshaller interface.
 func (f *Fixed8) UnmarshalJSON(data []byte) error {
-	return f.unmarshalHelper(func(v interface{}) error {
-		return json.Unmarshal(data, v)
-	})
+	if len(data) > 2 {
+		if data[0] == '"' && data[len(data)-1] == '"' {
+			data = data[1 : len(data)-1]
+		}
+	}
+	return f.setFromString(string(data))
 }
 
 // UnmarshalYAML implements the yaml unmarshaler interface.
 func (f *Fixed8) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	return f.unmarshalHelper(unmarshal)
-}
-
-// unmarshalHelper is an underlying unmarshaller func for JSON and YAML.
-func (f *Fixed8) unmarshalHelper(unmarshal func(interface{}) error) error {
 	var s string
-	if err := unmarshal(&s); err == nil {
-		p, err := Fixed8FromString(s)
-		if err != nil {
-			return err
-		}
-		*f = p
-		return nil
-	}
-
-	var fl float64
-	if err := unmarshal(&fl); err != nil {
+	err := unmarshal(&s)
+	if err != nil {
 		return err
 	}
+	return f.setFromString(s)
+}
 
-	*f = Fixed8(decimals * fl)
+func (f *Fixed8) setFromString(s string) error {
+	p, err := Fixed8FromString(s)
+	if err != nil {
+		return err
+	}
+	*f = p
 	return nil
 }
 

--- a/pkg/encoding/fixedn/fixed8_test.go
+++ b/pkg/encoding/fixedn/fixed8_test.go
@@ -123,6 +123,19 @@ func TestFixed8UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestFixed8_Unmarshal(t *testing.T) {
+	var expected = Fixed8(223719420)
+	var cases = []string{"2.2371942", `"2.2371942"`} // this easily gives 223719419 if interpreted as float
+
+	for _, c := range cases {
+		var u1, u2 Fixed8
+		assert.Nil(t, json.Unmarshal([]byte(c), &u1))
+		assert.Equal(t, expected, u1)
+		assert.Nil(t, yaml.Unmarshal([]byte(c), &u2))
+		assert.Equal(t, expected, u2)
+	}
+}
+
 func TestFixed8_MarshalJSON(t *testing.T) {
 	u, err := Fixed8FromString("123.4")
 	assert.NoError(t, err)


### PR DESCRIPTION
Some transactions failed to unmarshal with `txid doesn't match transaction hash`.