### PR TITLE
Consensus compatibility

### DIFF
--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -41,7 +41,7 @@ const defaultTimePerBlock = 15 * time.Second
 const nsInMs = 1000000
 
 // Category is message category for extensible payloads.
-const Category = "Consensus"
+const Category = "dBFT"
 
 // Service represents consensus instance.
 type Service interface {

--- a/pkg/network/payload/extensible.go
+++ b/pkg/network/payload/extensible.go
@@ -121,6 +121,7 @@ func (e *Extensible) updateHashes(b []byte) {
 // updateSignedPart updates serialized message if needed.
 func (e *Extensible) updateSignedPart() {
 	w := io.NewBufBinWriter()
+	w.WriteU32LE(uint32(e.Network))
 	e.encodeBinaryUnsigned(w.BinWriter)
 	e.signedpart = w.Bytes()
 }


### PR DESCRIPTION
### Problem

2+2 Go/C# consensus.

### Solution

This makes it work with preview5 C# nodes:
```
2021/02/04 13:57:49 empty block: 6
2021/02/04 13:57:50 CPU: 1.047%, Mem: 398.176MB
2021/02/04 13:57:51 (#7/122) 122 Tx's in 5010 ms 24.351297 tps
2021/02/04 13:57:56 (#8/252) 252 Tx's in 5020 ms 50.199203 tps
2021/02/04 13:58:00 CPU: 2.029%, Mem: 437.016MB
2021/02/04 13:58:01 (#9/249) 249 Tx's in 5011 ms 49.690681 tps
2021/02/04 13:58:06 (#10/252) 252 Tx's in 5017 ms 50.229221 tps
```
