### PR TITLE
native: fix `getCommittee` name

### DIFF
--- a/pkg/core/native/compatibility_test.go
+++ b/pkg/core/native/compatibility_test.go
@@ -2,6 +2,7 @@ package native
 
 import (
 	"testing"
+	"unicode"
 
 	"github.com/stretchr/testify/require"
 )
@@ -17,4 +18,26 @@ func TestNativeHashes(t *testing.T) {
 	require.Equal(t, "8dc0e742cbdfdeda51ff8a8b78d46829144c80ee", newOracle().Hash.StringLE())
 	// Not yet a part of NEO.
 	//require.Equal(t, "", newNotary().Hash.StringLE()())
+}
+
+// "C" and "O" can easily be typed by accident.
+func TestNamesASCII(t *testing.T) {
+	cs := NewContracts(true)
+	for _, c := range cs.Contracts {
+		require.True(t, isASCII(c.Metadata().Name))
+		for m := range c.Metadata().Methods {
+			require.True(t, isASCII(m.Name))
+		}
+		for _, e := range c.Metadata().Manifest.ABI.Events {
+			require.True(t, isASCII(e.Name))
+		}
+	}
+}
+
+func isASCII(s string) bool {
+	ok := true
+	for i := 0; i < len(s); i++ {
+		ok = ok && s[i] <= unicode.MaxASCII
+	}
+	return ok
 }

--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -133,7 +133,7 @@ func newNEO() *NEO {
 	md = newMethodAndPrice(n.getCandidatesCall, 100000000, callflag.ReadStates)
 	n.AddMethod(md, desc)
 
-	desc = newDescriptor("getСommittee", smartcontract.ArrayType)
+	desc = newDescriptor("getCommittee", smartcontract.ArrayType)
 	md = newMethodAndPrice(n.getCommittee, 100000000, callflag.ReadStates)
 	n.AddMethod(md, desc)
 


### PR DESCRIPTION
`C` was in russian.