### PR TITLE
Allow to inline internal wrappers in compiler

### DIFF
--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -55,14 +55,14 @@ func (c *codegen) traverseGlobals() (int, int, int) {
 				switch n := node.(type) {
 				case *ast.FuncDecl:
 					if isInitFunc(n) {
-						c, _ := countLocals(n)
-						if c > initLocals {
-							initLocals = c
+						num, _ := c.countLocals(n)
+						if num > initLocals {
+							initLocals = num
 						}
 					} else if isDeployFunc(n) {
-						c, _ := countLocals(n)
-						if c > deployLocals {
-							deployLocals = c
+						num, _ := c.countLocals(n)
+						if num > deployLocals {
+							deployLocals = num
 						}
 					}
 					return !hasDefer

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -175,10 +175,16 @@ func (f funcUsage) funcUsed(name string) bool {
 }
 
 // lastStmtIsReturn checks if last statement of the declaration was return statement..
-func lastStmtIsReturn(decl *ast.FuncDecl) (b bool) {
-	if l := len(decl.Body.List); l != 0 {
-		_, ok := decl.Body.List[l-1].(*ast.ReturnStmt)
-		return ok
+func lastStmtIsReturn(body *ast.BlockStmt) (b bool) {
+	if l := len(body.List); l != 0 {
+		switch inner := body.List[l-1].(type) {
+		case *ast.BlockStmt:
+			return lastStmtIsReturn(inner)
+		case *ast.ReturnStmt:
+			return true
+		default:
+			return false
+		}
 	}
 	return false
 }

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -304,3 +304,11 @@ func canConvert(s string) bool {
 	}
 	return true
 }
+
+// canInline returns true if function is to be inlined.
+// Currently there is a static list of function which are inlined,
+// this may change in future.
+func canInline(s string) bool {
+	return isNativeHelpersPath(s) ||
+		strings.HasPrefix(s, "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/inline")
+}

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -230,6 +230,9 @@ func (c *codegen) emitLoadVar(pkg string, name string) {
 	if vi.tv.Value != nil {
 		c.emitLoadConst(vi.tv)
 		return
+	} else if vi.index == unspecifiedVarIndex {
+		emit.Opcodes(c.prog.BinWriter, opcode.PUSHNULL)
+		return
 	}
 	c.emitLoadByIndex(vi.refType, vi.index)
 }

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -440,7 +440,7 @@ func (c *codegen) convertFuncDecl(file ast.Node, decl *ast.FuncDecl, pkg *types.
 	// If we have reached the end of the function without encountering `return` statement,
 	// we should clean alt.stack manually.
 	// This can be the case with void and named-return functions.
-	if !isInit && !isDeploy && !lastStmtIsReturn(decl) {
+	if !isInit && !isDeploy && !lastStmtIsReturn(decl.Body) {
 		c.saveSequencePoint(decl.Body)
 		emit.Opcodes(c.prog.BinWriter, opcode.RET)
 	}

--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -22,6 +22,8 @@ type funcScope struct {
 	// Package where the function is defined.
 	pkg *types.Package
 
+	file *ast.File
+
 	// Program label of the scope
 	label uint16
 

--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -102,11 +102,47 @@ func (c *funcScope) analyzeVoidCalls(node ast.Node) bool {
 	return true
 }
 
-func countLocals(decl *ast.FuncDecl) (int, bool) {
+func (c *codegen) countLocals(decl *ast.FuncDecl) (int, bool) {
+	return c.countLocalsInline(decl, nil, nil)
+}
+
+func (c *codegen) countLocalsInline(decl *ast.FuncDecl, pkg *types.Package, f *funcScope) (int, bool) {
+	oldMap := c.importMap
+	if pkg != nil {
+		c.fillImportMap(f.file, pkg)
+	}
+
 	size := 0
 	hasDefer := false
 	ast.Inspect(decl, func(n ast.Node) bool {
 		switch n := n.(type) {
+		case *ast.CallExpr:
+			var name string
+			switch fun := n.Fun.(type) {
+			case *ast.Ident:
+				var pkgName string
+				if pkg != nil {
+					pkgName = pkg.Path()
+				}
+				name = c.getIdentName(pkgName, fun.Name)
+			case *ast.SelectorExpr:
+				name, _ = c.getFuncNameFromSelector(fun)
+			default:
+				return false
+			}
+			if inner, ok := c.funcs[name]; ok && canInline(name) {
+				for i := range n.Args {
+					switch n.Args[i].(type) {
+					case *ast.Ident:
+					case *ast.BasicLit:
+					default:
+						size++
+					}
+				}
+				innerSz, _ := c.countLocalsInline(inner.decl, inner.pkg, inner)
+				size += innerSz
+			}
+			return false
 		case *ast.FuncType:
 			num := n.Results.NumFields()
 			if num != 0 && len(n.Results.List[0].Names) != 0 {
@@ -119,7 +155,11 @@ func countLocals(decl *ast.FuncDecl) (int, bool) {
 		case *ast.DeferStmt:
 			hasDefer = true
 			return false
-		case *ast.ReturnStmt, *ast.IfStmt:
+		case *ast.ReturnStmt:
+			if pkg == nil {
+				size++
+			}
+		case *ast.IfStmt:
 			size++
 		// This handles the inline GenDecl like "var x = 2"
 		case *ast.ValueSpec:
@@ -136,13 +176,16 @@ func countLocals(decl *ast.FuncDecl) (int, bool) {
 		}
 		return true
 	})
+	if pkg != nil {
+		c.importMap = oldMap
+	}
 	return size, hasDefer
 }
 
-func (c *funcScope) countLocals() int {
-	size, hasDefer := countLocals(c.decl)
+func (c *codegen) countLocalsWithDefer(f *funcScope) int {
+	size, hasDefer := c.countLocals(f.decl)
 	if hasDefer {
-		c.finallyProcessedIndex = size
+		f.finallyProcessedIndex = size
 		size++
 	}
 	return size
@@ -154,12 +197,6 @@ func (c *funcScope) countArgs() int {
 		n += c.decl.Recv.NumFields()
 	}
 	return n
-}
-
-func (c *funcScope) stackSize() int64 {
-	size := c.countLocals()
-	numArgs := c.countArgs()
-	return int64(size + numArgs)
 }
 
 // newVariable creates a new local variable or argument in the scope of the function.

--- a/pkg/compiler/inline.go
+++ b/pkg/compiler/inline.go
@@ -1,0 +1,49 @@
+package compiler
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+)
+
+// inlineCall inlines call of n for function represented by f.
+// Call `f(a,b)` for definition `func f(x,y int)` is translated to block:
+// {
+//    x := a
+//    y := b
+//    <inline body of f directly>
+// }
+func (c *codegen) inlineCall(f *funcScope, n *ast.CallExpr) {
+	pkg := c.buildInfo.program.Package(f.pkg.Path())
+	sig := c.typeOf(n.Fun).(*types.Signature)
+
+	// Arguments need to be walked with the current scope,
+	// while stored in the new.
+	oldScope := c.scope.vars.locals
+	c.scope.vars.newScope()
+	newScope := c.scope.vars.locals
+	defer c.scope.vars.dropScope()
+	for i := range n.Args {
+		c.scope.vars.locals = oldScope
+		ast.Walk(c, n.Args[i])
+		c.scope.vars.locals = newScope
+		name := sig.Params().At(i).Name()
+		c.scope.newLocal(name)
+		c.emitStoreVar("", name)
+	}
+
+	c.pkgInfoInline = append(c.pkgInfoInline, pkg)
+	oldMap := c.importMap
+	c.fillImportMap(f.file, pkg.Pkg)
+	ast.Inspect(f.decl, c.scope.analyzeVoidCalls)
+	ast.Walk(c, f.decl.Body)
+	if c.scope.voidCalls[n] {
+		for i := 0; i < f.decl.Type.Results.NumFields(); i++ {
+			emit.Opcodes(c.prog.BinWriter, opcode.DROP)
+		}
+	}
+	c.importMap = oldMap
+	c.pkgInfoInline = c.pkgInfoInline[:len(c.pkgInfoInline)-1]
+}

--- a/pkg/compiler/inline.go
+++ b/pkg/compiler/inline.go
@@ -53,6 +53,10 @@ func (c *codegen) inlineCall(f *funcScope, n *ast.CallExpr) {
 				c.scope.vars.locals = newScope
 				c.scope.vars.addAlias(name, varLocal, unspecifiedVarIndex, types.TypeAndValue{})
 				continue
+			} else if index, ok := c.globals[c.getIdentName("", arg.Name)]; ok {
+				c.scope.vars.locals = newScope
+				c.scope.vars.addAlias(name, varGlobal, index, types.TypeAndValue{})
+				continue
 			}
 		}
 		ast.Walk(c, n.Args[i])

--- a/pkg/compiler/inline.go
+++ b/pkg/compiler/inline.go
@@ -41,6 +41,10 @@ func (c *codegen) inlineCall(f *funcScope, n *ast.CallExpr) {
 				c.scope.vars.locals = newScope
 				c.scope.vars.addAlias(name, vi.refType, vi.index, vi.tv)
 				continue
+			} else if arg.Name == "nil" {
+				c.scope.vars.locals = newScope
+				c.scope.vars.addAlias(name, varLocal, unspecifiedVarIndex, types.TypeAndValue{})
+				continue
 			}
 		}
 		ast.Walk(c, n.Args[i])

--- a/pkg/compiler/inline_test.go
+++ b/pkg/compiler/inline_test.go
@@ -111,12 +111,7 @@ func TestInlineConversion(t *testing.T) {
 		a := 2
 		{
 			b := 1
-			c := a
-			{
-				bb := b
-				cc := c
-				return (bb + cc) * (b + c)
-			}
+			return (b + a) * (b + a)
 		}
 	}`
 	b2, err := compiler.Compile("foo.go", strings.NewReader(src2))

--- a/pkg/compiler/inline_test.go
+++ b/pkg/compiler/inline_test.go
@@ -1,0 +1,125 @@
+package compiler_test
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/compiler"
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/stretchr/testify/require"
+)
+
+func checkCallCount(t *testing.T, src string, expectedCall, expectedInitSlot int) {
+	v := vmAndCompile(t, src)
+	ctx := v.Context()
+	actualCall := 0
+	actualInitSlot := 0
+
+	for op, _, err := ctx.Next(); ; op, _, err = ctx.Next() {
+		require.NoError(t, err)
+		switch op {
+		case opcode.CALL, opcode.CALLL:
+			actualCall++
+		case opcode.INITSLOT:
+			actualInitSlot++
+		}
+		if ctx.IP() == ctx.LenInstr() {
+			break
+		}
+	}
+	require.Equal(t, expectedCall, actualCall)
+	require.Equal(t, expectedInitSlot, actualInitSlot)
+}
+
+func TestInline(t *testing.T) {
+	srcTmpl := `package foo
+	import "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/inline"
+	// local alias
+	func sum(a, b int) int {
+		return 42
+	}
+	func Main() int {
+		%s
+	}`
+	t.Run("no return", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `inline.NoArgsNoReturn()
+			return 1`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(1))
+	})
+	t.Run("has return, dropped", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `inline.NoArgsReturn1()
+			return 2`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(2))
+	})
+	t.Run("drop twice", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `inline.DropInsideInline()
+			return 42`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(42))
+	})
+	t.Run("no args return 1", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `return inline.NoArgsReturn1()`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(1))
+	})
+	t.Run("sum", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `return inline.Sum(1, 2)`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(3))
+	})
+	t.Run("sum squared (nested inline)", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `return inline.SumSquared(1, 2)`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(9))
+	})
+	t.Run("inline function in inline function parameter", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `return inline.Sum(inline.SumSquared(1, 2), inline.Sum(3, 4))`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(9+3+4))
+	})
+	t.Run("global name clash", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `return inline.GetSumSameName()`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(42))
+	})
+	t.Run("local name clash", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `return inline.Sum(inline.SumSquared(1, 2), sum(3, 4))`)
+		checkCallCount(t, src, 1, 2)
+		eval(t, src, big.NewInt(51))
+	})
+}
+
+func TestInlineConversion(t *testing.T) {
+	src1 := `package foo
+	import "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/inline"
+	var _ = inline.A
+	func Main() int {
+		a := 2
+		return inline.SumSquared(1, a)
+	}`
+	b1, err := compiler.Compile("foo.go", strings.NewReader(src1))
+	require.NoError(t, err)
+
+	src2 := `package foo
+	import "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/inline"
+	var _ = inline.A
+	func Main() int {
+		a := 2
+		{
+			b := 1
+			c := a
+			{
+				bb := b
+				cc := c
+				return (bb + cc) * (b + c)
+			}
+		}
+	}`
+	b2, err := compiler.Compile("foo.go", strings.NewReader(src2))
+	require.NoError(t, err)
+	require.Equal(t, b2, b1)
+}

--- a/pkg/compiler/inline_test.go
+++ b/pkg/compiler/inline_test.go
@@ -110,8 +110,7 @@ func TestInlineConversion(t *testing.T) {
 	func Main() int {
 		a := 2
 		{
-			b := 1
-			return (b + a) * (b + a)
+			return (1 + a) * (1 + a)
 		}
 	}`
 	b2, err := compiler.Compile("foo.go", strings.NewReader(src2))

--- a/pkg/compiler/inline_test.go
+++ b/pkg/compiler/inline_test.go
@@ -91,6 +91,22 @@ func TestInline(t *testing.T) {
 		checkCallCount(t, src, 1, 2)
 		eval(t, src, big.NewInt(51))
 	})
+	t.Run("var args, empty", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `return inline.VarSum(11)`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(11))
+	})
+	t.Run("var args, direct", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `return inline.VarSum(11, 14, 17)`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(42))
+	})
+	t.Run("var args, array", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `arr := []int{14, 17} 
+			return inline.VarSum(11, arr...)`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(42))
+	})
 }
 
 func TestInlineConversion(t *testing.T) {

--- a/pkg/compiler/testdata/inline/a/a.go
+++ b/pkg/compiler/testdata/inline/a/a.go
@@ -1,0 +1,7 @@
+package a
+
+var A = 29
+
+func GetA() int {
+	return A
+}

--- a/pkg/compiler/testdata/inline/b/b.go
+++ b/pkg/compiler/testdata/inline/b/b.go
@@ -1,0 +1,7 @@
+package b
+
+var A = 12
+
+func GetA() int {
+	return A
+}

--- a/pkg/compiler/testdata/inline/inline.go
+++ b/pkg/compiler/testdata/inline/inline.go
@@ -38,3 +38,7 @@ func VarSum(a int, b ...int) int {
 	}
 	return sum
 }
+
+func Concat(n int) int {
+	return n*100 + b.A*10 + A
+}

--- a/pkg/compiler/testdata/inline/inline.go
+++ b/pkg/compiler/testdata/inline/inline.go
@@ -1,0 +1,32 @@
+package inline
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/compiler/testdata/inline/a"
+	"github.com/nspcc-dev/neo-go/pkg/compiler/testdata/inline/b"
+)
+
+func NoArgsNoReturn() {}
+func NoArgsReturn1() int {
+	return 1
+}
+func Sum(a, b int) int {
+	return a + b
+}
+func sum(x, y int) int {
+	return x + y
+}
+func SumSquared(a, b int) int {
+	return sum(a, b) * (a + b)
+}
+
+var A = 1
+
+func GetSumSameName() int {
+	return a.GetA() + b.GetA() + A
+}
+
+func DropInsideInline() int {
+	sum(1, 2)
+	sum(3, 4)
+	return 7
+}

--- a/pkg/compiler/testdata/inline/inline.go
+++ b/pkg/compiler/testdata/inline/inline.go
@@ -30,3 +30,11 @@ func DropInsideInline() int {
 	sum(3, 4)
 	return 7
 }
+
+func VarSum(a int, b ...int) int {
+	sum := a
+	for i := range b {
+		sum += b[i]
+	}
+	return sum
+}

--- a/pkg/compiler/types.go
+++ b/pkg/compiler/types.go
@@ -8,6 +8,11 @@ import (
 )
 
 func (c *codegen) typeAndValueOf(e ast.Expr) types.TypeAndValue {
+	for i := len(c.pkgInfoInline) - 1; i >= 0; i-- {
+		if tv, ok := c.pkgInfoInline[i].Types[e]; ok {
+			return tv
+		}
+	}
 	return c.typeInfo.Types[e]
 }
 


### PR DESCRIPTION
Depends on #1702 .
Close #1691 .
Base for #941.

Haven't implemented general case, but enough to cover all our needs.
Current restrictions (none of them is a problem for wrappers):
1. Parameter in inline function can't be assigned to.
2. There should be exactly 1 exit point (`return`).
3. No `defer`s in inlined functions.
4. No recursion.

None of them is difficult to fix, but I don't see much value in doing this now without some real use-case.