### PR TITLE
oracle: fix mutex lock

### DIFF
--- a/pkg/services/oracle/oracle.go
+++ b/pkg/services/oracle/oracle.go
@@ -171,7 +171,7 @@ func (o *Oracle) Run() {
 			return
 		case <-tick.C:
 			var reprocess []uint64
-			o.respMtx.RLock()
+			o.respMtx.Lock()
 			o.removed = make(map[uint64]bool)
 			for id, incTx := range o.responses {
 				incTx.RLock()


### PR DESCRIPTION
fatal error: sync: Unlock of unlocked RWMutex

goroutine 5552 [running]:
runtime.throw(0xd57410, 0x20)
        /usr/lib/go/src/runtime/panic.go:1116 +0x72 fp=0xc00038dd30 sp=0xc00038dd00 pc=0x443132
sync.throw(0xd57410, 0x20)
        /usr/lib/go/src/runtime/panic.go:1102 +0x35 fp=0xc00038dd50 sp=0xc00038dd30 pc=0x475e55
sync.(*RWMutex).Unlock(0xc001448a40)
        /usr/lib/go/src/sync/rwmutex.go:129 +0xc6 fp=0xc00038dd88 sp=0xc00038dd50 pc=0x4863a6
github.com/nspcc-dev/neo-go/pkg/services/oracle.(*Oracle).Run(0xc0014488c0)
        /home/dzeta/repo/neo-go/pkg/services/oracle/oracle.go:189 +0x33d fp=0xc00038dfd8 sp=0xc00038dd88 pc=0xaa161d
runtime.goexit()
        /usr/lib/go/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc00038dfe0 sp=0xc00038dfd8 pc=0x47ad61
created by github.com/nspcc-dev/neo-go/pkg/core.TestOracleFull
        /home/dzeta/repo/neo-go/pkg/core/oracle_test.go:276 +0x2a5

