### PR TITLE
payload: treat zero-length headers as error

### DIFF
--- a/pkg/network/payload/headers.go
+++ b/pkg/network/payload/headers.go
@@ -1,6 +1,7 @@
 package payload
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/config/netmode"
@@ -24,9 +25,17 @@ const (
 // ErrTooManyHeaders is an error returned when too many headers were received.
 var ErrTooManyHeaders = fmt.Errorf("too many headers were received (max: %d)", MaxHeadersAllowed)
 
+// ErrNoHeaders is returned for zero-elements Headers payload which is considered to be invalid.
+var ErrNoHeaders = errors.New("no headers (zero length array)")
+
 // DecodeBinary implements Serializable interface.
 func (p *Headers) DecodeBinary(br *io.BinReader) {
 	lenHeaders := br.ReadVarUint()
+
+	if br.Err == nil && lenHeaders == 0 {
+		br.Err = ErrNoHeaders
+		return
+	}
 
 	var limitExceeded bool
 


### PR DESCRIPTION
See neo-project/neo#2259.
