### PR TITLE
smartcontract: add NEP-11 standard check

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -227,7 +227,7 @@ func CompileAndSave(src string, o *Options) ([]byte, error) {
 			return b, fmt.Errorf("failed to convert debug info to manifest: %w", err)
 		}
 		if !o.NoStandardCheck {
-			if err := standard.Check(m, o.ContractSupportedStandards...); err != nil {
+			if err := standard.CheckABI(m, o.ContractSupportedStandards...); err != nil {
 				return b, err
 			}
 		}

--- a/pkg/core/native/name_service_test.go
+++ b/pkg/core/native/name_service_test.go
@@ -3,6 +3,8 @@ package native
 import (
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest/standard"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,4 +87,9 @@ func TestNameService_CheckName(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestNameService_NEP11(t *testing.T) {
+	ns := newNameService()
+	require.NoError(t, standard.Check(&ns.Manifest, manifest.NEP11StandardName))
 }

--- a/pkg/core/native/nonfungible_test.go
+++ b/pkg/core/native/nonfungible_test.go
@@ -1,0 +1,14 @@
+package native
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest/standard"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNonfungibleNEP11(t *testing.T) {
+	n := newNonFungible("NFToken", -100, "SYM", 1)
+	require.NoError(t, standard.Check(&n.ContractMD.Manifest, manifest.NEP11StandardName))
+}

--- a/pkg/smartcontract/manifest/manifest.go
+++ b/pkg/smartcontract/manifest/manifest.go
@@ -20,6 +20,10 @@ const (
 	NEP11StandardName = "NEP-11"
 	// NEP17StandardName represents the name of NEP17 smartcontract standard.
 	NEP17StandardName = "NEP-17"
+	// NEP11Payable represents the name of contract interface which can receive NEP-11 tokens.
+	NEP11Payable = "NEP-11-Payable"
+	// NEP17Payable represents the name of contract interface which can receive NEP-17 tokens.
+	NEP17Payable = "NEP-17-Payable"
 )
 
 // Manifest represens contract metadata.

--- a/pkg/smartcontract/manifest/manifest.go
+++ b/pkg/smartcontract/manifest/manifest.go
@@ -16,6 +16,8 @@ const (
 
 	// NEP10StandardName represents the name of NEP10 smartcontract standard.
 	NEP10StandardName = "NEP-10"
+	// NEP11StandardName represents the name of NEP11 smartcontract standard.
+	NEP11StandardName = "NEP-11"
 	// NEP17StandardName represents the name of NEP17 smartcontract standard.
 	NEP17StandardName = "NEP-17"
 )

--- a/pkg/smartcontract/manifest/standard/check.go
+++ b/pkg/smartcontract/manifest/standard/check.go
@@ -1,0 +1,15 @@
+package standard
+
+import "github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+
+// Standard represents smart-contract standard.
+type Standard struct {
+	// Manifest describes mandatory methods and events.
+	manifest.Manifest
+	// Base contains base standard.
+	Base *Standard
+	// Optional contains optional contract methods.
+	// If contract contains method with the same name and parameter count,
+	// it must have signature declared by this contract.
+	Optional []manifest.Method
+}

--- a/pkg/smartcontract/manifest/standard/comply.go
+++ b/pkg/smartcontract/manifest/standard/comply.go
@@ -21,6 +21,8 @@ var (
 var checks = map[string][]*Standard{
 	manifest.NEP11StandardName: {nep11NonDivisible, nep11Divisible},
 	manifest.NEP17StandardName: {nep17},
+	manifest.NEP11Payable:      {nep11payable},
+	manifest.NEP17Payable:      {nep17payable},
 }
 
 // Check checks if manifest complies with all provided standards.

--- a/pkg/smartcontract/manifest/standard/comply_test.go
+++ b/pkg/smartcontract/manifest/standard/comply_test.go
@@ -121,3 +121,39 @@ func TestCheck(t *testing.T) {
 	m.ABI.Events = append(m.ABI.Events, nep17.ABI.Events...)
 	require.NoError(t, Check(m, manifest.NEP17StandardName))
 }
+
+func TestOptional(t *testing.T) {
+	var m Standard
+	m.Optional = []manifest.Method{{
+		Name:       "optMet",
+		Parameters: []manifest.Parameter{{Type: smartcontract.ByteArrayType}},
+		ReturnType: smartcontract.IntegerType,
+	}}
+
+	t.Run("wrong parameter count, do not check", func(t *testing.T) {
+		var actual manifest.Manifest
+		actual.ABI.Methods = []manifest.Method{{
+			Name:       "optMet",
+			ReturnType: smartcontract.IntegerType,
+		}}
+		require.NoError(t, Comply(&actual, &m))
+	})
+	t.Run("good parameter count, bad return", func(t *testing.T) {
+		var actual manifest.Manifest
+		actual.ABI.Methods = []manifest.Method{{
+			Name:       "optMet",
+			Parameters: []manifest.Parameter{{Type: smartcontract.ArrayType}},
+			ReturnType: smartcontract.IntegerType,
+		}}
+		require.Error(t, Comply(&actual, &m))
+	})
+	t.Run("good parameter count, good return", func(t *testing.T) {
+		var actual manifest.Manifest
+		actual.ABI.Methods = []manifest.Method{{
+			Name:       "optMet",
+			Parameters: []manifest.Parameter{{Type: smartcontract.ByteArrayType}},
+			ReturnType: smartcontract.IntegerType,
+		}}
+		require.NoError(t, Comply(&actual, &m))
+	})
+}

--- a/pkg/smartcontract/manifest/standard/comply_test.go
+++ b/pkg/smartcontract/manifest/standard/comply_test.go
@@ -38,14 +38,14 @@ func fooMethodBarEvent() *manifest.Manifest {
 func TestComplyMissingMethod(t *testing.T) {
 	m := fooMethodBarEvent()
 	m.ABI.GetMethod("foo", -1).Name = "notafoo"
-	err := Comply(m, fooMethodBarEvent())
+	err := Comply(m, &Standard{Manifest: *fooMethodBarEvent()})
 	require.True(t, errors.Is(err, ErrMethodMissing))
 }
 
 func TestComplyInvalidReturnType(t *testing.T) {
 	m := fooMethodBarEvent()
 	m.ABI.GetMethod("foo", -1).ReturnType = smartcontract.VoidType
-	err := Comply(m, fooMethodBarEvent())
+	err := Comply(m, &Standard{Manifest: *fooMethodBarEvent()})
 	require.True(t, errors.Is(err, ErrInvalidReturnType))
 }
 
@@ -54,14 +54,14 @@ func TestComplyMethodParameterCount(t *testing.T) {
 		m := fooMethodBarEvent()
 		f := m.ABI.GetMethod("foo", -1)
 		f.Parameters = append(f.Parameters, manifest.Parameter{Type: smartcontract.BoolType})
-		err := Comply(m, fooMethodBarEvent())
+		err := Comply(m, &Standard{Manifest: *fooMethodBarEvent()})
 		require.True(t, errors.Is(err, ErrMethodMissing))
 	})
 	t.Run("Event", func(t *testing.T) {
 		m := fooMethodBarEvent()
 		ev := m.ABI.GetEvent("bar")
 		ev.Parameters = append(ev.Parameters[:0])
-		err := Comply(m, fooMethodBarEvent())
+		err := Comply(m, &Standard{Manifest: *fooMethodBarEvent()})
 		require.True(t, errors.Is(err, ErrInvalidParameterCount))
 	})
 }
@@ -70,13 +70,13 @@ func TestComplyParameterType(t *testing.T) {
 	t.Run("Method", func(t *testing.T) {
 		m := fooMethodBarEvent()
 		m.ABI.GetMethod("foo", -1).Parameters[0].Type = smartcontract.InteropInterfaceType
-		err := Comply(m, fooMethodBarEvent())
+		err := Comply(m, &Standard{Manifest: *fooMethodBarEvent()})
 		require.True(t, errors.Is(err, ErrInvalidParameterType))
 	})
 	t.Run("Event", func(t *testing.T) {
 		m := fooMethodBarEvent()
 		m.ABI.GetEvent("bar").Parameters[0].Type = smartcontract.InteropInterfaceType
-		err := Comply(m, fooMethodBarEvent())
+		err := Comply(m, &Standard{Manifest: *fooMethodBarEvent()})
 		require.True(t, errors.Is(err, ErrInvalidParameterType))
 	})
 }
@@ -84,14 +84,14 @@ func TestComplyParameterType(t *testing.T) {
 func TestMissingEvent(t *testing.T) {
 	m := fooMethodBarEvent()
 	m.ABI.GetEvent("bar").Name = "notabar"
-	err := Comply(m, fooMethodBarEvent())
+	err := Comply(m, &Standard{Manifest: *fooMethodBarEvent()})
 	require.True(t, errors.Is(err, ErrEventMissing))
 }
 
 func TestSafeFlag(t *testing.T) {
 	m := fooMethodBarEvent()
 	m.ABI.GetMethod("foo", -1).Safe = false
-	err := Comply(m, fooMethodBarEvent())
+	err := Comply(m, &Standard{Manifest: *fooMethodBarEvent()})
 	require.True(t, errors.Is(err, ErrSafeMethodMismatch))
 }
 
@@ -109,12 +109,15 @@ func TestComplyValid(t *testing.T) {
 			Type: smartcontract.IntegerType,
 		}},
 	})
-	require.NoError(t, Comply(m, fooMethodBarEvent()))
+	require.NoError(t, Comply(m, &Standard{Manifest: *fooMethodBarEvent()}))
 }
 
 func TestCheck(t *testing.T) {
 	m := manifest.NewManifest("Test")
 	require.Error(t, Check(m, manifest.NEP17StandardName))
 
-	require.NoError(t, Check(nep17, manifest.NEP17StandardName))
+	m.ABI.Methods = append(m.ABI.Methods, decimalTokenBase.ABI.Methods...)
+	m.ABI.Methods = append(m.ABI.Methods, nep17.ABI.Methods...)
+	m.ABI.Events = append(m.ABI.Events, nep17.ABI.Events...)
+	require.NoError(t, Check(m, manifest.NEP17StandardName))
 }

--- a/pkg/smartcontract/manifest/standard/comply_test.go
+++ b/pkg/smartcontract/manifest/standard/comply_test.go
@@ -81,6 +81,25 @@ func TestComplyParameterType(t *testing.T) {
 	})
 }
 
+func TestComplyParameterName(t *testing.T) {
+	t.Run("Method", func(t *testing.T) {
+		m := fooMethodBarEvent()
+		m.ABI.GetMethod("foo", -1).Parameters[0].Name = "hehe"
+		s := &Standard{Manifest: *fooMethodBarEvent()}
+		err := Comply(m, s)
+		require.True(t, errors.Is(err, ErrInvalidParameterName))
+		require.NoError(t, ComplyABI(m, s))
+	})
+	t.Run("Event", func(t *testing.T) {
+		m := fooMethodBarEvent()
+		m.ABI.GetEvent("bar").Parameters[0].Name = "hehe"
+		s := &Standard{Manifest: *fooMethodBarEvent()}
+		err := Comply(m, s)
+		require.True(t, errors.Is(err, ErrInvalidParameterName))
+		require.NoError(t, ComplyABI(m, s))
+	})
+}
+
 func TestMissingEvent(t *testing.T) {
 	m := fooMethodBarEvent()
 	m.ABI.GetEvent("bar").Name = "notabar"
@@ -120,6 +139,7 @@ func TestCheck(t *testing.T) {
 	m.ABI.Methods = append(m.ABI.Methods, nep17.ABI.Methods...)
 	m.ABI.Events = append(m.ABI.Events, nep17.ABI.Events...)
 	require.NoError(t, Check(m, manifest.NEP17StandardName))
+	require.NoError(t, CheckABI(m, manifest.NEP17StandardName))
 }
 
 func TestOptional(t *testing.T) {

--- a/pkg/smartcontract/manifest/standard/nep11.go
+++ b/pkg/smartcontract/manifest/standard/nep11.go
@@ -1,0 +1,121 @@
+package standard
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+)
+
+var nep11Base = &Standard{
+	Base: decimalTokenBase,
+	Manifest: manifest.Manifest{
+		ABI: manifest.ABI{
+			Methods: []manifest.Method{
+				{
+					Name: "balanceOf",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.Hash160Type},
+					},
+					ReturnType: smartcontract.IntegerType,
+					Safe:       true,
+				},
+				{
+					Name:       "tokensOf",
+					ReturnType: smartcontract.AnyType, // Iterator
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.Hash160Type},
+					},
+					Safe: true,
+				},
+				{
+					Name: "transfer",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.Hash160Type},
+						{Type: smartcontract.ByteArrayType},
+					},
+					ReturnType: smartcontract.BoolType,
+				},
+			},
+			Events: []manifest.Event{
+				{
+					Name: "Transfer",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.Hash160Type},
+						{Type: smartcontract.Hash160Type},
+						{Type: smartcontract.IntegerType},
+						{Type: smartcontract.ByteArrayType},
+					},
+				},
+			},
+		},
+	},
+	Optional: []manifest.Method{
+		{
+			Name: "properties",
+			Parameters: []manifest.Parameter{
+				{Type: smartcontract.ByteArrayType},
+			},
+			ReturnType: smartcontract.MapType,
+			Safe:       true,
+		},
+		{
+			Name:       "tokens",
+			ReturnType: smartcontract.AnyType,
+			Safe:       true,
+		},
+	},
+}
+
+var nep11NonDivisible = &Standard{
+	Base: nep11Base,
+	Manifest: manifest.Manifest{
+		ABI: manifest.ABI{
+			Methods: []manifest.Method{
+				{
+					Name: "ownerOf",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.ByteArrayType},
+					},
+					ReturnType: smartcontract.Hash160Type,
+					Safe:       true,
+				},
+			},
+		},
+	},
+}
+
+var nep11Divisible = &Standard{
+	Base: nep11Base,
+	Manifest: manifest.Manifest{
+		ABI: manifest.ABI{
+			Methods: []manifest.Method{
+				{
+					Name: "balanceOf",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.Hash160Type},
+						{Type: smartcontract.ByteArrayType},
+					},
+					ReturnType: smartcontract.IntegerType,
+					Safe:       true,
+				},
+				{
+					Name: "ownerOf",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.ByteArrayType},
+					},
+					ReturnType: smartcontract.AnyType,
+					Safe:       true,
+				},
+				{
+					Name: "transfer",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.Hash160Type},
+						{Type: smartcontract.Hash160Type},
+						{Type: smartcontract.IntegerType},
+						{Type: smartcontract.ByteArrayType},
+					},
+					ReturnType: smartcontract.BoolType,
+				},
+			},
+		},
+	},
+}

--- a/pkg/smartcontract/manifest/standard/nep11.go
+++ b/pkg/smartcontract/manifest/standard/nep11.go
@@ -13,7 +13,7 @@ var nep11Base = &Standard{
 				{
 					Name: "balanceOf",
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.Hash160Type},
+						{Name: "owner", Type: smartcontract.Hash160Type},
 					},
 					ReturnType: smartcontract.IntegerType,
 					Safe:       true,
@@ -22,15 +22,15 @@ var nep11Base = &Standard{
 					Name:       "tokensOf",
 					ReturnType: smartcontract.AnyType, // Iterator
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.Hash160Type},
+						{Name: "owner", Type: smartcontract.Hash160Type},
 					},
 					Safe: true,
 				},
 				{
 					Name: "transfer",
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.Hash160Type},
-						{Type: smartcontract.ByteArrayType},
+						{Name: "to", Type: smartcontract.Hash160Type},
+						{Name: "tokenId", Type: smartcontract.ByteArrayType},
 					},
 					ReturnType: smartcontract.BoolType,
 				},
@@ -39,10 +39,10 @@ var nep11Base = &Standard{
 				{
 					Name: "Transfer",
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.Hash160Type},
-						{Type: smartcontract.Hash160Type},
-						{Type: smartcontract.IntegerType},
-						{Type: smartcontract.ByteArrayType},
+						{Name: "from", Type: smartcontract.Hash160Type},
+						{Name: "to", Type: smartcontract.Hash160Type},
+						{Name: "amount", Type: smartcontract.IntegerType},
+						{Name: "tokenId", Type: smartcontract.ByteArrayType},
 					},
 				},
 			},
@@ -52,7 +52,7 @@ var nep11Base = &Standard{
 		{
 			Name: "properties",
 			Parameters: []manifest.Parameter{
-				{Type: smartcontract.ByteArrayType},
+				{Name: "tokenId", Type: smartcontract.ByteArrayType},
 			},
 			ReturnType: smartcontract.MapType,
 			Safe:       true,
@@ -73,7 +73,7 @@ var nep11NonDivisible = &Standard{
 				{
 					Name: "ownerOf",
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.ByteArrayType},
+						{Name: "tokenId", Type: smartcontract.ByteArrayType},
 					},
 					ReturnType: smartcontract.Hash160Type,
 					Safe:       true,
@@ -91,8 +91,8 @@ var nep11Divisible = &Standard{
 				{
 					Name: "balanceOf",
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.Hash160Type},
-						{Type: smartcontract.ByteArrayType},
+						{Name: "owner", Type: smartcontract.Hash160Type},
+						{Name: "tokenId", Type: smartcontract.ByteArrayType},
 					},
 					ReturnType: smartcontract.IntegerType,
 					Safe:       true,
@@ -100,7 +100,7 @@ var nep11Divisible = &Standard{
 				{
 					Name: "ownerOf",
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.ByteArrayType},
+						{Name: "tokenId", Type: smartcontract.ByteArrayType},
 					},
 					ReturnType: smartcontract.AnyType,
 					Safe:       true,
@@ -108,10 +108,10 @@ var nep11Divisible = &Standard{
 				{
 					Name: "transfer",
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.Hash160Type},
-						{Type: smartcontract.Hash160Type},
-						{Type: smartcontract.IntegerType},
-						{Type: smartcontract.ByteArrayType},
+						{Name: "from", Type: smartcontract.Hash160Type},
+						{Name: "to", Type: smartcontract.Hash160Type},
+						{Name: "amount", Type: smartcontract.IntegerType},
+						{Name: "tokenId", Type: smartcontract.ByteArrayType},
 					},
 					ReturnType: smartcontract.BoolType,
 				},

--- a/pkg/smartcontract/manifest/standard/nep17.go
+++ b/pkg/smartcontract/manifest/standard/nep17.go
@@ -5,50 +5,38 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
 )
 
-var nep17 = &manifest.Manifest{
-	ABI: manifest.ABI{
-		Methods: []manifest.Method{
-			{
-				Name: "balanceOf",
-				Parameters: []manifest.Parameter{
-					{Type: smartcontract.Hash160Type},
+var nep17 = &Standard{
+	Base: decimalTokenBase,
+	Manifest: manifest.Manifest{
+		ABI: manifest.ABI{
+			Methods: []manifest.Method{
+				{
+					Name: "balanceOf",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.Hash160Type},
+					},
+					ReturnType: smartcontract.IntegerType,
+					Safe:       true,
 				},
-				ReturnType: smartcontract.IntegerType,
-				Safe:       true,
-			},
-			{
-				Name:       "decimals",
-				ReturnType: smartcontract.IntegerType,
-				Safe:       true,
-			},
-			{
-				Name:       "symbol",
-				ReturnType: smartcontract.StringType,
-				Safe:       true,
-			},
-			{
-				Name:       "totalSupply",
-				ReturnType: smartcontract.IntegerType,
-				Safe:       true,
-			},
-			{
-				Name: "transfer",
-				Parameters: []manifest.Parameter{
-					{Type: smartcontract.Hash160Type},
-					{Type: smartcontract.Hash160Type},
-					{Type: smartcontract.IntegerType},
-					{Type: smartcontract.AnyType},
+				{
+					Name: "transfer",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.Hash160Type},
+						{Type: smartcontract.Hash160Type},
+						{Type: smartcontract.IntegerType},
+						{Type: smartcontract.AnyType},
+					},
+					ReturnType: smartcontract.BoolType,
 				},
-				ReturnType: smartcontract.BoolType,
 			},
-		},
-		Events: []manifest.Event{
-			{
-				Name: "Transfer",
-				Parameters: []manifest.Parameter{
-					{Type: smartcontract.Hash160Type},
-					{Type: smartcontract.Hash160Type},
-					{Type: smartcontract.IntegerType},
+			Events: []manifest.Event{
+				{
+					Name: "Transfer",
+					Parameters: []manifest.Parameter{
+						{Type: smartcontract.Hash160Type},
+						{Type: smartcontract.Hash160Type},
+						{Type: smartcontract.IntegerType},
+					},
 				},
 			},
 		},

--- a/pkg/smartcontract/manifest/standard/nep17.go
+++ b/pkg/smartcontract/manifest/standard/nep17.go
@@ -13,7 +13,7 @@ var nep17 = &Standard{
 				{
 					Name: "balanceOf",
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.Hash160Type},
+						{Name: "account", Type: smartcontract.Hash160Type},
 					},
 					ReturnType: smartcontract.IntegerType,
 					Safe:       true,
@@ -21,10 +21,10 @@ var nep17 = &Standard{
 				{
 					Name: "transfer",
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.Hash160Type},
-						{Type: smartcontract.Hash160Type},
-						{Type: smartcontract.IntegerType},
-						{Type: smartcontract.AnyType},
+						{Name: "from", Type: smartcontract.Hash160Type},
+						{Name: "to", Type: smartcontract.Hash160Type},
+						{Name: "amount", Type: smartcontract.IntegerType},
+						{Name: "data", Type: smartcontract.AnyType},
 					},
 					ReturnType: smartcontract.BoolType,
 				},
@@ -33,9 +33,9 @@ var nep17 = &Standard{
 				{
 					Name: "Transfer",
 					Parameters: []manifest.Parameter{
-						{Type: smartcontract.Hash160Type},
-						{Type: smartcontract.Hash160Type},
-						{Type: smartcontract.IntegerType},
+						{Name: "from", Type: smartcontract.Hash160Type},
+						{Name: "to", Type: smartcontract.Hash160Type},
+						{Name: "amount", Type: smartcontract.IntegerType},
 					},
 				},
 			},

--- a/pkg/smartcontract/manifest/standard/nep17.go
+++ b/pkg/smartcontract/manifest/standard/nep17.go
@@ -42,8 +42,3 @@ var nep17 = &Standard{
 		},
 	},
 }
-
-// IsNEP17 checks if m is NEP-17 compliant.
-func IsNEP17(m *manifest.Manifest) error {
-	return Comply(m, nep17)
-}

--- a/pkg/smartcontract/manifest/standard/payable.go
+++ b/pkg/smartcontract/manifest/standard/payable.go
@@ -1,0 +1,38 @@
+package standard
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+)
+
+var nep11payable = &Standard{
+	Manifest: manifest.Manifest{
+		ABI: manifest.ABI{
+			Methods: []manifest.Method{{
+				Name: manifest.MethodOnNEP11Payment,
+				Parameters: []manifest.Parameter{
+					{Name: "from", Type: smartcontract.Hash160Type},
+					{Name: "amount", Type: smartcontract.IntegerType},
+					{Name: "tokenid", Type: smartcontract.ByteArrayType},
+				},
+				ReturnType: smartcontract.VoidType,
+			}},
+		},
+	},
+}
+
+var nep17payable = &Standard{
+	Manifest: manifest.Manifest{
+		ABI: manifest.ABI{
+			Methods: []manifest.Method{{
+				Name: manifest.MethodOnNEP17Payment,
+				Parameters: []manifest.Parameter{
+					{Name: "from", Type: smartcontract.Hash160Type},
+					{Name: "amount", Type: smartcontract.IntegerType},
+					{Name: "data", Type: smartcontract.AnyType},
+				},
+				ReturnType: smartcontract.VoidType,
+			}},
+		},
+	},
+}

--- a/pkg/smartcontract/manifest/standard/token.go
+++ b/pkg/smartcontract/manifest/standard/token.go
@@ -1,0 +1,30 @@
+package standard
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+)
+
+var decimalTokenBase = &Standard{
+	Manifest: manifest.Manifest{
+		ABI: manifest.ABI{
+			Methods: []manifest.Method{
+				{
+					Name:       "decimals",
+					ReturnType: smartcontract.IntegerType,
+					Safe:       true,
+				},
+				{
+					Name:       "symbol",
+					ReturnType: smartcontract.StringType,
+					Safe:       true,
+				},
+				{
+					Name:       "totalSupply",
+					ReturnType: smartcontract.IntegerType,
+					Safe:       true,
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
Close #1713 .

1. `name` method is missing  because it is provided in manifest.
2. Return type of `properties` method is `Map`, not string in JSON.