### PR TITLE
[2.x] RPC compatibility (and other) fixes and docs

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -46,11 +46,15 @@ which would yield the response:
 | `getclaimable` |
 | `getconnectioncount` |
 | `getcontractstate` |
+| `getminimumnetworkfee` |
 | `getnep5balances` |
 | `getnep5transfers` |
 | `getpeers` |
+| `getproof` |
 | `getrawmempool` |
 | `getrawtransaction` |
+| `getstateheight` |
+| `getstateroot` |
 | `getstorage` |
 | `gettransactionheight` |
 | `gettxout` |
@@ -65,8 +69,77 @@ which would yield the response:
 | `sendrawtransaction` |
 | `submitblock` |
 | `validateaddress` |
+| `verifyproof` |
 
 #### Implementation notices
+
+##### `getaccountstate`
+
+The order of assets in `balances` section may differ from the one returned by
+C# implementation. Assets can still be identified by their hashes so it
+shouldn't be an issue.
+
+##### `getapplicationlog`
+
+Error handling for incorrect stack items differs with C# implementation. C#
+implementation substitutes `stack` and `state` arrays with "error: recursive
+reference" string if there are any invalid items. NeoGo never does this, for
+bad `state` items it uses byte array susbstitute with message "bad
+notification: ..." (may vary depending on the problem), for incorrect `stack`
+items it just omits them (still returning valid ones).
+
+##### `getassetstate`
+
+It returns "NEO" for NEO and "NEOGas" for GAS in the `name` field instead of
+language-aware JSON structures.
+
+##### `getblock` and `getrawtransaction`
+
+In their verbose outputs neo-go can omit some fields with default values for
+transactions, this includes:
+ * zero "nonce" for Miner transactions (usually nonce is not zero)
+ * zero "gas" for Invocation transactions (most of the time it is zero).
+
+##### `getclaimable`
+
+`claimable` array ordering differs, neo-go orders entries there by the
+`end_height` field, while C# implementation orders by `txid`.
+
+##### `getcontractstate`
+
+C# implementation doesn't return `Payable` flag in its output, neo-go has
+`is_payable` field in `properties` for that.
+
+##### `getnep5transfers`
+
+`received` and `sent` entries are sorted differently, C# node uses
+chronological order and neo-go uses reverse chronological order (which is
+important for paging support, see Extensions section down below).
+
+##### `getrawmempool`
+
+neo-go doesn't support boolean parameter to `getrawmempool` for unverified
+transactions request because neo-go actually never stores unverified
+transactions in the mempool.
+
+##### `getunclaimed`
+
+Numeric results are wrapped into strings in neo-go (the same way fees are
+encoded) to prevent floating point rounding errors.
+
+##### `getunspents`
+
+neo-go uses standard "0xhash" syntax for `txid` and `asset_hash` fields
+whereas C# module doesn't add "0x" prefix. The order of `balance` or `unspent`
+entries can differ. neo-go returns all UTXO assets while C# module only tracks
+and returns NEO and GAS.
+
+##### `getutxotransfers`
+
+`transactions` are sorted differently, C# node uses chronological order and
+neo-go uses reverse chronological order (which is important for paging
+support, see Extensions section down below).
+
 
 ##### `invokefunction` and `invoke`
 

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -688,6 +688,7 @@ func (bc *Blockchain) storeBlock(block *block.Block) error {
 				Precision:  t.Precision,
 				Owner:      t.Owner,
 				Admin:      t.Admin,
+				Issuer:     t.Admin,
 				Expiration: bc.BlockHeight() + registeredAssetLifetime,
 			})
 			if err != nil {

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -32,7 +32,7 @@ import (
 // Tuning parameters.
 const (
 	headerBatchCount = 2000
-	version          = "0.0.9"
+	version          = "0.0.10"
 
 	// This one comes from C# code and it's different from the constant used
 	// when creating an asset with Neo.Asset.Create interop call. It looks

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -551,9 +551,9 @@ func (bc *Blockchain) processHeader(h *block.Header, batch storage.Batch, header
 	return nil
 }
 
-// bc.GetHeaderHash(int(endHeight)) returns sum of all system fees for blocks up to h.
+// GetSystemFeeAmount returns sum of all system fees for blocks up to h.
 // and 0 if no such block exists.
-func (bc *Blockchain) getSystemFeeAmount(h util.Uint256) uint32 {
+func (bc *Blockchain) GetSystemFeeAmount(h util.Uint256) uint32 {
 	_, sf, _ := bc.dao.GetBlock(h)
 	return sf
 }
@@ -582,7 +582,7 @@ func (bc *Blockchain) GetStateRoot(height uint32) (*state.MPTRootState, error) {
 func (bc *Blockchain) storeBlock(block *block.Block) error {
 	cache := dao.NewCached(bc.dao)
 	appExecResults := make([]*state.AppExecResult, 0, len(block.Transactions))
-	fee := bc.getSystemFeeAmount(block.PrevHash)
+	fee := bc.GetSystemFeeAmount(block.PrevHash)
 	for _, tx := range block.Transactions {
 		fee += uint32(bc.SystemFee(tx).IntegralValue())
 	}
@@ -1503,9 +1503,9 @@ func (bc *Blockchain) CalculateClaimable(value util.Fixed8, startHeight, endHeig
 		startHeight++
 	}
 	h := bc.GetHeaderHash(int(startHeight - 1))
-	feeStart := bc.getSystemFeeAmount(h)
+	feeStart := bc.GetSystemFeeAmount(h)
 	h = bc.GetHeaderHash(int(endHeight - 1))
-	feeEnd := bc.getSystemFeeAmount(h)
+	feeEnd := bc.GetSystemFeeAmount(h)
 
 	sysFeeTotal := util.Fixed8(feeEnd - feeStart)
 	ratio := value / 100000000

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2266,22 +2266,13 @@ func (bc *Blockchain) GetEnrollments() ([]*state.Validator, error) {
 	for _, validator := range validators {
 		if validator.Registered {
 			result = append(result, validator)
+			continue
 		}
-	}
-	for _, sBValidator := range uniqueSBValidators {
-		isAdded := false
-		for _, v := range result {
-			if v.PublicKey == sBValidator {
-				isAdded = true
+		for _, sbValidator := range uniqueSBValidators {
+			if validator.PublicKey.Equal(sbValidator) {
+				result = append(result, validator)
 				break
 			}
-		}
-		if !isAdded {
-			result = append(result, &state.Validator{
-				PublicKey:  sBValidator,
-				Registered: false,
-				Votes:      0,
-			})
 		}
 	}
 	return result, nil

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -945,8 +945,12 @@ func (bc *Blockchain) processNEP5Transfer(cache *dao.Cached, transfer *state.NEP
 		}
 		bs := balances.Trackers[transfer.Asset]
 		bs.Balance -= transfer.Amount
-		bs.LastUpdatedBlock = transfer.Block
-		balances.Trackers[transfer.Asset] = bs
+		if bs.Balance != 0 {
+			bs.LastUpdatedBlock = transfer.Block
+			balances.Trackers[transfer.Asset] = bs
+		} else {
+			delete(balances.Trackers, transfer.Asset)
+		}
 
 		transfer.Amount = -transfer.Amount
 		isBig, err := cache.AppendNEP5Transfer(transfer.From, balances.NextTransferBatch, transfer)

--- a/pkg/core/blockchainer.go
+++ b/pkg/core/blockchainer.go
@@ -44,6 +44,7 @@ type Blockchainer interface {
 	GetStateRoot(height uint32) (*state.MPTRootState, error)
 	GetStorageItem(scripthash util.Uint160, key []byte) *state.StorageItem
 	GetStorageItems(hash util.Uint160) (map[string]*state.StorageItem, error)
+	GetSystemFeeAmount(h util.Uint256) uint32
 	GetTestVM(tx *transaction.Transaction) *vm.VM
 	GetTransaction(util.Uint256) (*transaction.Transaction, uint32, error)
 	GetUnspentCoinState(util.Uint256) *state.UnspentCoin

--- a/pkg/core/state/nep5_test.go
+++ b/pkg/core/state/nep5_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"math/big"
 	"math/rand"
 	"testing"
 	"time"
@@ -41,7 +42,7 @@ func TestNEP5TransferLog_Append(t *testing.T) {
 
 func TestNEP5Tracker_EncodeBinary(t *testing.T) {
 	expected := &NEP5Tracker{
-		Balance:          int64(rand.Uint64()),
+		Balance:          big.NewInt(int64(rand.Uint64())),
 		LastUpdatedBlock: rand.Uint32(),
 	}
 
@@ -53,7 +54,7 @@ func TestNEP5Transfer_DecodeBinary(t *testing.T) {
 		Asset:     util.Uint160{1, 2, 3},
 		From:      util.Uint160{5, 6, 7},
 		To:        util.Uint160{8, 9, 10},
-		Amount:    42,
+		Amount:    big.NewInt(42),
 		Block:     12345,
 		Timestamp: 54321,
 		Tx:        util.Uint256{8, 5, 3},
@@ -70,7 +71,7 @@ func TestNEP5TransferSize(t *testing.T) {
 
 func randomTransfer(r *rand.Rand) *NEP5Transfer {
 	return &NEP5Transfer{
-		Amount: int64(r.Uint64()),
+		Amount: big.NewInt(int64(r.Uint64())),
 		Block:  r.Uint32(),
 		Asset:  random.Uint160(),
 		From:   random.Uint160(),

--- a/pkg/core/transaction/asset_type.go
+++ b/pkg/core/transaction/asset_type.go
@@ -1,5 +1,10 @@
 package transaction
 
+import (
+	"errors"
+	"fmt"
+)
+
 // AssetType represents a NEO asset type.
 type AssetType uint8
 
@@ -14,3 +19,68 @@ const (
 	Invoice        AssetType = DutyFlag | 0x18
 	Token          AssetType = CreditFlag | 0x20
 )
+
+// String implements Stringer interface.
+func (a AssetType) String() string {
+	switch a {
+	case CreditFlag:
+		return "CreditFlag"
+	case DutyFlag:
+		return "DutyFlag"
+	case GoverningToken:
+		return "GoverningToken"
+	case UtilityToken:
+		return "UtilityToken"
+	case Currency:
+		return "Currency"
+	case Share:
+		return "Share"
+	case Invoice:
+		return "Invoice"
+	case Token:
+		return "Token"
+	default:
+		return fmt.Sprintf("Unknonwn (%d)", a)
+
+	}
+}
+
+// MarshalJSON implements the json marshaller interface.
+func (a AssetType) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + a.String() + `"`), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (a *AssetType) UnmarshalJSON(data []byte) error {
+	l := len(data)
+	if l < 2 || data[0] != '"' || data[l-1] != '"' {
+		return errors.New("wrong format")
+	}
+	var err error
+	*a, err = AssetTypeFromString(string(data[1 : l-1]))
+	return err
+}
+
+// AssetTypeFromString converts string into AssetType.
+func AssetTypeFromString(s string) (AssetType, error) {
+	switch s {
+	case "CreditFlag":
+		return CreditFlag, nil
+	case "DutyFlag":
+		return DutyFlag, nil
+	case "GoverningToken":
+		return GoverningToken, nil
+	case "UtilityToken":
+		return UtilityToken, nil
+	case "Currency":
+		return Currency, nil
+	case "Share":
+		return Share, nil
+	case "Invoice":
+		return Invoice, nil
+	case "Token":
+		return Token, nil
+	default:
+		return 0, errors.New("bad asset type")
+	}
+}

--- a/pkg/core/transaction/publish.go
+++ b/pkg/core/transaction/publish.go
@@ -67,18 +67,18 @@ func (tx *PublishTX) EncodeBinary(bw *io.BinWriter) {
 // publishedContract is a JSON wrapper for PublishTransaction
 type publishedContract struct {
 	Code        publishedCode `json:"code"`
-	NeedStorage bool          `json:"needstorage,omitempty"`
-	Name        string        `json:"name,omitempty"`
-	CodeVersion string        `json:"version,omitempty"`
-	Author      string        `json:"author,omitempty"`
-	Email       string        `json:"email,omitempty"`
-	Description string        `json:"description,omitempty"`
+	NeedStorage bool          `json:"needstorage"`
+	Name        string        `json:"name"`
+	CodeVersion string        `json:"version"`
+	Author      string        `json:"author"`
+	Email       string        `json:"email"`
+	Description string        `json:"description"`
 }
 
 // publishedCode is a JSON wrapper for PublishTransaction Code
 type publishedCode struct {
-	Hash       util.Uint160              `json:"hash,omitempty"`
-	Script     string                    `json:"script,omitempty"`
-	ParamList  []smartcontract.ParamType `json:"parameters,omitempty"`
-	ReturnType smartcontract.ParamType   `json:"returntype,omitempty"`
+	Hash       util.Uint160              `json:"hash"`
+	Script     string                    `json:"script"`
+	ParamList  []smartcontract.ParamType `json:"parameters"`
+	ReturnType smartcontract.ParamType   `json:"returntype"`
 }

--- a/pkg/core/transaction/register.go
+++ b/pkg/core/transaction/register.go
@@ -56,10 +56,10 @@ func (tx *RegisterTX) EncodeBinary(bw *io.BinWriter) {
 
 // registeredAsset is a wrapper for RegisterTransaction
 type registeredAsset struct {
-	AssetType AssetType       `json:"type,omitempty"`
-	Name      json.RawMessage `json:"name,omitempty"`
-	Amount    util.Fixed8     `json:"amount,omitempty"`
-	Precision uint8           `json:"precision,omitempty"`
-	Owner     keys.PublicKey  `json:"owner,omitempty"`
-	Admin     string          `json:"admin,omitempty"`
+	AssetType AssetType       `json:"type"`
+	Name      json.RawMessage `json:"name"`
+	Amount    util.Fixed8     `json:"amount"`
+	Precision uint8           `json:"precision"`
+	Owner     keys.PublicKey  `json:"owner"`
+	Admin     string          `json:"admin"`
 }

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -123,6 +123,9 @@ func (chain testChain) GetStateRoot(height uint32) (*state.MPTRootState, error) 
 func (chain testChain) GetStorageItem(scripthash util.Uint160, key []byte) *state.StorageItem {
 	panic("TODO")
 }
+func (chain testChain) GetSystemFeeAmount(h util.Uint256) uint32 {
+	panic("TODO")
+}
 func (chain testChain) GetTestVM(tx *transaction.Transaction) *vm.VM {
 	panic("TODO")
 }

--- a/pkg/rpc/client/rpc_test.go
+++ b/pkg/rpc/client/rpc_test.go
@@ -178,7 +178,7 @@ var rpcClientTestCases = map[string][]rpcClientTestCase{
 			invoke: func(c *Client) (interface{}, error) {
 				return c.GetAssetState(util.Uint256{})
 			},
-			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{"id":"0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b","type":0,"name":"NEO","amount":"100000000","available":"100000000","precision":0,"owner":"00","admin":"Abf2qMs1pzQb8kYk9RuxtUb9jtRKJVuBJt","issuer":"AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM","expiration":4000000,"frozen":false}}`,
+			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{"id":"0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b","type":"GoverningToken","name":"NEO","amount":"100000000","available":"100000000","precision":0,"owner":"00","admin":"Abf2qMs1pzQb8kYk9RuxtUb9jtRKJVuBJt","issuer":"AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM","expiration":4000000,"frozen":false}}`,
 			result: func(c *Client) interface{} {
 				return &result.AssetState{
 					ID:         core.GoverningTokenID(),

--- a/pkg/rpc/client/rpc_test.go
+++ b/pkg/rpc/client/rpc_test.go
@@ -178,7 +178,7 @@ var rpcClientTestCases = map[string][]rpcClientTestCase{
 			invoke: func(c *Client) (interface{}, error) {
 				return c.GetAssetState(util.Uint256{})
 			},
-			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{"id":"0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b","type":0,"name":"NEO","amount":"100000000","available":"100000000","precision":0,"owner":"00","admin":"Abf2qMs1pzQb8kYk9RuxtUb9jtRKJVuBJt","issuer":"AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM","expiration":4000000,"is_frozen":false}}`,
+			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{"id":"0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b","type":0,"name":"NEO","amount":"100000000","available":"100000000","precision":0,"owner":"00","admin":"Abf2qMs1pzQb8kYk9RuxtUb9jtRKJVuBJt","issuer":"AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM","expiration":4000000,"frozen":false}}`,
 			result: func(c *Client) interface{} {
 				return &result.AssetState{
 					ID:         core.GoverningTokenID(),

--- a/pkg/rpc/client/rpc_test.go
+++ b/pkg/rpc/client/rpc_test.go
@@ -517,25 +517,25 @@ var rpcClientTestCases = map[string][]rpcClientTestCase{
 			invoke: func(c *Client) (interface{}, error) {
 				return c.GetPeers()
 			},
-			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{"unconnected":[{"address":"172.200.0.1","port":"20333"}],"connected":[{"address":"127.0.0.1","port":"20335"}],"bad":[{"address":"172.200.0.254","port":"20332"}]}}`,
+			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{"unconnected":[{"address":"172.200.0.1","port":20333}],"connected":[{"address":"127.0.0.1","port":20335}],"bad":[{"address":"172.200.0.254","port":20332}]}}`,
 			result: func(c *Client) interface{} {
 				return &result.GetPeers{
 					Unconnected: result.Peers{
 						{
 							Address: "172.200.0.1",
-							Port:    "20333",
+							Port:    20333,
 						},
 					},
 					Connected: result.Peers{
 						{
 							Address: "127.0.0.1",
-							Port:    "20335",
+							Port:    20335,
 						},
 					},
 					Bad: result.Peers{
 						{
 							Address: "172.200.0.254",
-							Port:    "20332",
+							Port:    20332,
 						},
 					},
 				}

--- a/pkg/rpc/response/result/asset_state.go
+++ b/pkg/rpc/response/result/asset_state.go
@@ -20,7 +20,7 @@ type AssetState struct {
 	Admin      string                `json:"admin"`
 	Issuer     string                `json:"issuer"`
 	Expiration uint32                `json:"expiration"`
-	IsFrozen   bool                  `json:"is_frozen"`
+	IsFrozen   bool                  `json:"frozen"`
 }
 
 // NewAssetState creates a new Asset wrapper.

--- a/pkg/rpc/response/result/block.go
+++ b/pkg/rpc/response/result/block.go
@@ -48,7 +48,7 @@ func NewBlock(b *block.Block, chain core.Blockchainer) Block {
 		Base: &b.Base,
 		BlockMetadataAndTx: BlockMetadataAndTx{
 			Size:          io.GetVarSize(b),
-			Confirmations: chain.BlockHeight() - b.Index - 1,
+			Confirmations: chain.BlockHeight() - b.Index + 1,
 			Tx:            make([]Tx, 0, len(b.Transactions)),
 		},
 	}

--- a/pkg/rpc/response/result/peers.go
+++ b/pkg/rpc/response/result/peers.go
@@ -1,6 +1,7 @@
 package result
 
 import (
+	"strconv"
 	"strings"
 )
 
@@ -18,7 +19,7 @@ type (
 	// Peer represents the peer.
 	Peer struct {
 		Address string `json:"address"`
-		Port    string `json:"port"`
+		Port    uint16 `json:"port"`
 	}
 )
 
@@ -50,9 +51,10 @@ func (g *GetPeers) AddBad(addrs []string) {
 func (p *Peers) addPeers(addrs []string) {
 	for i := range addrs {
 		addressParts := strings.Split(addrs[i], ":")
+		port, _ := strconv.Atoi(addressParts[1]) // We know it's a good port number.
 		peer := Peer{
 			Address: addressParts[0],
-			Port:    addressParts[1],
+			Port:    uint16(port),
 		}
 
 		*p = append(*p, peer)

--- a/pkg/rpc/response/result/peers_test.go
+++ b/pkg/rpc/response/result/peers_test.go
@@ -20,7 +20,7 @@ func TestGetPeers(t *testing.T) {
 	require.Equal(t, 1, len(gp.Connected))
 	require.Equal(t, 1, len(gp.Bad))
 	require.Equal(t, "192.168.0.1", gp.Connected[0].Address)
-	require.Equal(t, "10333", gp.Connected[0].Port)
+	require.Equal(t, uint16(10333), gp.Connected[0].Port)
 	require.Equal(t, "127.0.0.1", gp.Bad[0].Address)
-	require.Equal(t, "20333", gp.Bad[0].Port)
+	require.Equal(t, uint16(20333), gp.Bad[0].Port)
 }

--- a/pkg/rpc/response/result/tx_output.go
+++ b/pkg/rpc/response/result/tx_output.go
@@ -20,7 +20,7 @@ func NewTxOutput(out *transaction.Output) *TransactionOutput {
 
 	return &TransactionOutput{
 		N:       out.Position,
-		Asset:   "0x" + out.AssetID.String(),
+		Asset:   "0x" + out.AssetID.StringLE(),
 		Value:   out.Amount,
 		Address: addr,
 	}

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -1356,17 +1356,8 @@ func (s *Server) getBlockSysFee(reqParams request.Params) (interface{}, *respons
 	}
 
 	headerHash := s.chain.GetHeaderHash(num)
-	block, errBlock := s.chain.GetBlock(headerHash)
-	if errBlock != nil {
-		return 0, response.NewRPCError(errBlock.Error(), "", nil)
-	}
 
-	var blockSysFee util.Fixed8
-	for _, tx := range block.Transactions {
-		blockSysFee += s.chain.SystemFee(tx)
-	}
-
-	return blockSysFee, nil
+	return util.Fixed8FromInt64(int64(s.chain.GetSystemFeeAmount(headerHash))), nil
 }
 
 // getBlockHeader returns the corresponding block header information according to the specified script hash.

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -461,7 +461,7 @@ func (s *Server) getBlockHash(reqParams request.Params) (interface{}, *response.
 	}
 	num, err := s.blockHeightFromParam(param)
 	if err != nil {
-		return nil, response.ErrInvalidParams
+		return nil, err
 	}
 
 	return s.chain.GetHeaderHash(num), nil

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -1371,9 +1371,9 @@ func (s *Server) getBlockSysFee(reqParams request.Params) (interface{}, *respons
 
 // getBlockHeader returns the corresponding block header information according to the specified script hash.
 func (s *Server) getBlockHeader(reqParams request.Params) (interface{}, *response.Error) {
-	hash, err := reqParams.ValueWithType(0, request.StringT).GetUint256()
-	if err != nil {
-		return nil, response.ErrInvalidParams
+	hash, respErr := s.getBlockHashFromParam(reqParams.Value(0))
+	if respErr != nil {
+		return nil, respErr
 	}
 
 	verbose := reqParams.Value(1).GetBoolean()

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -723,12 +723,12 @@ var rpcTestCases = map[string][]rpcTestCase{
 			},
 			check: func(t *testing.T, e *executor, validators interface{}) {
 				var expected []result.Validator
-				sBValidators, err := e.chain.GetStandByValidators()
+				enrolls, err := e.chain.GetEnrollments()
 				require.NoError(t, err)
-				for _, sbValidator := range sBValidators {
+				for _, validator := range enrolls {
 					expected = append(expected, result.Validator{
-						PublicKey: *sbValidator,
-						Votes:     0,
+						PublicKey: *validator.PublicKey,
+						Votes:     validator.Votes,
 						Active:    true,
 					})
 				}

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -1213,7 +1213,7 @@ func testRPCProtocol(t *testing.T, doRPCCall func(string, string, *testing.T) []
 		err := json.Unmarshal(res, &txOut)
 		require.NoErrorf(t, err, "could not parse response: %s", res)
 		assert.Equal(t, 1, txOut.N)
-		assert.Equal(t, "0x9b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc5", txOut.Asset)
+		assert.Equal(t, "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b", txOut.Asset)
 		assert.Equal(t, util.Fixed8FromInt64(1000), txOut.Value)
 		assert.Equal(t, "AZ81H31DMWzbSnFDLFkzh9vHwaDLayV7fU", txOut.Address)
 	})

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -548,13 +548,9 @@ var rpcTestCases = map[string][]rpcTestCase{
 			name:   "positive",
 			params: "[1]",
 			result: func(e *executor) interface{} {
-				block, _ := e.chain.GetBlock(e.chain.GetHeaderHash(1))
-
-				var expectedBlockSysFee util.Fixed8
-				for _, tx := range block.Transactions {
-					expectedBlockSysFee += e.chain.SystemFee(tx)
-				}
-				return &expectedBlockSysFee
+				sf := e.chain.GetSystemFeeAmount(e.chain.GetHeaderHash(1))
+				r := util.Fixed8FromInt64(int64(sf))
+				return &r
 			},
 		},
 		{


### PR DESCRIPTION
### Problem

RPC audit.

### Solution

Lots of minor problems were found and fixed, but two problems stand out: system fee calculations (that affect available GAS estimations) and NEP5 balance switch from int64 to big.Int (because there are tokens that easily overflow int64).