### PR TITLE
rpc: detalize `submit*` RPC validation error

### DIFF
--- a/pkg/rpc/response/errors.go
+++ b/pkg/rpc/response/errors.go
@@ -93,3 +93,9 @@ func NewSubmitError(code int64, message string) *Error {
 func (e *Error) Error() string {
 	return fmt.Sprintf("%s (%d) - %s - %s", e.Message, e.Code, e.Data, e.Cause)
 }
+
+// WrapErrorWithData returns copy of the given error with specified data and cause.
+// It does not modify the source error.
+func WrapErrorWithData(e *Error, data error) *Error {
+	return NewError(e.Code, e.HTTPCode, e.Message, data.Error(), data)
+}

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -1235,9 +1235,9 @@ func (s *Server) submitBlock(reqParams request.Params) (interface{}, *response.E
 	if err != nil {
 		switch {
 		case errors.Is(err, core.ErrInvalidBlockIndex) || errors.Is(err, core.ErrAlreadyExists):
-			return nil, response.ErrAlreadyExists
+			return nil, response.WrapErrorWithData(response.ErrAlreadyExists, err)
 		default:
-			return nil, response.ErrValidationFailed
+			return nil, response.WrapErrorWithData(response.ErrValidationFailed, err)
 		}
 	}
 	return &result.RelayResult{
@@ -1273,13 +1273,13 @@ func getRelayResult(err error, hash util.Uint256) (interface{}, *response.Error)
 			Hash: hash,
 		}, nil
 	case errors.Is(err, core.ErrAlreadyExists):
-		return nil, response.ErrAlreadyExists
+		return nil, response.WrapErrorWithData(response.ErrAlreadyExists, err)
 	case errors.Is(err, core.ErrOOM):
-		return nil, response.ErrOutOfMemory
+		return nil, response.WrapErrorWithData(response.ErrOutOfMemory, err)
 	case errors.Is(err, core.ErrPolicy):
-		return nil, response.ErrPolicyFail
+		return nil, response.WrapErrorWithData(response.ErrPolicyFail, err)
 	default:
-		return nil, response.ErrValidationFailed
+		return nil, response.WrapErrorWithData(response.ErrValidationFailed, err)
 	}
 }
 


### PR DESCRIPTION
These changes do not break the compatibility with the C# node response.

It is useful for the end-user to be aware of the failed validation reason.
Also, the `cause` will be displayed at the running node log.