### PR TITLE
core: fix native method call flags

### DIFF
--- a/cli/wallet/validator.go
+++ b/cli/wallet/validator.go
@@ -106,7 +106,7 @@ func handleCandidate(ctx *cli.Context, method string, sysGas int64) error {
 		return err
 	}
 	w := io.NewBufBinWriter()
-	emit.AppCall(w.BinWriter, neoContractHash, method, callflag.WriteStates, acc.PrivateKey().PublicKey().Bytes())
+	emit.AppCall(w.BinWriter, neoContractHash, method, callflag.States, acc.PrivateKey().PublicKey().Bytes())
 	emit.Opcodes(w.BinWriter, opcode.ASSERT)
 	tx, err := c.CreateTxFromScript(w.Bytes(), acc, sysGas, int64(gas), transaction.Signer{
 		Account: acc.Contract.ScriptHash(),
@@ -168,7 +168,7 @@ func handleVote(ctx *cli.Context) error {
 		return cli.NewExitError(err, 1)
 	}
 	w := io.NewBufBinWriter()
-	emit.AppCall(w.BinWriter, neoContractHash, "vote", callflag.WriteStates, addr.BytesBE(), pubArg)
+	emit.AppCall(w.BinWriter, neoContractHash, "vote", callflag.States, addr.BytesBE(), pubArg)
 	emit.Opcodes(w.BinWriter, opcode.ASSERT)
 
 	tx, err := c.CreateTxFromScript(w.Bytes(), acc, -1, int64(gas), transaction.Signer{

--- a/pkg/compiler/interop_test.go
+++ b/pkg/compiler/interop_test.go
@@ -197,7 +197,7 @@ func TestAppCall(t *testing.T) {
 	})
 
 	t.Run("callEx, valid", func(t *testing.T) {
-		src := getCallExScript(fmt.Sprintf("%#v", ih.BytesBE()), "contract.AllowCall")
+		src := getCallExScript(fmt.Sprintf("%#v", ih.BytesBE()), "contract.ReadStates|contract.AllowCall")
 		v := spawnVM(t, ic, src)
 		require.NoError(t, v.Run())
 

--- a/pkg/compiler/native_test.go
+++ b/pkg/compiler/native_test.go
@@ -260,11 +260,7 @@ func testContractCall(t *testing.T, hash util.Uint160, md interop.MethodAndPrice
 		require.Equal(t, md.MD.Name, method)
 
 		fs := callflag.CallFlag(int32(v.Estack().Pop().BigInt().Int64()))
-		extended := md.RequiredFlags // In some (all?) cases it's desirable to have Read permissions where Write is also allowed.
-		if md.RequiredFlags&callflag.WriteStates != 0 {
-			extended |= callflag.ReadStates
-		}
-		require.True(t, fs == md.RequiredFlags || fs == extended)
+		require.Equal(t, fs, md.RequiredFlags)
 
 		args := v.Estack().Pop().Array()
 		require.Equal(t, len(md.MD.Parameters), len(args))

--- a/pkg/core/interop/contract/call.go
+++ b/pkg/core/interop/contract/call.go
@@ -19,6 +19,9 @@ import (
 func LoadToken(ic *interop.Context) func(id int32) error {
 	return func(id int32) error {
 		ctx := ic.VM.Context()
+		if !ctx.GetCallFlags().Has(callflag.ReadStates | callflag.AllowCall) {
+			return errors.New("invalid call flags")
+		}
 		tok := ctx.NEF.Tokens[id]
 		if int(tok.ParamCount) > ctx.Estack().Len() {
 			return errors.New("stack is too small")

--- a/pkg/core/interops.go
+++ b/pkg/core/interops.go
@@ -41,7 +41,7 @@ var systemInterops = []interop.Function{
 	{Name: interopnames.SystemBinaryItoa, Func: binary.Itoa, Price: 1 << 12, ParamCount: 2},
 	{Name: interopnames.SystemBinarySerialize, Func: binary.Serialize, Price: 1 << 12, ParamCount: 1},
 	{Name: interopnames.SystemContractCall, Func: contract.Call, Price: 1 << 15,
-		RequiredFlags: callflag.AllowCall, ParamCount: 4},
+		RequiredFlags: callflag.ReadStates | callflag.AllowCall, ParamCount: 4},
 	{Name: interopnames.SystemContractCallNative, Func: native.Call, Price: 0, ParamCount: 1},
 	{Name: interopnames.SystemContractCreateMultisigAccount, Func: contractCreateMultisigAccount, Price: 1 << 8, ParamCount: 1},
 	{Name: interopnames.SystemContractCreateStandardAccount, Func: contractCreateStandardAccount, Price: 1 << 8, ParamCount: 1},

--- a/pkg/core/native/designate.go
+++ b/pkg/core/native/designate.go
@@ -91,7 +91,7 @@ func newDesignate(p2pSigExtensionsEnabled bool) *Designate {
 	desc = newDescriptor("designateAsRole", smartcontract.VoidType,
 		manifest.NewParameter("role", smartcontract.IntegerType),
 		manifest.NewParameter("nodes", smartcontract.ArrayType))
-	md = newMethodAndPrice(s.designateAsRole, 0, callflag.WriteStates)
+	md = newMethodAndPrice(s.designateAsRole, 0, callflag.States)
 	s.AddMethod(md, desc)
 
 	return s

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -74,31 +74,31 @@ func newManagement() *Management {
 	desc = newDescriptor("deploy", smartcontract.ArrayType,
 		manifest.NewParameter("nefFile", smartcontract.ByteArrayType),
 		manifest.NewParameter("manifest", smartcontract.ByteArrayType))
-	md = newMethodAndPrice(m.deploy, 0, callflag.WriteStates|callflag.AllowNotify)
+	md = newMethodAndPrice(m.deploy, 0, callflag.States|callflag.AllowNotify)
 	m.AddMethod(md, desc)
 
 	desc = newDescriptor("deploy", smartcontract.ArrayType,
 		manifest.NewParameter("nefFile", smartcontract.ByteArrayType),
 		manifest.NewParameter("manifest", smartcontract.ByteArrayType),
 		manifest.NewParameter("data", smartcontract.AnyType))
-	md = newMethodAndPrice(m.deployWithData, 0, callflag.WriteStates|callflag.AllowNotify)
+	md = newMethodAndPrice(m.deployWithData, 0, callflag.States|callflag.AllowNotify)
 	m.AddMethod(md, desc)
 
 	desc = newDescriptor("update", smartcontract.VoidType,
 		manifest.NewParameter("nefFile", smartcontract.ByteArrayType),
 		manifest.NewParameter("manifest", smartcontract.ByteArrayType))
-	md = newMethodAndPrice(m.update, 0, callflag.WriteStates|callflag.AllowNotify)
+	md = newMethodAndPrice(m.update, 0, callflag.States|callflag.AllowNotify)
 	m.AddMethod(md, desc)
 
 	desc = newDescriptor("update", smartcontract.VoidType,
 		manifest.NewParameter("nefFile", smartcontract.ByteArrayType),
 		manifest.NewParameter("manifest", smartcontract.ByteArrayType),
 		manifest.NewParameter("data", smartcontract.AnyType))
-	md = newMethodAndPrice(m.updateWithData, 0, callflag.WriteStates|callflag.AllowNotify)
+	md = newMethodAndPrice(m.updateWithData, 0, callflag.States|callflag.AllowNotify)
 	m.AddMethod(md, desc)
 
 	desc = newDescriptor("destroy", smartcontract.VoidType)
-	md = newMethodAndPrice(m.destroy, 1000000, callflag.WriteStates|callflag.AllowNotify)
+	md = newMethodAndPrice(m.destroy, 1000000, callflag.States|callflag.AllowNotify)
 	m.AddMethod(md, desc)
 
 	desc = newDescriptor("getMinimumDeploymentFee", smartcontract.IntegerType)
@@ -107,7 +107,7 @@ func newManagement() *Management {
 
 	desc = newDescriptor("setMinimumDeploymentFee", smartcontract.VoidType,
 		manifest.NewParameter("value", smartcontract.IntegerType))
-	md = newMethodAndPrice(m.setMinimumDeploymentFee, 300_0000, callflag.WriteStates)
+	md = newMethodAndPrice(m.setMinimumDeploymentFee, 300_0000, callflag.States)
 	m.AddMethod(md, desc)
 
 	hashParam := manifest.NewParameter("Hash", smartcontract.Hash160Type)

--- a/pkg/core/native/name_service.go
+++ b/pkg/core/native/name_service.go
@@ -103,12 +103,12 @@ func newNameService() *NameService {
 
 	desc := newDescriptor("addRoot", smartcontract.VoidType,
 		manifest.NewParameter("root", smartcontract.StringType))
-	md := newMethodAndPrice(n.addRoot, 3000000, callflag.WriteStates)
+	md := newMethodAndPrice(n.addRoot, 3000000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("setPrice", smartcontract.VoidType,
 		manifest.NewParameter("price", smartcontract.IntegerType))
-	md = newMethodAndPrice(n.setPrice, 3000000, callflag.WriteStates)
+	md = newMethodAndPrice(n.setPrice, 3000000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("getPrice", smartcontract.IntegerType)
@@ -123,25 +123,25 @@ func newNameService() *NameService {
 	desc = newDescriptor("register", smartcontract.BoolType,
 		manifest.NewParameter("name", smartcontract.StringType),
 		manifest.NewParameter("owner", smartcontract.Hash160Type))
-	md = newMethodAndPrice(n.register, 1000000, callflag.WriteStates)
+	md = newMethodAndPrice(n.register, 1000000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("renew", smartcontract.IntegerType,
 		manifest.NewParameter("name", smartcontract.StringType))
-	md = newMethodAndPrice(n.renew, 0, callflag.WriteStates)
+	md = newMethodAndPrice(n.renew, 0, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("setAdmin", smartcontract.VoidType,
 		manifest.NewParameter("name", smartcontract.StringType),
 		manifest.NewParameter("admin", smartcontract.Hash160Type))
-	md = newMethodAndPrice(n.setAdmin, 3000000, callflag.WriteStates)
+	md = newMethodAndPrice(n.setAdmin, 3000000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("setRecord", smartcontract.VoidType,
 		manifest.NewParameter("name", smartcontract.StringType),
 		manifest.NewParameter("type", smartcontract.IntegerType),
 		manifest.NewParameter("data", smartcontract.StringType))
-	md = newMethodAndPrice(n.setRecord, 30000000, callflag.WriteStates)
+	md = newMethodAndPrice(n.setRecord, 30000000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("getRecord", smartcontract.StringType,
@@ -153,7 +153,7 @@ func newNameService() *NameService {
 	desc = newDescriptor("deleteRecord", smartcontract.VoidType,
 		manifest.NewParameter("name", smartcontract.StringType),
 		manifest.NewParameter("type", smartcontract.IntegerType))
-	md = newMethodAndPrice(n.deleteRecord, 1000000, callflag.WriteStates)
+	md = newMethodAndPrice(n.deleteRecord, 1000000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("resolve", smartcontract.StringType,

--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -115,18 +115,18 @@ func newNEO() *NEO {
 
 	desc = newDescriptor("registerCandidate", smartcontract.BoolType,
 		manifest.NewParameter("pubkey", smartcontract.ByteArrayType))
-	md = newMethodAndPrice(n.registerCandidate, 1000_00000000, callflag.WriteStates)
+	md = newMethodAndPrice(n.registerCandidate, 1000_00000000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("unregisterCandidate", smartcontract.BoolType,
 		manifest.NewParameter("pubkey", smartcontract.ByteArrayType))
-	md = newMethodAndPrice(n.unregisterCandidate, 5000000, callflag.WriteStates)
+	md = newMethodAndPrice(n.unregisterCandidate, 5000000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("vote", smartcontract.BoolType,
 		manifest.NewParameter("account", smartcontract.Hash160Type),
 		manifest.NewParameter("voteTo", smartcontract.ByteArrayType))
-	md = newMethodAndPrice(n.vote, 5000000, callflag.WriteStates)
+	md = newMethodAndPrice(n.vote, 5000000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("getCandidates", smartcontract.ArrayType)
@@ -147,7 +147,7 @@ func newNEO() *NEO {
 
 	desc = newDescriptor("setGasPerBlock", smartcontract.VoidType,
 		manifest.NewParameter("gasPerBlock", smartcontract.IntegerType))
-	md = newMethodAndPrice(n.setGASPerBlock, 500_0000, callflag.WriteStates)
+	md = newMethodAndPrice(n.setGASPerBlock, 500_0000, callflag.States)
 	n.AddMethod(md, desc)
 
 	return n

--- a/pkg/core/native/native_nep17.go
+++ b/pkg/core/native/native_nep17.go
@@ -71,7 +71,7 @@ func newNEP17Native(name string, id int32) *nep17TokenNative {
 	desc = newDescriptor("transfer", smartcontract.BoolType,
 		append(transferParams, manifest.NewParameter("data", smartcontract.AnyType))...,
 	)
-	md = newMethodAndPrice(n.Transfer, 9000000, callflag.WriteStates|callflag.AllowCall|callflag.AllowNotify)
+	md = newMethodAndPrice(n.Transfer, 9000000, callflag.States|callflag.AllowCall|callflag.AllowNotify)
 	n.AddMethod(md, desc)
 
 	n.AddEvent("Transfer", transferParams...)

--- a/pkg/core/native/nonfungible.go
+++ b/pkg/core/native/nonfungible.go
@@ -107,7 +107,7 @@ func newNonFungible(name string, id int32, symbol string, decimals byte) *nonfun
 	desc = newDescriptor("transfer", smartcontract.BoolType,
 		manifest.NewParameter("to", smartcontract.Hash160Type),
 		manifest.NewParameter("tokenId", smartcontract.ByteArrayType))
-	md = newMethodAndPrice(n.transfer, 9000000, callflag.WriteStates|callflag.AllowNotify)
+	md = newMethodAndPrice(n.transfer, 9000000, callflag.States|callflag.AllowNotify)
 	n.AddMethod(md, desc)
 
 	n.AddEvent("Transfer",

--- a/pkg/core/native/notary.go
+++ b/pkg/core/native/notary.go
@@ -59,19 +59,19 @@ func newNotary() *Notary {
 		manifest.NewParameter("from", smartcontract.Hash160Type),
 		manifest.NewParameter("amount", smartcontract.IntegerType),
 		manifest.NewParameter("data", smartcontract.AnyType))
-	md := newMethodAndPrice(n.onPayment, 100_0000, callflag.WriteStates)
+	md := newMethodAndPrice(n.onPayment, 100_0000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("lockDepositUntil", smartcontract.BoolType,
 		manifest.NewParameter("address", smartcontract.Hash160Type),
 		manifest.NewParameter("till", smartcontract.IntegerType))
-	md = newMethodAndPrice(n.lockDepositUntil, 100_0000, callflag.WriteStates)
+	md = newMethodAndPrice(n.lockDepositUntil, 100_0000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("withdraw", smartcontract.BoolType,
 		manifest.NewParameter("from", smartcontract.Hash160Type),
 		manifest.NewParameter("to", smartcontract.Hash160Type))
-	md = newMethodAndPrice(n.withdraw, 100_0000, callflag.WriteStates)
+	md = newMethodAndPrice(n.withdraw, 100_0000, callflag.States)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("balanceOf", smartcontract.IntegerType,
@@ -95,7 +95,7 @@ func newNotary() *Notary {
 
 	desc = newDescriptor("setMaxNotValidBeforeDelta", smartcontract.VoidType,
 		manifest.NewParameter("value", smartcontract.IntegerType))
-	md = newMethodAndPrice(n.setMaxNotValidBeforeDelta, 300_0000, callflag.WriteStates)
+	md = newMethodAndPrice(n.setMaxNotValidBeforeDelta, 300_0000, callflag.States)
 	n.AddMethod(md, desc)
 
 	return n

--- a/pkg/core/native/oracle.go
+++ b/pkg/core/native/oracle.go
@@ -90,11 +90,11 @@ func newOracle() *Oracle {
 		manifest.NewParameter("callback", smartcontract.StringType),
 		manifest.NewParameter("userData", smartcontract.AnyType),
 		manifest.NewParameter("gasForResponse", smartcontract.IntegerType))
-	md := newMethodAndPrice(o.request, oracleRequestPrice, callflag.WriteStates|callflag.AllowNotify)
+	md := newMethodAndPrice(o.request, oracleRequestPrice, callflag.States|callflag.AllowNotify)
 	o.AddMethod(md, desc)
 
 	desc = newDescriptor("finish", smartcontract.VoidType)
-	md = newMethodAndPrice(o.finish, 0, callflag.WriteStates|callflag.AllowCall|callflag.AllowNotify)
+	md = newMethodAndPrice(o.finish, 0, callflag.States|callflag.AllowCall|callflag.AllowNotify)
 	o.AddMethod(md, desc)
 
 	desc = newDescriptor("verify", smartcontract.BoolType)

--- a/pkg/core/native/policy.go
+++ b/pkg/core/native/policy.go
@@ -114,7 +114,7 @@ func newPolicy() *Policy {
 
 	desc = newDescriptor("setExecFeeFactor", smartcontract.VoidType,
 		manifest.NewParameter("value", smartcontract.IntegerType))
-	md = newMethodAndPrice(p.setExecFeeFactor, 3000000, callflag.WriteStates)
+	md = newMethodAndPrice(p.setExecFeeFactor, 3000000, callflag.States)
 	p.AddMethod(md, desc)
 
 	desc = newDescriptor("getStoragePrice", smartcontract.IntegerType)
@@ -123,37 +123,37 @@ func newPolicy() *Policy {
 
 	desc = newDescriptor("setStoragePrice", smartcontract.VoidType,
 		manifest.NewParameter("value", smartcontract.IntegerType))
-	md = newMethodAndPrice(p.setStoragePrice, 3000000, callflag.WriteStates)
+	md = newMethodAndPrice(p.setStoragePrice, 3000000, callflag.States)
 	p.AddMethod(md, desc)
 
 	desc = newDescriptor("setMaxBlockSize", smartcontract.VoidType,
 		manifest.NewParameter("value", smartcontract.IntegerType))
-	md = newMethodAndPrice(p.setMaxBlockSize, 3000000, callflag.WriteStates)
+	md = newMethodAndPrice(p.setMaxBlockSize, 3000000, callflag.States)
 	p.AddMethod(md, desc)
 
 	desc = newDescriptor("setMaxTransactionsPerBlock", smartcontract.VoidType,
 		manifest.NewParameter("value", smartcontract.IntegerType))
-	md = newMethodAndPrice(p.setMaxTransactionsPerBlock, 3000000, callflag.WriteStates)
+	md = newMethodAndPrice(p.setMaxTransactionsPerBlock, 3000000, callflag.States)
 	p.AddMethod(md, desc)
 
 	desc = newDescriptor("setFeePerByte", smartcontract.VoidType,
 		manifest.NewParameter("value", smartcontract.IntegerType))
-	md = newMethodAndPrice(p.setFeePerByte, 3000000, callflag.WriteStates)
+	md = newMethodAndPrice(p.setFeePerByte, 3000000, callflag.States)
 	p.AddMethod(md, desc)
 
 	desc = newDescriptor("setMaxBlockSystemFee", smartcontract.VoidType,
 		manifest.NewParameter("value", smartcontract.IntegerType))
-	md = newMethodAndPrice(p.setMaxBlockSystemFee, 3000000, callflag.WriteStates)
+	md = newMethodAndPrice(p.setMaxBlockSystemFee, 3000000, callflag.States)
 	p.AddMethod(md, desc)
 
 	desc = newDescriptor("blockAccount", smartcontract.BoolType,
 		manifest.NewParameter("account", smartcontract.Hash160Type))
-	md = newMethodAndPrice(p.blockAccount, 3000000, callflag.WriteStates)
+	md = newMethodAndPrice(p.blockAccount, 3000000, callflag.States)
 	p.AddMethod(md, desc)
 
 	desc = newDescriptor("unblockAccount", smartcontract.BoolType,
 		manifest.NewParameter("account", smartcontract.Hash160Type))
-	md = newMethodAndPrice(p.unblockAccount, 3000000, callflag.WriteStates)
+	md = newMethodAndPrice(p.unblockAccount, 3000000, callflag.States)
 	p.AddMethod(md, desc)
 
 	return p

--- a/pkg/interop/native/management/management.go
+++ b/pkg/interop/native/management/management.go
@@ -11,18 +11,18 @@ const Hash = "\x43\x0e\x9f\x6f\xb3\x13\xa8\xd3\xa2\xb7\x61\x3b\x67\x83\x09\xd1\x
 // Deploy represents `deploy` method of Management native contract.
 func Deploy(script, manifest []byte) *Contract {
 	return contract.Call(interop.Hash160(Hash), "deploy",
-		contract.WriteStates|contract.AllowNotify, script, manifest).(*Contract)
+		contract.States|contract.AllowNotify, script, manifest).(*Contract)
 }
 
 // DeployWithData represents `deploy` method of Management native contract.
 func DeployWithData(script, manifest []byte, data interface{}) *Contract {
 	return contract.Call(interop.Hash160(Hash), "deploy",
-		contract.WriteStates|contract.AllowNotify, script, manifest, data).(*Contract)
+		contract.States|contract.AllowNotify, script, manifest, data).(*Contract)
 }
 
 // Destroy represents `destroy` method of Management native contract.
 func Destroy() {
-	contract.Call(interop.Hash160(Hash), "destroy", contract.WriteStates|contract.AllowNotify)
+	contract.Call(interop.Hash160(Hash), "destroy", contract.States|contract.AllowNotify)
 }
 
 // GetContract represents `getContract` method of Management native contract.
@@ -37,17 +37,17 @@ func GetMinimumDeploymentFee() int {
 
 // SetMinimumDeploymentFee represents `setMinimumDeploymentFee` method of Management native contract.
 func SetMinimumDeploymentFee(value int) {
-	contract.Call(interop.Hash160(Hash), "setMinimumDeploymentFee", contract.WriteStates, value)
+	contract.Call(interop.Hash160(Hash), "setMinimumDeploymentFee", contract.States, value)
 }
 
 // Update represents `update` method of Management native contract.
 func Update(script, manifest []byte) {
 	contract.Call(interop.Hash160(Hash), "update",
-		contract.WriteStates|contract.AllowNotify, script, manifest)
+		contract.States|contract.AllowNotify, script, manifest)
 }
 
 // UpdateWithData represents `update` method of Management native contract.
 func UpdateWithData(script, manifest []byte, data interface{}) {
 	contract.Call(interop.Hash160(Hash), "update",
-		contract.WriteStates|contract.AllowNotify, script, manifest, data)
+		contract.States|contract.AllowNotify, script, manifest, data)
 }

--- a/pkg/interop/native/nameservice/name_service.go
+++ b/pkg/interop/native/nameservice/name_service.go
@@ -65,17 +65,17 @@ func TokensOf(addr interop.Hash160) iterator.Iterator {
 // Transfer represents `transfer` method of NameService native contract.
 func Transfer(to interop.Hash160, tokenID string) bool {
 	return contract.Call(interop.Hash160(Hash), "transfer",
-		contract.ReadStates|contract.WriteStates|contract.AllowNotify, to, tokenID).(bool)
+		contract.ReadStates|contract.States|contract.AllowNotify, to, tokenID).(bool)
 }
 
 // AddRoot represents `addRoot` method of NameService native contract.
 func AddRoot(root string) {
-	contract.Call(interop.Hash160(Hash), "addRoot", contract.WriteStates, root)
+	contract.Call(interop.Hash160(Hash), "addRoot", contract.States, root)
 }
 
 // SetPrice represents `setPrice` method of NameService native contract.
 func SetPrice(price int) {
-	contract.Call(interop.Hash160(Hash), "setPrice", contract.WriteStates, price)
+	contract.Call(interop.Hash160(Hash), "setPrice", contract.States, price)
 }
 
 // GetPrice represents `getPrice` method of NameService native contract.
@@ -90,22 +90,22 @@ func IsAvailable(name string) bool {
 
 // Register represents `register` method of NameService native contract.
 func Register(name string, owner interop.Hash160) bool {
-	return contract.Call(interop.Hash160(Hash), "register", contract.WriteStates, name, owner).(bool)
+	return contract.Call(interop.Hash160(Hash), "register", contract.States, name, owner).(bool)
 }
 
 // Renew represents `renew` method of NameService native contract.
 func Renew(name string) int {
-	return contract.Call(interop.Hash160(Hash), "renew", contract.WriteStates, name).(int)
+	return contract.Call(interop.Hash160(Hash), "renew", contract.States, name).(int)
 }
 
 // SetAdmin represents `setAdmin` method of NameService native contract.
 func SetAdmin(name string, admin interop.Hash160) {
-	contract.Call(interop.Hash160(Hash), "setAdmin", contract.WriteStates, name, admin)
+	contract.Call(interop.Hash160(Hash), "setAdmin", contract.States, name, admin)
 }
 
 // SetRecord represents `setRecord` method of NameService native contract.
 func SetRecord(name string, recType RecordType, data string) {
-	contract.Call(interop.Hash160(Hash), "setRecord", contract.WriteStates, name, recType, data)
+	contract.Call(interop.Hash160(Hash), "setRecord", contract.States, name, recType, data)
 }
 
 // GetRecord represents `getRecord` method of NameService native contract.
@@ -116,7 +116,7 @@ func GetRecord(name string, recType RecordType) []byte {
 
 // DeleteRecord represents `deleteRecord` method of NameService native contract.
 func DeleteRecord(name string, recType RecordType) {
-	contract.Call(interop.Hash160(Hash), "deleteRecord", contract.WriteStates, name, recType)
+	contract.Call(interop.Hash160(Hash), "deleteRecord", contract.States, name, recType)
 }
 
 // Resolve represents `resolve` method of NameService native contract.

--- a/pkg/interop/native/neo/neo.go
+++ b/pkg/interop/native/neo/neo.go
@@ -56,22 +56,22 @@ func GetGASPerBlock() int {
 
 // SetGASPerBlock represents `setGasPerBlock` method of NEO native contract.
 func SetGASPerBlock(amount int) {
-	contract.Call(interop.Hash160(Hash), "setGasPerBlock", contract.WriteStates, amount)
+	contract.Call(interop.Hash160(Hash), "setGasPerBlock", contract.States, amount)
 }
 
 // RegisterCandidate represents `registerCandidate` method of NEO native contract.
 func RegisterCandidate(pub interop.PublicKey) bool {
-	return contract.Call(interop.Hash160(Hash), "registerCandidate", contract.WriteStates, pub).(bool)
+	return contract.Call(interop.Hash160(Hash), "registerCandidate", contract.States, pub).(bool)
 }
 
 // UnregisterCandidate represents `unregisterCandidate` method of NEO native contract.
 func UnregisterCandidate(pub interop.PublicKey) bool {
-	return contract.Call(interop.Hash160(Hash), "unregisterCandidate", contract.WriteStates, pub).(bool)
+	return contract.Call(interop.Hash160(Hash), "unregisterCandidate", contract.States, pub).(bool)
 }
 
 // Vote represents `vote` method of NEO native contract.
 func Vote(addr interop.Hash160, pub interop.PublicKey) bool {
-	return contract.Call(interop.Hash160(Hash), "vote", contract.WriteStates, addr, pub).(bool)
+	return contract.Call(interop.Hash160(Hash), "vote", contract.States, addr, pub).(bool)
 }
 
 // UnclaimedGAS represents `unclaimedGas` method of NEO native contract.

--- a/pkg/interop/native/notary/notary.go
+++ b/pkg/interop/native/notary/notary.go
@@ -10,13 +10,13 @@ const Hash = "\x0c\xcf\x26\x94\x3f\xb5\xc9\xb6\x05\xe2\x06\xd2\xa2\x75\xbe\x3e\x
 
 // LockDepositUntil represents `lockDepositUntil` method of Notary native contract.
 func LockDepositUntil(addr interop.Hash160, till int) bool {
-	return contract.Call(interop.Hash160(Hash), "lockDepositUntil", contract.WriteStates,
+	return contract.Call(interop.Hash160(Hash), "lockDepositUntil", contract.States,
 		addr, till).(bool)
 }
 
 // Withdraw represents `withdraw` method of Notary native contract.
 func Withdraw(from, to interop.Hash160) bool {
-	return contract.Call(interop.Hash160(Hash), "withdraw", contract.WriteStates,
+	return contract.Call(interop.Hash160(Hash), "withdraw", contract.States,
 		from, to).(bool)
 }
 
@@ -37,5 +37,5 @@ func GetMaxNotValidBeforeDelta() int {
 
 // SetMaxNotValidBeforeDelta represents `setMaxNotValidBeforeDelta` method of Notary native contract.
 func SetMaxNotValidBeforeDelta(value int) {
-	contract.Call(interop.Hash160(Hash), "setMaxNotValidBeforeDelta", contract.WriteStates, value)
+	contract.Call(interop.Hash160(Hash), "setMaxNotValidBeforeDelta", contract.States, value)
 }

--- a/pkg/interop/native/oracle/oracle.go
+++ b/pkg/interop/native/oracle/oracle.go
@@ -11,6 +11,6 @@ const Hash = "\xee\x80\x4c\x14\x29\x68\xd4\x78\x8b\x8a\xff\x51\xda\xde\xdf\xcb\x
 // Request represents `request` method of Oracle native contract.
 func Request(url string, filter []byte, cb string, userData interface{}, gasForResponse int) {
 	contract.Call(interop.Hash160(Hash), "request",
-		contract.WriteStates|contract.AllowNotify,
+		contract.States|contract.AllowNotify,
 		url, filter, cb, userData, gasForResponse)
 }

--- a/pkg/interop/native/policy/policy.go
+++ b/pkg/interop/native/policy/policy.go
@@ -15,7 +15,7 @@ func GetMaxTransactionsPerBlock() int {
 
 // SetMaxTransactionsPerBlock represents `setMaxTransactionsPerBlock` method of Policy native contract.
 func SetMaxTransactionsPerBlock(value int) {
-	contract.Call(interop.Hash160(Hash), "setMaxTransactionsPerBlock", contract.WriteStates, value)
+	contract.Call(interop.Hash160(Hash), "setMaxTransactionsPerBlock", contract.States, value)
 }
 
 // GetMaxBlockSize represents `getMaxBlockSize` method of Policy native contract.
@@ -25,7 +25,7 @@ func GetMaxBlockSize() int {
 
 // SetMaxBlockSize represents `setMaxBlockSize` method of Policy native contract.
 func SetMaxBlockSize(value int) {
-	contract.Call(interop.Hash160(Hash), "setMaxBlockSize", contract.WriteStates, value)
+	contract.Call(interop.Hash160(Hash), "setMaxBlockSize", contract.States, value)
 }
 
 // GetFeePerByte represents `getFeePerByte` method of Policy native contract.
@@ -35,7 +35,7 @@ func GetFeePerByte() int {
 
 // SetFeePerByte represents `setFeePerByte` method of Policy native contract.
 func SetFeePerByte(value int) {
-	contract.Call(interop.Hash160(Hash), "setFeePerByte", contract.WriteStates, value)
+	contract.Call(interop.Hash160(Hash), "setFeePerByte", contract.States, value)
 }
 
 // GetMaxBlockSystemFee represents `getMaxBlockSystemFee` method of Policy native contract.
@@ -45,7 +45,7 @@ func GetMaxBlockSystemFee() int {
 
 // SetMaxBlockSystemFee represents `setMaxBlockSystemFee` method of Policy native contract.
 func SetMaxBlockSystemFee(value int) {
-	contract.Call(interop.Hash160(Hash), "setMaxBlockSystemFee", contract.WriteStates, value)
+	contract.Call(interop.Hash160(Hash), "setMaxBlockSystemFee", contract.States, value)
 }
 
 // GetExecFeeFactor represents `getExecFeeFactor` method of Policy native contract.
@@ -55,7 +55,7 @@ func GetExecFeeFactor() int {
 
 // SetExecFeeFactor represents `setExecFeeFactor` method of Policy native contract.
 func SetExecFeeFactor(value int) {
-	contract.Call(interop.Hash160(Hash), "setExecFeeFactor", contract.WriteStates, value)
+	contract.Call(interop.Hash160(Hash), "setExecFeeFactor", contract.States, value)
 }
 
 // GetStoragePrice represents `getStoragePrice` method of Policy native contract.
@@ -65,7 +65,7 @@ func GetStoragePrice() int {
 
 // SetStoragePrice represents `setStoragePrice` method of Policy native contract.
 func SetStoragePrice(value int) {
-	contract.Call(interop.Hash160(Hash), "setStoragePrice", contract.WriteStates, value)
+	contract.Call(interop.Hash160(Hash), "setStoragePrice", contract.States, value)
 }
 
 // IsBlocked represents `isBlocked` method of Policy native contract.
@@ -75,10 +75,10 @@ func IsBlocked(addr interop.Hash160) bool {
 
 // BlockAccount represents `blockAccount` method of Policy native contract.
 func BlockAccount(addr interop.Hash160) bool {
-	return contract.Call(interop.Hash160(Hash), "blockAccount", contract.WriteStates, addr).(bool)
+	return contract.Call(interop.Hash160(Hash), "blockAccount", contract.States, addr).(bool)
 }
 
 // UnblockAccount represents `unblockAccount` method of Policy native contract.
 func UnblockAccount(addr interop.Hash160) bool {
-	return contract.Call(interop.Hash160(Hash), "unblockAccount", contract.WriteStates, addr).(bool)
+	return contract.Call(interop.Hash160(Hash), "unblockAccount", contract.States, addr).(bool)
 }

--- a/pkg/interop/native/roles/roles.go
+++ b/pkg/interop/native/roles/roles.go
@@ -27,5 +27,5 @@ func GetDesignatedByRole(r Role, height uint32) []interop.PublicKey {
 // DesignateAsRole represents `designateAsRole` method of RoleManagement native contract.
 func DesignateAsRole(r Role, pubs []interop.PublicKey) {
 	contract.Call(interop.Hash160(Hash), "designateAsRole",
-		contract.WriteStates, r, pubs)
+		contract.States, r, pubs)
 }


### PR DESCRIPTION
Replace `WriteStates` with `States`.

Follow neo-project/neo#2339.
Close #1775.
Related #1725.
