### PR TITLE
Add syscalls for POW and SQRT opcodes

### DIFF
--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -288,7 +288,8 @@ func isSyscall(fun *funcScope) bool {
 	if fun.selector == nil || fun.pkg == nil || !isInteropPath(fun.pkg.Path()) {
 		return false
 	}
-	return fun.pkg.Name() == "neogointernal" && strings.HasPrefix(fun.name, "Syscall")
+	return fun.pkg.Name() == "neogointernal" && (strings.HasPrefix(fun.name, "Syscall") ||
+		strings.HasPrefix(fun.name, "Opcode"))
 }
 
 const interopPrefix = "github.com/nspcc-dev/neo-go/pkg/interop"

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -327,6 +327,5 @@ func canInline(s string) bool {
 		return false
 	}
 	return !strings.HasPrefix(s[len(interopPrefix):], "/neogointernal") &&
-		!strings.HasPrefix(s[len(interopPrefix):], "/util") &&
-		!strings.HasPrefix(s[len(interopPrefix):], "/convert")
+		!strings.HasPrefix(s[len(interopPrefix):], "/util")
 }

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -1708,15 +1708,6 @@ func (c *codegen) convertBuiltin(expr *ast.CallExpr) {
 		c.emitStoreByIndex(varGlobal, c.exceptionIndex)
 	case "delete":
 		emit.Opcodes(c.prog.BinWriter, opcode.REMOVE)
-	case "ToInteger", "ToByteArray", "ToBool":
-		typ := stackitem.IntegerT
-		switch name {
-		case "ToByteArray":
-			typ = stackitem.ByteArrayT
-		case "ToBool":
-			typ = stackitem.BooleanT
-		}
-		c.emitConvert(typ)
 	case "Remove":
 		if !isCompoundSlice(c.typeOf(expr.Args[0])) {
 			c.prog.Err = errors.New("`Remove` supports only non-byte slices")

--- a/pkg/compiler/constant_test.go
+++ b/pkg/compiler/constant_test.go
@@ -40,7 +40,7 @@ func TestByteConstant(t *testing.T) {
 	src := `package foo
 	import "github.com/nspcc-dev/neo-go/pkg/interop/convert"
 	const a byte = 0xFF
-	func Main() int64 {
+	func Main() int {
 		x := convert.ToInteger(a)
 		return x+1
 	}`

--- a/pkg/compiler/convert_test.go
+++ b/pkg/compiler/convert_test.go
@@ -18,7 +18,7 @@ func getFunctionName(typ string) string {
 		return "Bool"
 	case "[]byte":
 		return "ByteArray"
-	case "int64":
+	case "int":
 		return "Integer"
 	}
 	panic("invalid type")
@@ -40,12 +40,12 @@ func TestConvert(t *testing.T) {
 		{"bool", "[]byte{0, 1, 0}", true},
 		{"bool", "[]byte{0}", true},
 		{"bool", `""`, false},
-		{"int64", "true", big.NewInt(1)},
-		{"int64", "false", big.NewInt(0)},
-		{"int64", "12", big.NewInt(12)},
-		{"int64", "0", big.NewInt(0)},
-		{"int64", "[]byte{0, 1, 0}", big.NewInt(256)},
-		{"int64", "[]byte{0}", big.NewInt(0)},
+		{"int", "true", big.NewInt(1)},
+		{"int", "false", big.NewInt(0)},
+		{"int", "12", big.NewInt(12)},
+		{"int", "0", big.NewInt(0)},
+		{"int", "[]byte{0, 1, 0}", big.NewInt(256)},
+		{"int", "[]byte{0}", big.NewInt(0)},
 		{"[]byte", "true", []byte{1}},
 		{"[]byte", "false", []byte{0}},
 		{"[]byte", "12", []byte{0x0C}},

--- a/pkg/compiler/syscall_test.go
+++ b/pkg/compiler/syscall_test.go
@@ -133,4 +133,64 @@ func TestOpcode(t *testing.T) {
 		}`
 		eval(t, src, big.NewInt(3))
 	})
+	t.Run("SIGN", func(t *testing.T) {
+		src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/interop/math"
+		func Main() []int {
+			signs := make([]int, 3)
+			signs[0] = math.Sign(-123)
+			signs[1] = math.Sign(0)
+			signs[2] = math.Sign(42)
+			return signs
+		}`
+		eval(t, src, []stackitem.Item{
+			stackitem.Make(-1),
+			stackitem.Make(0),
+			stackitem.Make(1),
+		})
+	})
+	t.Run("ABS", func(t *testing.T) {
+		src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/interop/math"
+		func Main() int {
+			return math.Abs(-3)
+		}`
+		eval(t, src, big.NewInt(3))
+	})
+	t.Run("MAX", func(t *testing.T) {
+		src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/interop/math"
+		func Main() int {
+			return math.Max(1, 2) + math.Max(8, 3)
+		}`
+		eval(t, src, big.NewInt(10))
+	})
+	t.Run("MIN", func(t *testing.T) {
+		src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/interop/math"
+		func Main() int {
+			return math.Min(1, 2) + math.Min(8, 3)
+		}`
+		eval(t, src, big.NewInt(4))
+	})
+	t.Run("WITHIN", func(t *testing.T) {
+		src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/interop/math"
+		func Main() []bool {
+			r := make([]bool, 5)
+			r[0] = math.Within(2, 3, 5)
+			r[1] = math.Within(3, 3, 5)
+			r[2] = math.Within(4, 3, 5)
+			r[3] = math.Within(5, 3, 5)
+			r[4] = math.Within(6, 3, 5)
+			return r
+		}`
+		eval(t, src, []stackitem.Item{
+			stackitem.Make(false),
+			stackitem.Make(true),
+			stackitem.Make(true),
+			stackitem.Make(false),
+			stackitem.Make(false),
+		})
+	})
 }

--- a/pkg/compiler/syscall_test.go
+++ b/pkg/compiler/syscall_test.go
@@ -117,4 +117,20 @@ func TestOpcode(t *testing.T) {
 		}`
 		eval(t, src, big.NewInt(42))
 	})
+	t.Run("POW", func(t *testing.T) {
+		src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/interop/math"
+		func Main() int {
+			return math.Pow(2, math.Pow(3, 2))
+		}`
+		eval(t, src, big.NewInt(512))
+	})
+	t.Run("SRQT", func(t *testing.T) {
+		src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/interop/math"
+		func Main() int {
+			return math.Sqrt(math.Sqrt(101)) // == sqrt(10) == 3
+		}`
+		eval(t, src, big.NewInt(3))
+	})
 }

--- a/pkg/compiler/syscall_test.go
+++ b/pkg/compiler/syscall_test.go
@@ -92,3 +92,29 @@ func TestSyscallInGlobalInit(t *testing.T) {
 	require.NoError(t, v.Run())
 	require.Equal(t, []byte{1, 2}, v.Estack().Pop().Value())
 }
+
+func TestOpcode(t *testing.T) {
+	t.Run("1 argument", func(t *testing.T) {
+		src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/interop/neogointernal"
+		func abs(a int) int {
+			return neogointernal.Opcode1("ABS", a).(int)
+		}
+		func Main() int {
+			return abs(-42)
+		}`
+		eval(t, src, big.NewInt(42))
+	})
+	t.Run("2 arguments", func(t *testing.T) {
+		src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/interop/neogointernal"
+		func add3(a, b, c int) int {
+			return neogointernal.Opcode2("SUB", a,
+				neogointernal.Opcode2("SUB", b, c).(int)).(int)
+		}
+		func Main() int {
+			return add3(53, 12, 1)
+		}`
+		eval(t, src, big.NewInt(42))
+	})
+}

--- a/pkg/interop/contract/contract.go
+++ b/pkg/interop/contract/contract.go
@@ -45,8 +45,8 @@ func CreateStandardAccount(pub interop.PublicKey) []byte {
 
 // GetCallFlags returns calling flags which execution context was created with.
 // This function uses `System.Contract.GetCallFlags` syscall.
-func GetCallFlags() int64 {
-	return neogointernal.Syscall0("System.Contract.GetFlags").(int64)
+func GetCallFlags() CallFlag {
+	return neogointernal.Syscall0("System.Contract.GetFlags").(CallFlag)
 }
 
 // Call executes previously deployed blockchain contract with specified hash

--- a/pkg/interop/convert/convert.go
+++ b/pkg/interop/convert/convert.go
@@ -3,15 +3,15 @@ package convert
 
 // ToInteger converts it's argument to an Integer.
 func ToInteger(v interface{}) int64 {
-	return 0
+	return v.(int64)
 }
 
 // ToByteArray converts it's argument to a ByteArray.
 func ToByteArray(v interface{}) []byte {
-	return nil
+	return v.([]byte)
 }
 
 // ToBool converts it's argument to a Boolean.
 func ToBool(v interface{}) bool {
-	return false
+	return v.(bool)
 }

--- a/pkg/interop/convert/convert.go
+++ b/pkg/interop/convert/convert.go
@@ -2,8 +2,8 @@
 package convert
 
 // ToInteger converts it's argument to an Integer.
-func ToInteger(v interface{}) int64 {
-	return v.(int64)
+func ToInteger(v interface{}) int {
+	return v.(int)
 }
 
 // ToByteArray converts it's argument to a ByteArray.

--- a/pkg/interop/math/math.go
+++ b/pkg/interop/math/math.go
@@ -12,3 +12,32 @@ func Pow(a, b int) int {
 func Sqrt(x int) int {
 	return neogointernal.Opcode1("SQRT", x).(int)
 }
+
+// Sign returns:
+//
+//	-1 if x <  0
+//	 0 if x == 0
+//	+1 if x >  0
+func Sign(a int) int {
+	return neogointernal.Opcode1("SIGN", a).(int)
+}
+
+// Abs returns absolute value of a.
+func Abs(a int) int {
+	return neogointernal.Opcode1("ABS", a).(int)
+}
+
+// Max returns maximum of a, b.
+func Max(a, b int) int {
+	return neogointernal.Opcode2("MAX", a, b).(int)
+}
+
+// Min returns minimum of a, b.
+func Min(a, b int) int {
+	return neogointernal.Opcode2("MIN", a, b).(int)
+}
+
+// Within returns true if a <= x < b.
+func Within(x, a, b int) bool {
+	return neogointernal.Opcode3("WITHIN", x, a, b).(bool)
+}

--- a/pkg/interop/math/math.go
+++ b/pkg/interop/math/math.go
@@ -1,0 +1,14 @@
+package math
+
+import "github.com/nspcc-dev/neo-go/pkg/interop/neogointernal"
+
+// Pow returns a^b using POW VM opcode.
+// b must be >= 0 and <= 2^31-1.
+func Pow(a, b int) int {
+	return neogointernal.Opcode2("POW", a, b).(int)
+}
+
+// Sqrt returns positive square root of x rounded down.
+func Sqrt(x int) int {
+	return neogointernal.Opcode1("SQRT", x).(int)
+}

--- a/pkg/interop/neogointernal/opcode.go
+++ b/pkg/interop/neogointernal/opcode.go
@@ -9,3 +9,8 @@ func Opcode1(op string, arg interface{}) interface{} {
 func Opcode2(op string, arg1, arg2 interface{}) interface{} {
 	return nil
 }
+
+// Opcode3 emits opcode with 3 arguments.
+func Opcode3(op string, arg1, arg2, arg3 interface{}) interface{} {
+	return nil
+}

--- a/pkg/interop/neogointernal/opcode.go
+++ b/pkg/interop/neogointernal/opcode.go
@@ -1,0 +1,11 @@
+package neogointernal
+
+// Opcode1 emits opcode with 1 argument.
+func Opcode1(op string, arg interface{}) interface{} {
+	return nil
+}
+
+// Opcode2 emits opcode with 2 arguments.
+func Opcode2(op string, arg1, arg2 interface{}) interface{} {
+	return nil
+}

--- a/pkg/interop/runtime/runtime.go
+++ b/pkg/interop/runtime/runtime.go
@@ -62,8 +62,8 @@ func GetTrigger() byte {
 
 // GasLeft returns the amount of gas available for the current execution.
 // This function uses `System.Runtime.GasLeft` syscall.
-func GasLeft() int64 {
-	return neogointernal.Syscall0("System.Runtime.GasLeft").(int64)
+func GasLeft() int {
+	return neogointernal.Syscall0("System.Runtime.GasLeft").(int)
 }
 
 // GetNotifications returns notifications emitted by contract h.

--- a/pkg/interop/storage/storage.go
+++ b/pkg/interop/storage/storage.go
@@ -38,6 +38,16 @@ const (
 	PickField1 FindFlags = 1 << 5
 )
 
+// PutFlags represents flag of `PutEx` syscall.
+type PutFlags byte
+
+const (
+	// PutDefault is a storage flag for non-constant items.
+	PutDefault PutFlags = 0
+	// PutConstant is a storage flag for constant items.
+	PutConstant PutFlags = 0x01
+)
+
 // ConvertContextToReadOnly returns new context from the given one, but with
 // writing capability turned off, so that you could only invoke Get and Find
 // using this new Context. If Context is already read-only this function is a
@@ -74,7 +84,7 @@ func Put(ctx Context, key interface{}, value interface{}) {
 // can either be odd for constant storage items or even for variable storage items.
 // Refer to Put function description for details on how to pass the remaining
 // arguments. This function uses `System.Storage.PutEx` syscall.
-func PutEx(ctx Context, key interface{}, value interface{}, flag int64) {
+func PutEx(ctx Context, key interface{}, value interface{}, flag PutFlags) {
 	neogointernal.Syscall4NoReturn("System.Storage.PutEx", ctx, key, value, flag)
 }
 


### PR DESCRIPTION
Close #1793 .

Also:
1. Don't convert syscall results.
2. Simplify `convert.To*` handling in compiler.
3. Add other missing interops (`ABS`, `SIGN`, `MAX`, `MIN`).