### PR TITLE
rpc, cli: allow to provide cosigners accounts to (*Client).CreateTxFromScript

### DIFF
--- a/cli/executor_test.go
+++ b/cli/executor_test.go
@@ -32,6 +32,7 @@ import (
 const (
 	validatorWIF  = "KxyjQ8eUa4FHt3Gvioyt1Wz29cTUrE4eTqX3yFSk1YFCsPL8uNsY"
 	validatorAddr = "NVNvVRW5Q5naSx2k2iZm7xRgtRNGuZppAK"
+	multisigAddr  = "NUVPACMnKFhpuHjsRjhUvXz1XhqfGZYVtY"
 
 	validatorWallet = "testdata/wallet1_solo.json"
 )

--- a/cli/nep17_test.go
+++ b/cli/nep17_test.go
@@ -83,6 +83,11 @@ func TestNEP17Balance(t *testing.T) {
 				e.checkNextLine(t, "^\\s*Updated\\s*:\\s*"+strconv.FormatUint(uint64(index), 10))
 			}
 		}
+
+		e.checkNextLine(t, "^\\s*$")
+		addr4, err := address.StringToUint160("NbxpLNCCSWZ9BkYpCYT8NfN1uoxq9Rfbrn") // deployed verify.go contract
+		require.NoError(t, err)
+		e.checkNextLine(t, "^Account "+address.Uint160ToString(addr4))
 		e.checkEOF(t)
 	})
 	t.Run("Bad token", func(t *testing.T) {

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -579,7 +579,7 @@ func invokeInternal(ctx *cli.Context, signAndPush bool) error {
 		fmt.Fprintln(ctx.App.Writer, errText+". Sending transaction...")
 	}
 	if out := ctx.String("out"); out != "" {
-		tx, err := c.CreateTxFromScript(resp.Script, acc, resp.GasConsumed, int64(gas), cosigners...)
+		tx, err := c.CreateTxFromScript(resp.Script, acc, resp.GasConsumed, int64(gas), cosigners)
 		if err != nil {
 			return cli.NewExitError(fmt.Errorf("failed to create tx: %w", err), 1)
 		}

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
 	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/client"
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
@@ -509,15 +510,17 @@ func invokeFunction(ctx *cli.Context) error {
 
 func invokeInternal(ctx *cli.Context, signAndPush bool) error {
 	var (
-		err             error
-		gas             fixedn.Fixed8
-		operation       string
-		params          = make([]smartcontract.Parameter, 0)
-		paramsStart     = 1
-		cosigners       []transaction.Signer
-		cosignersOffset = 0
-		resp            *result.Invoke
-		acc             *wallet.Account
+		err               error
+		gas               fixedn.Fixed8
+		operation         string
+		params            = make([]smartcontract.Parameter, 0)
+		paramsStart       = 1
+		cosigners         []transaction.Signer
+		cosignersAccounts []client.SignerAccount
+		cosignersOffset   = 0
+		resp              *result.Invoke
+		acc               *wallet.Account
+		wall              *wallet.Wallet
 	)
 
 	args := ctx.Args()
@@ -554,9 +557,19 @@ func invokeInternal(ctx *cli.Context, signAndPush bool) error {
 
 	if signAndPush {
 		gas = flags.Fixed8FromContext(ctx, "gas")
-		acc, err = getAccFromContext(ctx)
+		acc, wall, err = getAccFromContext(ctx)
 		if err != nil {
 			return err
+		}
+		for i := range cosigners {
+			cosignerAcc := wall.GetAccount(cosigners[i].Account)
+			if cosignerAcc == nil {
+				return cli.NewExitError(fmt.Errorf("can't calculate network fee: no account was found in the wallet for cosigner #%d", i), 1)
+			}
+			cosignersAccounts = append(cosignersAccounts, client.SignerAccount{
+				Signer:  cosigners[i],
+				Account: cosignerAcc,
+			})
 		}
 	}
 	gctx, cancel := options.GetTimeoutContext(ctx)
@@ -579,7 +592,7 @@ func invokeInternal(ctx *cli.Context, signAndPush bool) error {
 		fmt.Fprintln(ctx.App.Writer, errText+". Sending transaction...")
 	}
 	if out := ctx.String("out"); out != "" {
-		tx, err := c.CreateTxFromScript(resp.Script, acc, resp.GasConsumed, int64(gas), cosigners)
+		tx, err := c.CreateTxFromScript(resp.Script, acc, resp.GasConsumed, int64(gas), cosignersAccounts)
 		if err != nil {
 			return cli.NewExitError(fmt.Errorf("failed to create tx: %w", err), 1)
 		}
@@ -593,7 +606,7 @@ func invokeInternal(ctx *cli.Context, signAndPush bool) error {
 		if len(resp.Script) == 0 {
 			return cli.NewExitError(errors.New("no script returned from the RPC node"), 1)
 		}
-		txHash, err := c.SignAndPushInvocationTx(resp.Script, acc, resp.GasConsumed, gas, cosigners)
+		txHash, err := c.SignAndPushInvocationTx(resp.Script, acc, resp.GasConsumed, gas, cosignersAccounts)
 		if err != nil {
 			return cli.NewExitError(fmt.Errorf("failed to push invocation tx: %w", err), 1)
 		}
@@ -747,17 +760,17 @@ func inspect(ctx *cli.Context) error {
 	return nil
 }
 
-func getAccFromContext(ctx *cli.Context) (*wallet.Account, error) {
+func getAccFromContext(ctx *cli.Context) (*wallet.Account, *wallet.Wallet, error) {
 	var addr util.Uint160
 
 	wPath := ctx.String("wallet")
 	if len(wPath) == 0 {
-		return nil, cli.NewExitError(errNoWallet, 1)
+		return nil, nil, cli.NewExitError(errNoWallet, 1)
 	}
 
 	wall, err := wallet.NewWalletFromFile(wPath)
 	if err != nil {
-		return nil, cli.NewExitError(err, 1)
+		return nil, nil, cli.NewExitError(err, 1)
 	}
 	addrFlag := ctx.Generic("address").(*flags.Address)
 	if addrFlag.IsSet {
@@ -767,20 +780,20 @@ func getAccFromContext(ctx *cli.Context) (*wallet.Account, error) {
 	}
 	acc := wall.GetAccount(addr)
 	if acc == nil {
-		return nil, cli.NewExitError(fmt.Errorf("wallet contains no account for '%s'", address.Uint160ToString(addr)), 1)
+		return nil, nil, cli.NewExitError(fmt.Errorf("wallet contains no account for '%s'", address.Uint160ToString(addr)), 1)
 	}
 
 	rawPass, err := input.ReadPassword(
 		fmt.Sprintf("Enter account %s password > ", address.Uint160ToString(addr)))
 	if err != nil {
-		return nil, cli.NewExitError(err, 1)
+		return nil, nil, cli.NewExitError(err, 1)
 	}
 	pass := strings.TrimRight(string(rawPass), "\n")
 	err = acc.Decrypt(pass)
 	if err != nil {
-		return nil, cli.NewExitError(err, 1)
+		return nil, nil, cli.NewExitError(err, 1)
 	}
-	return acc, nil
+	return acc, wall, nil
 }
 
 // contractDeploy deploys contract.
@@ -795,7 +808,7 @@ func contractDeploy(ctx *cli.Context) error {
 	}
 	gas := flags.Fixed8FromContext(ctx, "gas")
 
-	acc, err := getAccFromContext(ctx)
+	acc, _, err := getAccFromContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/testdata/verify.go
+++ b/cli/testdata/verify.go
@@ -1,8 +1,10 @@
 package testdata
 
+import "github.com/nspcc-dev/neo-go/pkg/interop"
+
 func Verify() bool {
 	return true
 }
 
-func OnNEP17Payment(from []byte, amount int, data interface{}) {
+func OnNEP17Payment(from interop.Hash160, amount int, data interface{}) {
 }

--- a/cli/testdata/verify.yml
+++ b/cli/testdata/verify.yml
@@ -1,0 +1,1 @@
+name: Test verify

--- a/cli/testdata/wallet1_solo.json
+++ b/cli/testdata/wallet1_solo.json
@@ -59,6 +59,18 @@
       },
       "lock": false,
       "isdefault": false
+    },
+    {
+      "address" : "NbxpLNCCSWZ9BkYpCYT8NfN1uoxq9Rfbrn",
+      "key" : "6PYXDze5Ak4HahYKygcNzk6n65ACjWdDCYLSuKgA5KG8vyMJSFboUNSiPD",
+      "label" : "",
+      "contract" : {
+        "script" : "VwEAEUBXAANA",
+        "deployed" : true,
+        "parameters" : []
+      },
+      "lock" : false,
+      "isdefault" : false
     }
   ],
   "scrypt": {

--- a/cli/wallet/validator.go
+++ b/cli/wallet/validator.go
@@ -108,10 +108,10 @@ func handleCandidate(ctx *cli.Context, method string, sysGas int64) error {
 	w := io.NewBufBinWriter()
 	emit.AppCall(w.BinWriter, neoContractHash, method, callflag.States, acc.PrivateKey().PublicKey().Bytes())
 	emit.Opcodes(w.BinWriter, opcode.ASSERT)
-	tx, err := c.CreateTxFromScript(w.Bytes(), acc, sysGas, int64(gas), transaction.Signer{
+	tx, err := c.CreateTxFromScript(w.Bytes(), acc, sysGas, int64(gas), []transaction.Signer{{
 		Account: acc.Contract.ScriptHash(),
 		Scopes:  transaction.CalledByEntry,
-	})
+	}})
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	} else if err = acc.SignTx(tx); err != nil {
@@ -171,10 +171,10 @@ func handleVote(ctx *cli.Context) error {
 	emit.AppCall(w.BinWriter, neoContractHash, "vote", callflag.States, addr.BytesBE(), pubArg)
 	emit.Opcodes(w.BinWriter, opcode.ASSERT)
 
-	tx, err := c.CreateTxFromScript(w.Bytes(), acc, -1, int64(gas), transaction.Signer{
+	tx, err := c.CreateTxFromScript(w.Bytes(), acc, -1, int64(gas), []transaction.Signer{{
 		Account: acc.Contract.ScriptHash(),
 		Scopes:  transaction.CalledByEntry,
-	})
+	}})
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}

--- a/cli/wallet/validator.go
+++ b/cli/wallet/validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/client"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
@@ -108,10 +109,14 @@ func handleCandidate(ctx *cli.Context, method string, sysGas int64) error {
 	w := io.NewBufBinWriter()
 	emit.AppCall(w.BinWriter, neoContractHash, method, callflag.States, acc.PrivateKey().PublicKey().Bytes())
 	emit.Opcodes(w.BinWriter, opcode.ASSERT)
-	tx, err := c.CreateTxFromScript(w.Bytes(), acc, sysGas, int64(gas), []transaction.Signer{{
-		Account: acc.Contract.ScriptHash(),
-		Scopes:  transaction.CalledByEntry,
-	}})
+	tx, err := c.CreateTxFromScript(w.Bytes(), acc, sysGas, int64(gas), []client.SignerAccount{{
+		Signer: transaction.Signer{
+			Account: acc.Contract.ScriptHash(),
+			Scopes:  transaction.CalledByEntry,
+		},
+		Account: acc,
+	},
+	})
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	} else if err = acc.SignTx(tx); err != nil {
@@ -171,9 +176,12 @@ func handleVote(ctx *cli.Context) error {
 	emit.AppCall(w.BinWriter, neoContractHash, "vote", callflag.States, addr.BytesBE(), pubArg)
 	emit.Opcodes(w.BinWriter, opcode.ASSERT)
 
-	tx, err := c.CreateTxFromScript(w.Bytes(), acc, -1, int64(gas), []transaction.Signer{{
-		Account: acc.Contract.ScriptHash(),
-		Scopes:  transaction.CalledByEntry,
+	tx, err := c.CreateTxFromScript(w.Bytes(), acc, -1, int64(gas), []client.SignerAccount{{
+		Signer: transaction.Signer{
+			Account: acc.Contract.ScriptHash(),
+			Scopes:  transaction.CalledByEntry,
+		},
+		Account: acc,
 	}})
 	if err != nil {
 		return cli.NewExitError(err, 1)

--- a/pkg/rpc/client/nep17.go
+++ b/pkg/rpc/client/nep17.go
@@ -140,17 +140,17 @@ func (c *Client) CreateNEP17MultiTransferTx(acc *wallet.Account, gas int64, reci
 	if err != nil {
 		return nil, fmt.Errorf("bad account address: %v", err)
 	}
-	return c.CreateTxFromScript(w.Bytes(), acc, -1, gas, transaction.Signer{
+	return c.CreateTxFromScript(w.Bytes(), acc, -1, gas, []transaction.Signer{{
 		Account: accAddr,
 		Scopes:  transaction.CalledByEntry,
-	})
+	}})
 }
 
 // CreateTxFromScript creates transaction and properly sets cosigners and NetworkFee.
 // If sysFee <= 0, it is determined via result of `invokescript` RPC. You should
 // initialize network magic with Init before calling CreateTxFromScript.
 func (c *Client) CreateTxFromScript(script []byte, acc *wallet.Account, sysFee, netFee int64,
-	cosigners ...transaction.Signer) (*transaction.Transaction, error) {
+	cosigners []transaction.Signer) (*transaction.Transaction, error) {
 	from, err := address.StringToUint160(acc.Address)
 	if err != nil {
 		return nil, fmt.Errorf("bad account address: %v", err)

--- a/pkg/rpc/client/nep17.go
+++ b/pkg/rpc/client/nep17.go
@@ -24,6 +24,13 @@ type TransferTarget struct {
 	Amount  int64
 }
 
+// SignerAccount represents combination of the transaction.Signer and the
+// corresponding wallet.Account.
+type SignerAccount struct {
+	Signer  transaction.Signer
+	Account *wallet.Account
+}
+
 // NEP17Decimals invokes `decimals` NEP17 method on a specified contract.
 func (c *Client) NEP17Decimals(tokenHash util.Uint160) (int64, error) {
 	result, err := c.InvokeFunction(tokenHash, "decimals", []smartcontract.Parameter{}, nil)
@@ -140,9 +147,12 @@ func (c *Client) CreateNEP17MultiTransferTx(acc *wallet.Account, gas int64, reci
 	if err != nil {
 		return nil, fmt.Errorf("bad account address: %v", err)
 	}
-	return c.CreateTxFromScript(w.Bytes(), acc, -1, gas, []transaction.Signer{{
-		Account: accAddr,
-		Scopes:  transaction.CalledByEntry,
+	return c.CreateTxFromScript(w.Bytes(), acc, -1, gas, []SignerAccount{{
+		Signer: transaction.Signer{
+			Account: accAddr,
+			Scopes:  transaction.CalledByEntry,
+		},
+		Account: acc,
 	}})
 }
 
@@ -150,13 +160,11 @@ func (c *Client) CreateNEP17MultiTransferTx(acc *wallet.Account, gas int64, reci
 // If sysFee <= 0, it is determined via result of `invokescript` RPC. You should
 // initialize network magic with Init before calling CreateTxFromScript.
 func (c *Client) CreateTxFromScript(script []byte, acc *wallet.Account, sysFee, netFee int64,
-	cosigners []transaction.Signer) (*transaction.Transaction, error) {
-	from, err := address.StringToUint160(acc.Address)
+	cosigners []SignerAccount) (*transaction.Transaction, error) {
+	signers, accounts, err := getSigners(acc, cosigners)
 	if err != nil {
-		return nil, fmt.Errorf("bad account address: %v", err)
+		return nil, fmt.Errorf("failed to construct tx signers: %w", err)
 	}
-
-	signers := getSigners(from, cosigners)
 	if sysFee < 0 {
 		result, err := c.InvokeScript(script, signers)
 		if err != nil {
@@ -179,7 +187,7 @@ func (c *Client) CreateTxFromScript(script []byte, acc *wallet.Account, sysFee, 
 		return nil, fmt.Errorf("failed to add validUntilBlock to transaction: %w", err)
 	}
 
-	err = c.AddNetworkFee(tx, netFee, acc)
+	err = c.AddNetworkFee(tx, netFee, accounts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add network fee: %w", err)
 	}

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -526,7 +526,7 @@ func (c *Client) SignAndPushInvocationTx(script []byte, acc *wallet.Account, sys
 	var txHash util.Uint256
 	var err error
 
-	tx, err := c.CreateTxFromScript(script, acc, sysfee, int64(netfee), cosigners...)
+	tx, err := c.CreateTxFromScript(script, acc, sysfee, int64(netfee), cosigners)
 	if err != nil {
 		return txHash, fmt.Errorf("failed to create tx: %w", err)
 	}

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -522,7 +522,7 @@ func (c *Client) SubmitRawOracleResponse(ps request.RawParams) error {
 // SignAndPushInvocationTx signs and pushes given script as an invocation
 // transaction  using given wif to sign it and spending the amount of gas
 // specified. It returns a hash of the invocation transaction and an error.
-func (c *Client) SignAndPushInvocationTx(script []byte, acc *wallet.Account, sysfee int64, netfee fixedn.Fixed8, cosigners []transaction.Signer) (util.Uint256, error) {
+func (c *Client) SignAndPushInvocationTx(script []byte, acc *wallet.Account, sysfee int64, netfee fixedn.Fixed8, cosigners []SignerAccount) (util.Uint256, error) {
 	var txHash util.Uint256
 	var err error
 
@@ -544,25 +544,33 @@ func (c *Client) SignAndPushInvocationTx(script []byte, acc *wallet.Account, sys
 	return txHash, nil
 }
 
-// getSigners returns an array of transaction signers from given sender and cosigners.
-// If cosigners list already contains sender, the sender will be placed at the start of
-// the list.
-func getSigners(sender util.Uint160, cosigners []transaction.Signer) []transaction.Signer {
+// getSigners returns an array of transaction signers and corresponding accounts from
+// given sender and cosigners. If cosigners list already contains sender, the sender
+// will be placed at the start of the list.
+func getSigners(sender *wallet.Account, cosigners []SignerAccount) ([]transaction.Signer, []*wallet.Account, error) {
+	var (
+		signers  []transaction.Signer
+		accounts []*wallet.Account
+	)
+	from, err := address.StringToUint160(sender.Address)
+	if err != nil {
+		return nil, nil, fmt.Errorf("bad sender account address: %v", err)
+	}
 	s := transaction.Signer{
-		Account: sender,
+		Account: from,
 		Scopes:  transaction.None,
 	}
-	for i, c := range cosigners {
-		if c.Account == sender {
-			if i == 0 {
-				return cosigners
-			}
-			s.Scopes = c.Scopes
-			cosigners = append(cosigners[:i], cosigners[i+1:]...)
-			break
+	for _, c := range cosigners {
+		if c.Signer.Account == from {
+			s.Scopes = c.Signer.Scopes
+			continue
 		}
+		signers = append(signers, c.Signer)
+		accounts = append(accounts, c.Account)
 	}
-	return append([]transaction.Signer{s}, cosigners...)
+	signers = append([]transaction.Signer{s}, signers...)
+	accounts = append([]*wallet.Account{sender}, accounts...)
+	return signers, accounts, nil
 }
 
 // SignAndPushP2PNotaryRequest creates and pushes P2PNotary request constructed from the main

--- a/pkg/rpc/server/client_test.go
+++ b/pkg/rpc/server/client_test.go
@@ -347,7 +347,7 @@ func TestCreateTxFromScript(t *testing.T) {
 	priv := testchain.PrivateKey(0)
 	acc := wallet.NewAccountFromPrivateKey(priv)
 	t.Run("NoSystemFee", func(t *testing.T) {
-		tx, err := c.CreateTxFromScript([]byte{byte(opcode.PUSH1)}, acc, -1, 10)
+		tx, err := c.CreateTxFromScript([]byte{byte(opcode.PUSH1)}, acc, -1, 10, nil)
 		require.NoError(t, err)
 		require.True(t, tx.ValidUntilBlock > chain.BlockHeight())
 		require.EqualValues(t, 30, tx.SystemFee) // PUSH1
@@ -355,7 +355,7 @@ func TestCreateTxFromScript(t *testing.T) {
 		require.Equal(t, acc.PrivateKey().GetScriptHash(), tx.Signers[0].Account)
 	})
 	t.Run("ProvideSystemFee", func(t *testing.T) {
-		tx, err := c.CreateTxFromScript([]byte{byte(opcode.PUSH1)}, acc, 123, 10)
+		tx, err := c.CreateTxFromScript([]byte{byte(opcode.PUSH1)}, acc, 123, 10, nil)
 		require.NoError(t, err)
 		require.True(t, tx.ValidUntilBlock > chain.BlockHeight())
 		require.EqualValues(t, 123, tx.SystemFee)

--- a/pkg/rpc/server/client_test.go
+++ b/pkg/rpc/server/client_test.go
@@ -203,10 +203,15 @@ func TestSignAndPushInvocationTx(t *testing.T) {
 
 	priv := testchain.PrivateKey(0)
 	acc := wallet.NewAccountFromPrivateKey(priv)
-	h, err := c.SignAndPushInvocationTx([]byte{byte(opcode.PUSH1)}, acc, 30, 0, []transaction.Signer{{
-		Account: priv.GetScriptHash(),
-		Scopes:  transaction.CalledByEntry,
-	}})
+	h, err := c.SignAndPushInvocationTx([]byte{byte(opcode.PUSH1)}, acc, 30, 0, []client.SignerAccount{
+		{
+			Signer: transaction.Signer{
+				Account: priv.GetScriptHash(),
+				Scopes:  transaction.CalledByEntry,
+			},
+			Account: acc,
+		},
+	})
 	require.NoError(t, err)
 
 	mp := chain.GetMemPool()


### PR DESCRIPTION
We need cosigners' accounts to calculate the network fee properly.