### PR TITLE
consensus/test: add missing `t.Cleanup()`

### DIFF
--- a/pkg/consensus/consensus_test.go
+++ b/pkg/consensus/consensus_test.go
@@ -494,6 +494,7 @@ func newSingleTestChain(t *testing.T) *core.Blockchain {
 	require.NoError(t, err, "could not create chain")
 
 	go chain.Run()
+	t.Cleanup(chain.Close)
 	return chain
 }
 


### PR DESCRIPTION
Fix #1800 .

The test executed before `TestService_GetVerified` is `TestService_NextConsensus`, where chain is not closed.
Haven't reproduced it locally, happens only on CI. This can be a reason for this race.