### PR TITLE
interop: fix ConvertContextToReadOnly interop

### DIFF
--- a/pkg/interop/storage/storage.go
+++ b/pkg/interop/storage/storage.go
@@ -43,7 +43,7 @@ const (
 // using this new Context. If Context is already read-only this function is a
 // no-op. It uses `System.Storage.AsReadOnly` syscall.
 func ConvertContextToReadOnly(ctx Context) Context {
-	return neogointernal.Syscall0("System.Storage.AsReadOnly").(Context)
+	return neogointernal.Syscall1("System.Storage.AsReadOnly", ctx).(Context)
 }
 
 // GetContext returns current contract's (that invokes this function) storage


### PR DESCRIPTION
The same bug as in #1804.

Also checked the rest of interops, they're OK. Maybe we need some test for such bugs.