### PR TITLE
config: adjust default testnet magic for RC1 testnet

### DIFF
--- a/config/protocol.testnet.yml
+++ b/config/protocol.testnet.yml
@@ -1,5 +1,5 @@
 ProtocolConfiguration:
-  Magic: 1951352142
+  Magic: 827601742
   MaxTraceableBlocks: 2102400
   SecondsPerBlock: 15
   MemPoolSize: 50000

--- a/pkg/config/netmode/netmode.go
+++ b/pkg/config/netmode/netmode.go
@@ -6,7 +6,7 @@ const (
 	// MainNet contains magic code used in the NEO main official network.
 	MainNet Magic = 0x004f454e // 5195086
 	// TestNet contains magic code used in the NEO testing network.
-	TestNet Magic = 0x744f454e // 1951352142
+	TestNet Magic = 0x3154334e // 827601742
 	// PrivNet contains magic code usually used for NEO private networks.
 	PrivNet Magic = 56753 // docker privnet
 	// UnitTestNet is a stub magic code used for testing purposes.


### PR DESCRIPTION
It's 827601742, N3T1, see https://github.com/neo-project/neo-node/releases/tag/v3.0.0-rc1
