### PR TITLE
rpc/server: fix getversion reply for staterootinheader extension

### DIFF
--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -509,10 +509,11 @@ func (s *Server) getVersion(_ request.Params) (interface{}, *response.Error) {
 		return nil, response.NewInternalServerError("Cannot fetch tcp port", err)
 	}
 	return result.Version{
-		Magic:     s.network,
-		TCPPort:   port,
-		Nonce:     s.coreServer.ID(),
-		UserAgent: s.coreServer.UserAgent,
+		Magic:             s.network,
+		TCPPort:           port,
+		Nonce:             s.coreServer.ID(),
+		UserAgent:         s.coreServer.UserAgent,
+		StateRootInHeader: s.chain.GetConfig().StateRootInHeader,
 	}, nil
 }
 


### PR DESCRIPTION
Proper network should have it set to `true` and client should know about it.
