### PR TITLE
rpc: refactor (*Client).AddNetworkFee

### DIFF
--- a/pkg/core/native_contract_test.go
+++ b/pkg/core/native_contract_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/interop/contract"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
 	"github.com/nspcc-dev/neo-go/pkg/core/storage"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
@@ -19,6 +21,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/vm"
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -318,4 +321,13 @@ func TestNativeContract_InvokeOtherContract(t *testing.T) {
 		drainTN(t)
 		checkResult(t, res, stackitem.Make(8))
 	})
+}
+
+func TestCreateContractHashableScript(t *testing.T) {
+	chain := newTestChain(t)
+	for _, c := range chain.contracts.Contracts {
+		assert.Equal(t, c.Metadata().Hash, hash.Hash160(state.CreateContractHashableScript(util.Uint160{}, 0, c.Metadata().Name)),
+			fmt.Errorf("fix all usages of state.CreateContractHashableScript for contract %s: "+
+				"contract hash expected to match hash160(state.CreateContractHashableScript(...))", c.Metadata().Name))
+	}
 }

--- a/pkg/core/state/contract.go
+++ b/pkg/core/state/contract.go
@@ -121,9 +121,9 @@ func (c *Contract) FromStackItem(item stackitem.Item) error {
 	return nil
 }
 
-// CreateContractHash creates deployed contract hash from transaction sender
-// and contract script.
-func CreateContractHash(sender util.Uint160, checksum uint32, name string) util.Uint160 {
+// CreateContractHashableScript creates deployed contract script from transaction sender
+// and contract script which should be hashed.
+func CreateContractHashableScript(sender util.Uint160, checksum uint32, name string) []byte {
 	w := io.NewBufBinWriter()
 	emit.Opcodes(w.BinWriter, opcode.ABORT)
 	emit.Bytes(w.BinWriter, sender.BytesBE())
@@ -132,5 +132,11 @@ func CreateContractHash(sender util.Uint160, checksum uint32, name string) util.
 	if w.Err != nil {
 		panic(w.Err)
 	}
-	return hash.Hash160(w.Bytes())
+	return w.Bytes()
+}
+
+// CreateContractHash creates deployed contract hash from transaction sender
+// and contract script.
+func CreateContractHash(sender util.Uint160, checksum uint32, name string) util.Uint160 {
+	return hash.Hash160(CreateContractHashableScript(sender, checksum, name))
 }

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/native/nativeprices"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
@@ -770,53 +771,40 @@ func (c *Client) CalculateValidUntilBlock() (uint32, error) {
 }
 
 // AddNetworkFee adds network fee for each witness script and optional extra
-// network fee to transaction. `accs` is an array signer's accounts.
+// network fee to transaction. `accs` is an array of signer's accounts with
+// matching order.
 func (c *Client) AddNetworkFee(tx *transaction.Transaction, extraFee int64, accs ...*wallet.Account) error {
 	if len(tx.Signers) != len(accs) {
 		return errors.New("number of signers must match number of scripts")
 	}
-	size := io.GetVarSize(tx)
-	var ef int64
-	for i, cosigner := range tx.Signers {
-		if accs[i].Contract.Deployed {
-			res, err := c.InvokeContractVerify(cosigner.Account, smartcontract.Params{}, tx.Signers)
-			if err != nil {
-				return fmt.Errorf("failed to invoke verify: %w", err)
+	oldScripts := tx.Scripts
+	tx.Scripts = make([]transaction.Witness, len(tx.Signers))
+	for i := range tx.Signers {
+		if accs[i].Contract != nil {
+			if accs[i].Contract.Deployed == true {
+				tx.Scripts[i] = transaction.Witness{InvocationScript: []byte{}, VerificationScript: []byte{}}
+				continue
 			}
-			if res.State != "HALT" {
-				return fmt.Errorf("invalid VM state %s due to an error: %s", res.State, res.FaultException)
-			}
-			if l := len(res.Stack); l != 1 {
-				return fmt.Errorf("result stack length should be equal to 1, got %d", l)
-			}
-			r, err := topIntFromStack(res.Stack)
-			if err != nil {
-				return fmt.Errorf("signer #%d: failed to get `verify` result from stack: %w", i, err)
-			}
-			if r == 0 {
-				return fmt.Errorf("signer #%d: `verify` returned `false`", i)
-			}
-			tx.NetworkFee += res.GasConsumed
-			size += io.GetVarSize([]byte{}) * 2 // both scripts are empty
-			continue
-		}
-
-		if ef == 0 {
-			var err error
-			ef, err = c.GetExecFeeFactor()
-			if err != nil {
-				return fmt.Errorf("can't get `ExecFeeFactor`: %w", err)
+			nativeNotaryHashableScript := state.CreateContractHashableScript(util.Uint160{}, 0, nativenames.Notary)
+			if accs[i].Contract.Script == nil && tx.Signers[i].Account == hash.Hash160(nativeNotaryHashableScript) {
+				// This is a hack for Notary contract witness in uncompleted Notary request transactions.
+				// Witness check for such uncompleted transactions will fail, but we need the tx to pass
+				// witness check for the rest of witnesses. We're OK with 0 netfee for Notary witness,
+				// so all we need is just to skip Notary witness check. Given `CalculateNetworkFee`, the
+				// most simple way to do it is to pretend that Notary witness is an unusual witness
+				// (neither of sig/multisig/contract-based) with hash(verificationScript) == Notary contract hash.
+				tx.Scripts[i] = transaction.Witness{InvocationScript: []byte{}, VerificationScript: nativeNotaryHashableScript}
+				continue
 			}
 		}
-		netFee, sizeDelta := fee.Calculate(ef, accs[i].Contract.Script)
-		tx.NetworkFee += netFee
-		size += sizeDelta
+		tx.Scripts[i] = transaction.Witness{InvocationScript: []byte{}, VerificationScript: accs[i].GetVerificationScript()}
 	}
-	fee, err := c.GetFeePerByte()
+	netFee, err := c.CalculateNetworkFee(tx)
 	if err != nil {
-		return err
+		return fmt.Errorf("`calculatenetworkfee` RPC request returned an error: %w", err)
 	}
-	tx.NetworkFee += int64(size)*fee + extraFee
+	tx.NetworkFee += netFee + extraFee
+	tx.Scripts = oldScripts
 	return nil
 }
 

--- a/pkg/rpc/server/client_test.go
+++ b/pkg/rpc/server/client_test.go
@@ -308,11 +308,11 @@ func TestAddNetworkFeeCalculateNetworkFee(t *testing.T) {
 					Scopes:  transaction.CalledByEntry,
 				},
 				{
-					Account: util.Uint160{},
+					Account: util.Uint160{}, // there's no such contract in chain, so (s *Server).calculateNetworkFee returns an error
 					Scopes:  transaction.Global,
 				},
 			}
-			require.Error(t, c.AddNetworkFee(tx, 10, acc0, acc1))
+			require.Error(t, c.AddNetworkFee(tx, extraFee, acc0, acc1))
 		})
 	})
 }


### PR DESCRIPTION
### Problem

Massive code duplication between `(*Client).AddNetworkFee` and `(*Server).calculateNetworkFee` methods. They perform almost the same things, but AddNetworkFee is able to deal with incomplete Notary contract witnesses because it works with accounts (not with witnesses themselves). And CalculateNetworkFee is not able to process incomplete witnesses (we have to think about a workaround).

### Solution

The current solution presented in the PR seems to me bad and I'd suggest to leave AddNetworkFee "as is" without changing anything. We have a lot of tests for both methods, so we may keep them all.

So we need to discuss it.

Depends on #1858.
