### PR TITLE
core: get native nep17 balance from contract storage

### DIFF
--- a/pkg/core/native/native_gas.go
+++ b/pkg/core/native/native_gas.go
@@ -34,6 +34,7 @@ func newGAS() *GAS {
 	nep17.decimals = 8
 	nep17.factor = GASFactor
 	nep17.incBalance = g.increaseBalance
+	nep17.balFromBytes = g.balanceFromBytes
 
 	g.nep17TokenNative = *nep17
 
@@ -57,6 +58,14 @@ func (g *GAS) increaseBalance(_ *interop.Context, _ util.Uint160, si *state.Stor
 		*si = nil
 	}
 	return nil
+}
+
+func (g *GAS) balanceFromBytes(si *state.StorageItem) (*big.Int, error) {
+	acc, err := state.NEP17BalanceStateFromBytes(*si)
+	if err != nil {
+		return nil, err
+	}
+	return &acc.Balance, err
 }
 
 // Initialize initializes GAS contract.

--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -107,6 +107,7 @@ func newNEO() *NEO {
 	nep17.decimals = 0
 	nep17.factor = 1
 	nep17.incBalance = n.increaseBalance
+	nep17.balFromBytes = n.balanceFromBytes
 
 	n.nep17TokenNative = *nep17
 	n.votesChanged.Store(true)
@@ -402,6 +403,14 @@ func (n *NEO) increaseBalance(ic *interop.Context, h util.Uint160, si *state.Sto
 		*si = nil
 	}
 	return nil
+}
+
+func (n *NEO) balanceFromBytes(si *state.StorageItem) (*big.Int, error) {
+	acc, err := state.NEOBalanceStateFromBytes(*si)
+	if err != nil {
+		return nil, err
+	}
+	return &acc.Balance, err
 }
 
 func (n *NEO) distributeGas(ic *interop.Context, h util.Uint160, acc *state.NEOBalanceState) error {


### PR DESCRIPTION
Not from DAO's items with storage.STNEP17Balances prefix, because
changes are reflected there only after notifications processing. And
this happens only after the transaction script is executed, but there
might be cases when we need to get the balance that was updated
earlier during the same transaction processing.

Affects storage dumps.

This PR makes us compatible with the C# nodes up to 44k of the RC1 testnet.