### PR TITLE
Compiler inlining fixes

### DIFF
--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -162,7 +162,6 @@ func (c *codegen) countLocalsInline(decl *ast.FuncDecl, pkg *types.Package, f *f
 		switch n := n.(type) {
 		case *ast.CallExpr:
 			size += c.countLocalsCall(n, pkg)
-			return false
 		case *ast.FuncType:
 			num := n.Results.NumFields()
 			if num != 0 && len(n.Results.List[0].Names) != 0 {

--- a/pkg/compiler/inline_test.go
+++ b/pkg/compiler/inline_test.go
@@ -209,6 +209,15 @@ func TestInlineGlobalVariable(t *testing.T) {
 	})
 }
 
+func TestInlineVariadicInInlinedCall(t *testing.T) {
+	src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/inline"
+		func Main() int {
+			return inline.SumSquared(inline.SumVar(3, 4) - 2, 3)
+		}`
+	eval(t, src, big.NewInt(64))
+}
+
 func TestInlineConversion(t *testing.T) {
 	src1 := `package foo
 	import "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/inline"

--- a/pkg/compiler/inline_test.go
+++ b/pkg/compiler/inline_test.go
@@ -264,3 +264,13 @@ func TestInlineConversionQualified(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, b2, b1)
 }
+
+func TestPackageVarsInInlinedCalls(t *testing.T) {
+	src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/inline"
+		import "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/inline/b"
+		func Main() int {
+			return inline.Sum(inline.A, b.A)
+		}`
+	eval(t, src, big.NewInt(13))
+}

--- a/pkg/compiler/testdata/inline/inline.go
+++ b/pkg/compiler/testdata/inline/inline.go
@@ -39,6 +39,10 @@ func VarSum(a int, b ...int) int {
 	return sum
 }
 
+func SumVar(a, b int) int {
+	return VarSum(a, b)
+}
+
 func Concat(n int) int {
 	return n*100 + b.A*10 + A
 }


### PR DESCRIPTION
### Problem

This simple code:
```
// OracleCallback is called by Oracle contract when the request is finished.
func OracleCallback(url []byte, data []byte, code int, res []byte) {
        if code != 0 {
                panic("oracle request failed for " + string(url) + " with " + std.Itoa(code, 10))
        }
        runtime.Log("oracle result for " + string(url) + ":" + string(res))
}
```
Fails with
```
error encountered at instruction 1 (SYSCALL): error during call from native: error encountered at instruction 205 (STLOC2): runtime error: index out of range [2] with length 2
```
Which means that the code generated is just plain wrong because it initializes two local slots and then uses all three of them.

### Solution

#1878 would be a better one, but this one suffices for now.