### PR TITLE
cli: refactor AddressFlag usages

### DIFF
--- a/cli/candidate_test.go
+++ b/cli/candidate_test.go
@@ -23,6 +23,11 @@ func TestRegisterCandidate(t *testing.T) {
 		"GAS:"+validatorPriv.Address()+":10000")
 	e.checkTxPersisted(t)
 
+	// missing address
+	e.RunWithError(t, "neo-go", "wallet", "candidate", "register",
+		"--rpc-endpoint", "http://"+e.RPC.Addr,
+		"--wallet", validatorWallet)
+
 	e.In.WriteString("one\r")
 	e.Run(t, "neo-go", "wallet", "candidate", "register",
 		"--rpc-endpoint", "http://"+e.RPC.Addr,
@@ -51,6 +56,11 @@ func TestRegisterCandidate(t *testing.T) {
 		b, _ := e.Chain.GetGoverningTokenBalance(validatorPriv.GetScriptHash())
 		require.Equal(t, b, vs[0].Votes)
 	})
+
+	// missing address
+	e.RunWithError(t, "neo-go", "wallet", "candidate", "unregister",
+		"--rpc-endpoint", "http://"+e.RPC.Addr,
+		"--wallet", validatorWallet)
 
 	e.In.WriteString("one\r")
 	e.Run(t, "neo-go", "wallet", "candidate", "unregister",

--- a/cli/contract_test.go
+++ b/cli/contract_test.go
@@ -211,6 +211,11 @@ func TestComlileAndInvokeFunction(t *testing.T) {
 	e.checkTxPersisted(t)
 
 	t.Run("check calc hash", func(t *testing.T) {
+		// missing sender
+		e.RunWithError(t, "neo-go", "contract", "calc-hash",
+			"--in", nefName,
+			"--manifest", manifestName)
+
 		e.Run(t, "neo-go", "contract", "calc-hash",
 			"--sender", validatorAddr, "--in", nefName,
 			"--manifest", manifestName)

--- a/cli/multisig_test.go
+++ b/cli/multisig_test.go
@@ -91,6 +91,12 @@ func TestSignMultisigTx(t *testing.T) {
 		})
 	}
 
+	// missing address
+	e.RunWithError(t, "neo-go", "wallet", "sign",
+		"--rpc-endpoint", "http://"+e.RPC.Addr,
+		"--wallet", wallet2Path,
+		"--in", txPath, "--out", txPath)
+
 	e.In.WriteString("pass\r")
 	e.Run(t, "neo-go", "wallet", "sign",
 		"--rpc-endpoint", "http://"+e.RPC.Addr,
@@ -127,7 +133,7 @@ func TestSignMultisigTx(t *testing.T) {
 		e.In.WriteString("pass\r")
 		e.Run(t, "neo-go", "contract", "invokefunction",
 			"--rpc-endpoint", "http://"+e.RPC.Addr,
-			"--wallet", wallet1Path, "--address", multisigAddr,
+			"--wallet", wallet1Path, "--address", multisigHash.StringLE(), // test with scripthash instead of address
 			"--out", txPath,
 			e.Chain.GoverningTokenHash().StringLE(), "transfer",
 			"bytes:"+multisigHash.StringBE(),

--- a/cli/nep17_test.go
+++ b/cli/nep17_test.go
@@ -200,6 +200,12 @@ func TestNEP17ImportToken(t *testing.T) {
 	gasContractHash, err := e.Chain.GetNativeContractScriptHash(nativenames.Gas)
 	require.NoError(t, err)
 	e.Run(t, "neo-go", "wallet", "init", "--wallet", walletPath)
+
+	// missing token hash
+	e.RunWithError(t, "neo-go", "wallet", "nep17", "import",
+		"--rpc-endpoint", "http://"+e.RPC.Addr,
+		"--wallet", walletPath)
+
 	e.Run(t, "neo-go", "wallet", "nep17", "import",
 		"--rpc-endpoint", "http://"+e.RPC.Addr,
 		"--wallet", walletPath,
@@ -207,7 +213,7 @@ func TestNEP17ImportToken(t *testing.T) {
 	e.Run(t, "neo-go", "wallet", "nep17", "import",
 		"--rpc-endpoint", "http://"+e.RPC.Addr,
 		"--wallet", walletPath,
-		"--token", neoContractHash.StringLE())
+		"--token", address.Uint160ToString(neoContractHash)) // try address instead of sh
 
 	t.Run("Info", func(t *testing.T) {
 		checkGASInfo := func(t *testing.T) {

--- a/cli/nep17_test.go
+++ b/cli/nep17_test.go
@@ -98,9 +98,6 @@ func TestNEP17Balance(t *testing.T) {
 	t.Run("Bad wallet", func(t *testing.T) {
 		e.RunWithError(t, append(cmdbalance, "--wallet", "/dev/null")...)
 	})
-	t.Run("Bad address", func(t *testing.T) {
-		e.RunWithError(t, append(cmdbalance, "--rpc-endpoint", "http://"+e.RPC.Addr, "--wallet", validatorWallet, "--address", "xxx")...)
-	})
 	return
 }
 

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -348,7 +348,7 @@ func NewCommands() []cli.Command {
 				Usage:  "calculates hash of a contract after deployment",
 				Action: calcHash,
 				Flags: []cli.Flag{
-					cli.StringFlag{
+					flags.AddressFlag{
 						Name:  "sender, s",
 						Usage: "sender script hash or address",
 					},
@@ -466,10 +466,9 @@ func contractCompile(ctx *cli.Context) error {
 }
 
 func calcHash(ctx *cli.Context) error {
-	s := ctx.String("sender")
-	u, err := flags.ParseAddress(s)
-	if err != nil {
-		return cli.NewExitError(errors.New("invalid sender: must be either address or Uint160 in LE form"), 1)
+	sender := ctx.Generic("sender").(*flags.Address)
+	if !sender.IsSet {
+		return cli.NewExitError("sender is not set", 1)
 	}
 
 	p := ctx.String("in")
@@ -497,7 +496,7 @@ func calcHash(ctx *cli.Context) error {
 	if err != nil {
 		return cli.NewExitError(fmt.Errorf("failed to restore manifest file: %w", err), 1)
 	}
-	fmt.Fprintln(ctx.App.Writer, "Contract hash:", state.CreateContractHash(u, nefFile.Checksum, m.Name).StringLE())
+	fmt.Fprintln(ctx.App.Writer, "Contract hash:", state.CreateContractHash(sender.Uint160(), nefFile.Checksum, m.Name).StringLE())
 	return nil
 }
 

--- a/cli/wallet/multisig.go
+++ b/cli/wallet/multisig.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neo-go/cli/flags"
 	"github.com/nspcc-dev/neo-go/cli/options"
 	"github.com/nspcc-dev/neo-go/cli/paramcontext"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
@@ -21,12 +22,11 @@ func signStoredTransaction(ctx *cli.Context) error {
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
-	addr := ctx.String("address")
-	sh, err := address.StringToUint160(addr)
-	if err != nil {
-		return cli.NewExitError(fmt.Errorf("invalid address: %w", err), 1)
+	addrFlag := ctx.Generic("address").(*flags.Address)
+	if !addrFlag.IsSet {
+		return cli.NewExitError("address was not provided", 1)
 	}
-	acc, err := getDecryptedAccount(ctx, wall, sh)
+	acc, err := getDecryptedAccount(ctx, wall, addrFlag.Uint160())
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}

--- a/cli/wallet/nep17.go
+++ b/cli/wallet/nep17.go
@@ -40,9 +40,9 @@ func newNEP17Commands() []cli.Command {
 	balanceFlags = append(balanceFlags, options.RPC...)
 	importFlags := []cli.Flag{
 		walletPathFlag,
-		cli.StringFlag{
+		flags.AddressFlag{
 			Name:  "token",
-			Usage: "Token contract hash in LE",
+			Usage: "Token contract address or hash in LE",
 		},
 	}
 	importFlags = append(importFlags, options.RPC...)
@@ -257,10 +257,11 @@ func importNEP17Token(ctx *cli.Context) error {
 	}
 	defer wall.Close()
 
-	tokenHash, err := flags.ParseAddress(ctx.String("token"))
-	if err != nil {
-		return cli.NewExitError(fmt.Errorf("invalid token contract hash: %w", err), 1)
+	tokenHashFlag := ctx.Generic("token").(*flags.Address)
+	if !tokenHashFlag.IsSet {
+		return cli.NewExitError("token contract hash was not set", 1)
 	}
+	tokenHash := tokenHashFlag.Uint160()
 
 	for _, t := range wall.Extra.Tokens {
 		if t.Hash.Equals(tokenHash) {

--- a/cli/wallet/nep17.go
+++ b/cli/wallet/nep17.go
@@ -32,7 +32,7 @@ func newNEP17Commands() []cli.Command {
 	balanceFlags := []cli.Flag{
 		walletPathFlag,
 		tokenFlag,
-		cli.StringFlag{
+		flags.AddressFlag{
 			Name:  "address, a",
 			Usage: "Address to use",
 		},
@@ -135,15 +135,12 @@ func getNEP17Balance(ctx *cli.Context) error {
 	}
 	defer wall.Close()
 
-	addr := ctx.String("address")
-	if addr != "" {
-		addrHash, err := address.StringToUint160(addr)
-		if err != nil {
-			return cli.NewExitError(fmt.Errorf("invalid address: %w", err), 1)
-		}
+	addrFlag := ctx.Generic("address").(*flags.Address)
+	if addrFlag.IsSet {
+		addrHash := addrFlag.Uint160()
 		acc := wall.GetAccount(addrHash)
 		if acc == nil {
-			return cli.NewExitError(fmt.Errorf("can't find account for the address: %s", addr), 1)
+			return cli.NewExitError(fmt.Errorf("can't find account for the address: %s", address.Uint160ToString(addrHash)), 1)
 		}
 		accounts = append(accounts, acc)
 	} else {

--- a/cli/wallet/validator.go
+++ b/cli/wallet/validator.go
@@ -87,6 +87,9 @@ func handleCandidate(ctx *cli.Context, method string, sysGas int64) error {
 	defer wall.Close()
 
 	addrFlag := ctx.Generic("address").(*flags.Address)
+	if !addrFlag.IsSet {
+		return cli.NewExitError("address was not provided", 1)
+	}
 	addr := addrFlag.Uint160()
 	acc, err := getDecryptedAccount(ctx, wall, addr)
 	if err != nil {
@@ -139,6 +142,9 @@ func handleVote(ctx *cli.Context) error {
 	defer wall.Close()
 
 	addrFlag := ctx.Generic("address").(*flags.Address)
+	if !addrFlag.IsSet {
+		return cli.NewExitError("address was not provided", 1)
+	}
 	addr := addrFlag.Uint160()
 	acc, err := getDecryptedAccount(ctx, wall, addr)
 	if err != nil {

--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -137,7 +137,7 @@ func NewCommands() []cli.Command {
 				Action: dumpKeys,
 				Flags: []cli.Flag{
 					walletPathFlag,
-					cli.StringFlag{
+					flags.AddressFlag{
 						Name:  "address, a",
 						Usage: "address to print public keys for",
 					},
@@ -568,13 +568,10 @@ func dumpKeys(ctx *cli.Context) error {
 		return cli.NewExitError(err, 1)
 	}
 	accounts := wall.Accounts
-	addr := ctx.String("address")
-	if addr != "" {
-		u, err := flags.ParseAddress(addr)
-		if err != nil {
-			return cli.NewExitError(fmt.Errorf("invalid address: %w", err), 1)
-		}
-		acc := wall.GetAccount(u)
+
+	addrFlag := ctx.Generic("address").(*flags.Address)
+	if addrFlag.IsSet {
+		acc := wall.GetAccount(addrFlag.Uint160())
 		if acc == nil {
 			return cli.NewExitError("account is missing", 1)
 		}
@@ -605,8 +602,8 @@ func dumpKeys(ctx *cli.Context) error {
 			hasPrinted = true
 			continue
 		}
-		if addr != "" {
-			return cli.NewExitError(fmt.Errorf("Unknown script type for address %s", addr), 1)
+		if addrFlag.IsSet {
+			return cli.NewExitError(fmt.Errorf("Unknown script type for address %s", address.Uint160ToString(addrFlag.Uint160())), 1)
 		}
 	}
 	return nil

--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -603,7 +603,7 @@ func dumpKeys(ctx *cli.Context) error {
 			continue
 		}
 		if addrFlag.IsSet {
-			return cli.NewExitError(fmt.Errorf("Unknown script type for address %s", address.Uint160ToString(addrFlag.Uint160())), 1)
+			return cli.NewExitError(fmt.Errorf("unknown script type for address %s", address.Uint160ToString(addrFlag.Uint160())), 1)
 		}
 	}
 	return nil

--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -197,9 +197,9 @@ func NewCommands() []cli.Command {
 				Flags: append([]cli.Flag{
 					walletPathFlag,
 					wifFlag,
-					cli.StringFlag{
+					flags.AddressFlag{
 						Name:  "contract, c",
-						Usage: "Contract hash",
+						Usage: "Contract hash or address",
 					},
 				}, options.RPC...),
 			},
@@ -421,10 +421,9 @@ func importDeployed(ctx *cli.Context) error {
 
 	defer wall.Close()
 
-	rawHash := ctx.String("contract")
-	h, err := flags.ParseAddress(rawHash)
-	if err != nil {
-		return cli.NewExitError(fmt.Errorf("invalid contract hash: %w", err), 1)
+	rawHash := ctx.Generic("contract").(*flags.Address)
+	if !rawHash.IsSet {
+		return cli.NewExitError("contract hash was not provided", 1)
 	}
 
 	acc, err := newAccountFromWIF(ctx.App.Writer, ctx.String("wif"))
@@ -440,7 +439,7 @@ func importDeployed(ctx *cli.Context) error {
 		return cli.NewExitError(err, 1)
 	}
 
-	cs, err := c.GetContractStateByHash(h)
+	cs, err := c.GetContractStateByHash(rawHash.Uint160())
 	if err != nil {
 		return cli.NewExitError(fmt.Errorf("can't fetch contract info: %w", err), 1)
 	}

--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -74,7 +74,7 @@ func NewCommands() []cli.Command {
 		walletPathFlag,
 		outFlag,
 		inFlag,
-		cli.StringFlag{
+		flags.AddressFlag{
 			Name:  "address, a",
 			Usage: "Address to use",
 		},

--- a/cli/wallet_test.go
+++ b/cli/wallet_test.go
@@ -267,6 +267,11 @@ func TestImportDeployed(t *testing.T) {
 	priv, err := keys.NewPrivateKey()
 	require.NoError(t, err)
 
+	// missing contract sh
+	e.RunWithError(t, "neo-go", "wallet", "import-deployed",
+		"--rpc-endpoint", "http://"+e.RPC.Addr,
+		"--wallet", walletPath, "--wif", priv.WIF())
+
 	e.In.WriteString("acc\rpass\rpass\r")
 	e.Run(t, "neo-go", "wallet", "import-deployed",
 		"--rpc-endpoint", "http://"+e.RPC.Addr,


### PR DESCRIPTION
### Problem

We have a lot of places where `cli.StringFlag` is used instead of `flags.AdddressFlag`.

Also close #1895.