### PR TITLE
cli: allow to pass 'data' for nep17 transfer command

### DIFF
--- a/cli/nep17_test.go
+++ b/cli/nep17_test.go
@@ -161,6 +161,22 @@ func TestNEP17Transfer(t *testing.T) {
 		b, _ = e.Chain.GetGoverningTokenBalance(sh)
 		require.Equal(t, big.NewInt(41), b)
 	})
+
+	t.Run("with data", func(t *testing.T) {
+		e.In.WriteString("one\r")
+		validTil := e.Chain.BlockHeight() + 100
+		e.Run(t, []string{
+			"neo-go", "wallet", "nep17", "transfer",
+			"--rpc-endpoint", "http://" + e.RPC.Addr,
+			"--wallet", validatorWallet,
+			"--to", address.Uint160ToString(e.Chain.GetNotaryContractScriptHash()),
+			"--token", "GAS",
+			"--amount", "1",
+			"--from", validatorAddr,
+			"[", validatorAddr, strconv.Itoa(int(validTil)), "]",
+		}...)
+		e.checkTxPersisted(t)
+	})
 }
 
 func TestNEP17MultiTransfer(t *testing.T) {

--- a/cli/smartcontract/smart_contract_test.go
+++ b/cli/smartcontract/smart_contract_test.go
@@ -202,7 +202,7 @@ func TestParseParams_CalledFromItself(t *testing.T) {
 
 	for str, expected := range testCases {
 		input := strings.Split(str, " ")
-		offset, actual, err := parseParams(input, false)
+		offset, actual, err := ParseParams(input, false)
 		require.NoError(t, err)
 		require.Equal(t, expected.WordsRead, offset)
 		require.Equal(t, expected.Value, actual)
@@ -218,7 +218,7 @@ func TestParseParams_CalledFromItself(t *testing.T) {
 
 	for _, str := range errorCases {
 		input := strings.Split(str, " ")
-		_, _, err := parseParams(input, false)
+		_, _, err := ParseParams(input, false)
 		require.Error(t, err)
 	}
 }
@@ -400,7 +400,7 @@ func TestParseParams_CalledFromOutside(t *testing.T) {
 	}
 	for str, expected := range testCases {
 		input := strings.Split(str, " ")
-		offset, arr, err := parseParams(input, true)
+		offset, arr, err := ParseParams(input, true)
 		require.NoError(t, err)
 		require.Equal(t, expected.WordsRead, offset)
 		require.Equal(t, expected.Parameters, arr)
@@ -415,7 +415,7 @@ func TestParseParams_CalledFromOutside(t *testing.T) {
 	}
 	for _, str := range errorCases {
 		input := strings.Split(str, " ")
-		_, _, err := parseParams(input, true)
+		_, _, err := ParseParams(input, true)
 		require.Error(t, err)
 	}
 }

--- a/cli/wallet/nep17.go
+++ b/cli/wallet/nep17.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neo-go/cli/flags"
 	"github.com/nspcc-dev/neo-go/cli/options"
 	"github.com/nspcc-dev/neo-go/cli/paramcontext"
+	smartcontractcli "github.com/nspcc-dev/neo-go/cli/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
 	"github.com/nspcc-dev/neo-go/pkg/rpc/client"
@@ -111,9 +112,12 @@ func newNEP17Commands() []cli.Command {
 		{
 			Name:      "transfer",
 			Usage:     "transfer NEP17 tokens",
-			UsageText: "transfer --wallet <path> --rpc-endpoint <node> --timeout <time> --from <addr> --to <addr> --token <hash> --amount string",
+			UsageText: "transfer --wallet <path> --rpc-endpoint <node> --timeout <time> --from <addr> --to <addr> --token <hash> --amount string [data]",
 			Action:    transferNEP17,
 			Flags:     transferFlags,
+			Description: `Transfers specified NEP17 token amount with optional 'data' parameter attached to the transfer.
+   See 'contract testinvokefunction' documentation for the details about 'data'
+   parameter. If no 'data' is given then default nil value will be used`,
 		},
 		{
 			Name:  "multitransfer",
@@ -459,11 +463,16 @@ func transferNEP17(ctx *cli.Context) error {
 		return cli.NewExitError(fmt.Errorf("invalid amount: %w", err), 1)
 	}
 
+	data, extErr := smartcontractcli.GetDataFromContext(ctx)
+	if extErr != nil {
+		return extErr
+	}
+
 	return signAndSendTransfer(ctx, c, acc, []client.TransferTarget{{
 		Token:   token.Hash,
 		Address: to,
 		Amount:  amount.Int64(),
-		Data:    nil,
+		Data:    data,
 	}})
 }
 

--- a/cli/wallet/nep17.go
+++ b/cli/wallet/nep17.go
@@ -411,6 +411,7 @@ func multiTransferNEP17(ctx *cli.Context) error {
 			Token:   token.Hash,
 			Address: addr,
 			Amount:  amount.Int64(),
+			Data:    nil,
 		})
 	}
 
@@ -462,13 +463,14 @@ func transferNEP17(ctx *cli.Context) error {
 		Token:   token.Hash,
 		Address: to,
 		Amount:  amount.Int64(),
+		Data:    nil,
 	}})
 }
 
 func signAndSendTransfer(ctx *cli.Context, c *client.Client, acc *wallet.Account, recipients []client.TransferTarget) error {
 	gas := flags.Fixed8FromContext(ctx, "gas")
 
-	tx, err := c.CreateNEP17MultiTransferTx(acc, int64(gas), recipients, nil)
+	tx, err := c.CreateNEP17MultiTransferTx(acc, int64(gas), recipients)
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}

--- a/config/protocol.unit_testnet.single.yml
+++ b/config/protocol.unit_testnet.single.yml
@@ -8,7 +8,7 @@ ProtocolConfiguration:
   ValidatorsCount: 1
   VerifyBlocks: true
   VerifyTransactions: true
-  P2PSigExtensions: false
+  P2PSigExtensions: true
   NativeActivations:
     ContractManagement: [0]
     StdLib: [0]
@@ -20,6 +20,7 @@ ProtocolConfiguration:
     RoleManagement: [0]
     OracleContract: [0]
     NameService: [0]
+    Notary: [0]
 
 ApplicationConfiguration:
   # LogPath could be set up in case you need stdout logs to some proper file.

--- a/pkg/vm/emit/emit.go
+++ b/pkg/vm/emit/emit.go
@@ -88,6 +88,8 @@ func Array(w *io.BinWriter, es ...interface{}) {
 			String(w, e)
 		case util.Uint160:
 			Bytes(w, e.BytesBE())
+		case util.Uint256:
+			Bytes(w, e.BytesBE())
 		case []byte:
 			Bytes(w, e)
 		case bool:


### PR DESCRIPTION
Close #1896.

Implemented only for single transfer, because multitransfer syntax doesn't allow to easily parse data for each token. However, we may add an ability to provide one common data parameter for all multitransfer tokens via the last argument.