### PR TITLE
rpc, internal: fix CodeQL int conversions warnings

### DIFF
--- a/internal/fakechain/fakechain.go
+++ b/internal/fakechain/fakechain.go
@@ -2,6 +2,7 @@ package fakechain
 
 import (
 	"errors"
+	"math"
 	"math/big"
 	"sync/atomic"
 
@@ -233,6 +234,9 @@ func (chain *FakeChain) GetNativeContractScriptHash(name string) (util.Uint160, 
 
 // GetHeaderHash implements Blockchainer interface.
 func (chain *FakeChain) GetHeaderHash(n int) util.Uint256 {
+	if n < 0 || n > math.MaxUint32 {
+		return util.Uint256{}
+	}
 	return chain.hdrHashes[uint32(n)]
 }
 

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -841,6 +841,9 @@ func (s *Server) contractIDFromParam(param *request.Param) (int32, *response.Err
 		if err != nil {
 			return 0, response.ErrInvalidParams
 		}
+		if err := checkInt32(id); err != nil {
+			return 0, response.WrapErrorWithData(response.ErrInvalidParams, err)
+		}
 		result = int32(id)
 	default:
 		return 0, response.ErrInvalidParams
@@ -873,6 +876,9 @@ func (s *Server) contractScriptHashFromParam(param *request.Param) (util.Uint160
 		id, err := param.GetInt()
 		if err != nil {
 			return result, response.ErrInvalidParams
+		}
+		if err := checkInt32(id); err != nil {
+			return result, response.WrapErrorWithData(response.ErrInvalidParams, err)
 		}
 		result, err = s.chain.GetContractScriptHash(int32(id))
 		if err != nil {
@@ -969,6 +975,9 @@ func (s *Server) getStateRoot(ps request.Params) (interface{}, *response.Error) 
 	var h util.Uint256
 	height, err := p.GetInt()
 	if err == nil {
+		if err := checkUint32(height); err != nil {
+			return nil, response.WrapErrorWithData(response.ErrInvalidParams, err)
+		}
 		rt, err = s.chain.GetStateModule().GetStateRoot(uint32(height))
 	} else if h, err = p.GetUint256(); err == nil {
 		var hdr *block.Header

--- a/pkg/rpc/server/util.go
+++ b/pkg/rpc/server/util.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"errors"
+	"math"
+)
+
+func checkUint32(i int) error {
+	if i < 0 || i > math.MaxUint32 {
+		return errors.New("value should fit uint32")
+	}
+	return nil
+}
+
+func checkInt32(i int) error {
+	if i < math.MinInt32 || i > math.MaxInt32 {
+		return errors.New("value should fit int32")
+	}
+	return nil
+}


### PR DESCRIPTION
### Problem

```
Incorrect conversion of an integer with architecture-dependent bit
size from to a lower bit size type int32 without an upper bound
check.
```