### PR TITLE
cli, rpc: use CalledByEntry as a default cosigner's scope

### DIFF
--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -289,7 +289,7 @@ func NewCommands() []cli.Command {
         - 'CustomContracts' - define valid custom contract hashes for witness check.
         - 'CustomGroups' - define custom pubkey for group members.
 
-   If no scopes were specified, 'Global' used as default. If no signers were
+   If no scopes were specified, 'CalledByEntry' used as default. If no signers were
    specified, no array is passed. Note that scopes are properly handled by 
    neo-go RPC server only. C# implementation does not support scopes capability.
 
@@ -926,7 +926,7 @@ func parseCosigner(c string) (transaction.Signer, error) {
 	var (
 		err error
 		res = transaction.Signer{
-			Scopes: transaction.Global,
+			Scopes: transaction.CalledByEntry,
 		}
 	)
 	data := strings.SplitN(c, ":", 2)

--- a/cli/smartcontract/smart_contract_test.go
+++ b/cli/smartcontract/smart_contract_test.go
@@ -74,11 +74,11 @@ func TestParseCosigner(t *testing.T) {
 	testCases := map[string]transaction.Signer{
 		acc.StringLE(): {
 			Account: acc,
-			Scopes:  transaction.Global,
+			Scopes:  transaction.CalledByEntry,
 		},
 		"0x" + acc.StringLE(): {
 			Account: acc,
-			Scopes:  transaction.Global,
+			Scopes:  transaction.CalledByEntry,
 		},
 		acc.StringLE() + ":Global": {
 			Account: acc,

--- a/pkg/rpc/request/param.go
+++ b/pkg/rpc/request/param.go
@@ -224,9 +224,9 @@ func (p Param) GetSignerWithWitness() (SignerWithWitness, error) {
 	return c, nil
 }
 
-// GetSignersWithWitnesses returns a slice of SignerWithWitness with global scope from
-// array of Uint160 or array of serialized transaction.Signer stored in the
-// parameter.
+// GetSignersWithWitnesses returns a slice of SignerWithWitness with CalledByEntry
+// scope from array of Uint160 or array of serialized transaction.Signer stored
+// in the parameter.
 func (p Param) GetSignersWithWitnesses() ([]transaction.Signer, []transaction.Witness, error) {
 	hashes, err := p.GetArray()
 	if err != nil {
@@ -243,7 +243,7 @@ func (p Param) GetSignersWithWitnesses() ([]transaction.Signer, []transaction.Wi
 		}
 		signers[i] = transaction.Signer{
 			Account: u,
-			Scopes:  transaction.Global,
+			Scopes:  transaction.CalledByEntry,
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
Close #1897.