### PR TITLE
core: add NEP11 to nonfungible supported standards list

### DIFF
--- a/pkg/core/native/nonfungible.go
+++ b/pkg/core/native/nonfungible.go
@@ -67,6 +67,7 @@ func newNonFungible(name string, id int32, symbol string, decimals byte) *nonfun
 			return new(state.NFTTokenState)
 		},
 	}
+	n.Manifest.SupportedStandards = []string{manifest.NEP11StandardName}
 
 	desc := newDescriptor("symbol", smartcontract.StringType)
 	md := newMethodAndPrice(n.symbol, 0, callflag.NoneFlag)


### PR DESCRIPTION
It's not so important because native NNS will be removed, but let's fix it.