### PR TITLE
compiler: drop `countLocals` logic

### DIFF
--- a/cli/nep17_test.go
+++ b/cli/nep17_test.go
@@ -86,7 +86,7 @@ func TestNEP17Balance(t *testing.T) {
 		}
 
 		e.checkNextLine(t, "^\\s*$")
-		addr4, err := address.StringToUint160("NQKpygA5oG8KRivZeYjXVU2T1ZPmUmaqQF") // deployed verify.go contract
+		addr4, err := address.StringToUint160("NU4CTk9H2fgNCuC3ZPqX4LjUX3MHt3Rh6p") // deployed verify.go contract
 		require.NoError(t, err)
 		e.checkNextLine(t, "^Account "+address.Uint160ToString(addr4))
 		e.checkEOF(t)

--- a/cli/testdata/wallet1_solo.json
+++ b/cli/testdata/wallet1_solo.json
@@ -63,9 +63,9 @@
       "key" : "6PYM8VdX2BSm7BSXKzV4Fz6S3R9cDLLWNrD9nMjxW352jEv3fsC8N3wNLY"
     },
     {
-      "address" : "NQKpygA5oG8KRivZeYjXVU2T1ZPmUmaqQF",
+      "address" : "NU4CTk9H2fgNCuC3ZPqX4LjUX3MHt3Rh6p",
       "contract" : {
-        "script" : "VwEAEdsgQFcAA0BXAQR4eXp7VBTAcAwOT25ORVAxMVBheW1lbnRoUEGVAW9hIUA=",
+        "script" : "EdsgQFcAA0BXAQR4eXp7VBTAcAwOT25ORVAxMVBheW1lbnRoUEGVAW9hIUA=",
         "parameters" : [],
         "deployed" : true
       },

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -98,6 +98,10 @@ func (c *codegen) traverseGlobals() bool {
 		c.scope = nil
 	})
 
+	if c.globalInlineCount > maxCnt {
+		maxCnt = c.globalInlineCount
+	}
+
 	// Here we remove `INITSLOT` if no code was emitted for `init` function.
 	// Note that the `INITSSLOT` must stay in place.
 	hasNoInit := initOffset+3 == c.prog.Len()

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -121,7 +121,7 @@ func (c *codegen) traverseGlobals() (int, int, int) {
 		// store auxiliary variables after all others.
 		if hasDefer {
 			c.exceptionIndex = len(c.globals)
-			c.globals["<exception>"] = c.exceptionIndex
+			c.globals[exceptionVarName] = c.exceptionIndex
 		}
 	}
 	return n, initLocals, deployLocals

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -37,46 +37,20 @@ func (c *codegen) getIdentName(pkg string, name string) string {
 }
 
 // traverseGlobals visits and initializes global variables.
-// and returns number of variables initialized.
-// Second return value is -1 if no `init()` functions were encountered
-// and number of maximum amount of locals in any of init functions otherwise.
-// Same for `_deploy()` functions (see docs/compiler.md).
-func (c *codegen) traverseGlobals() (int, int, int) {
+// It returns `true` if contract has `_deploy` function.
+func (c *codegen) traverseGlobals() bool {
 	var hasDefer bool
 	var n, nConst int
-	initLocals := -1
-	deployLocals := -1
+	var hasDeploy bool
 	c.ForEachFile(func(f *ast.File, pkg *types.Package) {
 		nv, nc := countGlobals(f)
 		n += nv
 		nConst += nc
-		if initLocals == -1 || deployLocals == -1 || !hasDefer {
+		if !hasDeploy || !hasDefer {
 			ast.Inspect(f, func(node ast.Node) bool {
 				switch n := node.(type) {
-				case *ast.GenDecl:
-					if n.Tok == token.VAR {
-						for i := range n.Specs {
-							for _, v := range n.Specs[i].(*ast.ValueSpec).Values {
-								num := c.countLocalsCall(v, pkg)
-								if num > initLocals {
-									initLocals = num
-								}
-							}
-						}
-					}
 				case *ast.FuncDecl:
-					if isInitFunc(n) {
-						num, _ := c.countLocals(n)
-						if num > initLocals {
-							initLocals = num
-						}
-					} else if isDeployFunc(n) {
-						num, _ := c.countLocals(n)
-						if num > deployLocals {
-							deployLocals = num
-						}
-					}
-					return !hasDefer
+					hasDeploy = hasDeploy || isDeployFunc(n)
 				case *ast.DeferStmt:
 					hasDefer = true
 					return false
@@ -88,43 +62,70 @@ func (c *codegen) traverseGlobals() (int, int, int) {
 	if hasDefer {
 		n++
 	}
-	if n+nConst != 0 || initLocals > -1 {
-		if n > 255 {
-			c.prog.BinWriter.Err = errors.New("too many global variables")
-			return 0, initLocals, deployLocals
-		}
-		if n != 0 {
-			emit.Instruction(c.prog.BinWriter, opcode.INITSSLOT, []byte{byte(n)})
-		}
-		if initLocals > 0 {
-			emit.Instruction(c.prog.BinWriter, opcode.INITSLOT, []byte{byte(initLocals), 0})
-		}
-		seenBefore := false
-		c.ForEachPackage(func(pkg *loader.PackageInfo) {
-			if n+nConst > 0 {
-				for _, f := range pkg.Files {
-					c.fillImportMap(f, pkg.Pkg)
-					c.convertGlobals(f, pkg.Pkg)
-				}
+
+	if n > 255 {
+		c.prog.BinWriter.Err = errors.New("too many global variables")
+		return hasDeploy
+	}
+
+	if n != 0 {
+		emit.Instruction(c.prog.BinWriter, opcode.INITSSLOT, []byte{byte(n)})
+	}
+
+	initOffset := c.prog.Len()
+	emit.Instruction(c.prog.BinWriter, opcode.INITSLOT, []byte{0, 0})
+
+	lastCnt, maxCnt := -1, -1
+	c.ForEachPackage(func(pkg *loader.PackageInfo) {
+		if n+nConst > 0 {
+			for _, f := range pkg.Files {
+				c.fillImportMap(f, pkg.Pkg)
+				c.convertGlobals(f, pkg.Pkg)
 			}
-			if initLocals > -1 {
-				for _, f := range pkg.Files {
-					c.fillImportMap(f, pkg.Pkg)
-					seenBefore = c.convertInitFuncs(f, pkg.Pkg, seenBefore) || seenBefore
-				}
+		}
+		for _, f := range pkg.Files {
+			c.fillImportMap(f, pkg.Pkg)
+
+			var currMax int
+			lastCnt, currMax = c.convertInitFuncs(f, pkg.Pkg, lastCnt)
+			if currMax > maxCnt {
+				maxCnt = currMax
 			}
-			// because we reuse `convertFuncDecl` for init funcs,
-			// we need to cleare scope, so that global variables
-			// encountered after will be recognized as globals.
-			c.scope = nil
-		})
-		// store auxiliary variables after all others.
-		if hasDefer {
-			c.exceptionIndex = len(c.globals)
-			c.globals[exceptionVarName] = c.exceptionIndex
+		}
+		// because we reuse `convertFuncDecl` for init funcs,
+		// we need to cleare scope, so that global variables
+		// encountered after will be recognized as globals.
+		c.scope = nil
+	})
+
+	// Here we remove `INITSLOT` if no code was emitted for `init` function.
+	// Note that the `INITSSLOT` must stay in place.
+	hasNoInit := initOffset+3 == c.prog.Len()
+	if hasNoInit {
+		buf := c.prog.Bytes()
+		c.prog.Reset()
+		c.prog.WriteBytes(buf[:initOffset])
+	}
+
+	if initOffset != 0 || !hasNoInit { // if there are some globals or `init()`.
+		c.initEndOffset = c.prog.Len()
+		emit.Opcodes(c.prog.BinWriter, opcode.RET)
+
+		if maxCnt >= 0 {
+			c.reverseOffsetMap[initOffset] = nameWithLocals{
+				name:  "init",
+				count: maxCnt,
+			}
 		}
 	}
-	return n, initLocals, deployLocals
+
+	// store auxiliary variables after all others.
+	if hasDefer {
+		c.exceptionIndex = len(c.globals)
+		c.globals[exceptionVarName] = c.exceptionIndex
+	}
+
+	return hasDeploy
 }
 
 // countGlobals counts the global variables in the program to add

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -61,6 +61,9 @@ type codegen struct {
 	// inlineLabelOffsets contains size of labelList at the start of inline call processing.
 	// For such calls we need to drop only newly created part of stack.
 	inlineLabelOffsets []int
+	// globalInlineCount contains amount of auxiliary variables introduced by
+	// function inlining during global variables initialization.
+	globalInlineCount int
 
 	// A label for the for-loop being currently visited.
 	currentFor string

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -1296,7 +1296,9 @@ func (c *codegen) processDefers() {
 		c.setLabel(stmt.catchLabel)
 		c.emitStoreByIndex(varGlobal, c.exceptionIndex)
 		emit.Int(c.prog.BinWriter, 1)
-		c.emitStoreByIndex(varLocal, c.scope.finallyProcessedIndex)
+
+		finalIndex := c.getVarIndex("", finallyVarName).index
+		c.emitStoreByIndex(varLocal, finalIndex)
 		ast.Walk(c, stmt.expr)
 		if i == 0 {
 			// After panic, default values must be returns, except for named returns,
@@ -1309,12 +1311,12 @@ func (c *codegen) processDefers() {
 
 		c.setLabel(stmt.finallyLabel)
 		before := c.newLabel()
-		c.emitLoadByIndex(varLocal, c.scope.finallyProcessedIndex)
+		c.emitLoadByIndex(varLocal, finalIndex)
 		emit.Jmp(c.prog.BinWriter, opcode.JMPIFL, before)
 		ast.Walk(c, stmt.expr)
 		c.setLabel(before)
 		emit.Int(c.prog.BinWriter, 0)
-		c.emitStoreByIndex(varLocal, c.scope.finallyProcessedIndex)
+		c.emitStoreByIndex(varLocal, finalIndex)
 		emit.Opcodes(c.prog.BinWriter, opcode.ENDFINALLY)
 		c.setLabel(after)
 	}

--- a/pkg/compiler/debug_test.go
+++ b/pkg/compiler/debug_test.go
@@ -73,7 +73,9 @@ func _deploy(data interface{}, isUpdate bool) { x := 1; _ = x }
 	c := newCodegen(info, pkg)
 	require.NoError(t, c.compile(info, pkg))
 
-	buf := c.prog.Bytes()
+	buf, err := c.writeJumps(c.prog.Bytes())
+	require.NoError(t, err)
+
 	d := c.emitDebugInfo(buf)
 	require.NotNil(t, d)
 

--- a/pkg/compiler/defer_test.go
+++ b/pkg/compiler/defer_test.go
@@ -137,3 +137,14 @@ func TestRecover(t *testing.T) {
 		eval(t, src, big.NewInt(5))
 	})
 }
+
+func TestDeferNoGlobals(t *testing.T) {
+	src := `package foo
+	func Main() int {
+		a := 1
+		defer func() { recover() }()
+		panic("msg")
+		return a
+	}`
+	eval(t, src, big.NewInt(0))
+}

--- a/pkg/compiler/func_scope.go
+++ b/pkg/compiler/func_scope.go
@@ -34,9 +34,6 @@ type funcScope struct {
 
 	// deferStack is a stack containing encountered `defer` statements.
 	deferStack []deferInfo
-	// finallyProcessed is a index of static slot with boolean flag determining
-	// if `defer` statement was already processed.
-	finallyProcessedIndex int
 
 	// Local variables
 	vars varScope
@@ -58,6 +55,11 @@ type deferInfo struct {
 	finallyLabel uint16
 	expr         *ast.CallExpr
 }
+
+const (
+	finallyVarName   = "<finally>"
+	exceptionVarName = "<exception>"
+)
 
 func (c *codegen) newFuncScope(decl *ast.FuncDecl, label uint16) *funcScope {
 	var name string
@@ -204,7 +206,6 @@ func (c *codegen) countLocalsInline(decl *ast.FuncDecl, pkg *types.Package, f *f
 func (c *codegen) countLocalsWithDefer(f *funcScope) int {
 	size, hasDefer := c.countLocals(f.decl)
 	if hasDefer {
-		f.finallyProcessedIndex = size
 		size++
 	}
 	return size

--- a/pkg/compiler/function_call_test.go
+++ b/pkg/compiler/function_call_test.go
@@ -306,7 +306,10 @@ func TestJumpOptimize(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 6, len(di.Methods))
 	for _, mi := range di.Methods {
-		require.Equal(t, b[mi.Range.Start], byte(opcode.INITSLOT))
+		// only _deploy and init have locals here
+		if mi.Name.Name == "_deploy" || mi.Name.Name == "init" {
+			require.Equal(t, b[mi.Range.Start], byte(opcode.INITSLOT))
+		}
 		require.Equal(t, b[mi.Range.End], byte(opcode.RET))
 	}
 }

--- a/pkg/compiler/inline.go
+++ b/pkg/compiler/inline.go
@@ -32,7 +32,12 @@ func (c *codegen) inlineCall(f *funcScope, n *ast.CallExpr) {
 	if c.scope == nil {
 		c.scope = &funcScope{}
 		c.scope.vars.newScope()
-		defer func() { c.scope = nil }()
+		defer func() {
+			if cnt := c.scope.vars.localsCnt; cnt > c.globalInlineCount {
+				c.globalInlineCount = cnt
+			}
+			c.scope = nil
+		}()
 	}
 
 	// Arguments need to be walked with the current scope,

--- a/pkg/compiler/inline_test.go
+++ b/pkg/compiler/inline_test.go
@@ -30,7 +30,7 @@ func checkCallCount(t *testing.T, src string, expectedCall, expectedInitSlot int
 		}
 	}
 	require.Equal(t, expectedCall, actualCall)
-	require.Equal(t, expectedInitSlot, actualInitSlot)
+	require.True(t, expectedInitSlot == actualInitSlot)
 }
 
 func TestInline(t *testing.T) {
@@ -47,34 +47,34 @@ func TestInline(t *testing.T) {
 	t.Run("no return", func(t *testing.T) {
 		src := fmt.Sprintf(srcTmpl, `inline.NoArgsNoReturn()
 			return 1`)
-		checkCallCount(t, src, 0, 1)
+		checkCallCount(t, src, 0, 0)
 		eval(t, src, big.NewInt(1))
 	})
 	t.Run("has return, dropped", func(t *testing.T) {
 		src := fmt.Sprintf(srcTmpl, `inline.NoArgsReturn1()
 			return 2`)
-		checkCallCount(t, src, 0, 1)
+		checkCallCount(t, src, 0, 0)
 		eval(t, src, big.NewInt(2))
 	})
 	t.Run("drop twice", func(t *testing.T) {
 		src := fmt.Sprintf(srcTmpl, `inline.DropInsideInline()
 			return 42`)
-		checkCallCount(t, src, 0, 1)
+		checkCallCount(t, src, 0, 0)
 		eval(t, src, big.NewInt(42))
 	})
 	t.Run("no args return 1", func(t *testing.T) {
 		src := fmt.Sprintf(srcTmpl, `return inline.NoArgsReturn1()`)
-		checkCallCount(t, src, 0, 1)
+		checkCallCount(t, src, 0, 0)
 		eval(t, src, big.NewInt(1))
 	})
 	t.Run("sum", func(t *testing.T) {
 		src := fmt.Sprintf(srcTmpl, `return inline.Sum(1, 2)`)
-		checkCallCount(t, src, 0, 1)
+		checkCallCount(t, src, 0, 0)
 		eval(t, src, big.NewInt(3))
 	})
 	t.Run("sum squared (nested inline)", func(t *testing.T) {
 		src := fmt.Sprintf(srcTmpl, `return inline.SumSquared(1, 2)`)
-		checkCallCount(t, src, 0, 1)
+		checkCallCount(t, src, 0, 0)
 		eval(t, src, big.NewInt(9))
 	})
 	t.Run("inline function in inline function parameter", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestInline(t *testing.T) {
 	})
 	t.Run("global name clash", func(t *testing.T) {
 		src := fmt.Sprintf(srcTmpl, `return inline.GetSumSameName()`)
-		checkCallCount(t, src, 0, 1)
+		checkCallCount(t, src, 0, 0)
 		eval(t, src, big.NewInt(42))
 	})
 	t.Run("local name clash", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestInline(t *testing.T) {
 	})
 	t.Run("globals", func(t *testing.T) {
 		src := fmt.Sprintf(srcTmpl, `return inline.Concat(Num)`)
-		checkCallCount(t, src, 0, 1)
+		checkCallCount(t, src, 0, 0)
 		eval(t, src, big.NewInt(221))
 	})
 }

--- a/pkg/compiler/inline_test.go
+++ b/pkg/compiler/inline_test.go
@@ -113,6 +113,11 @@ func TestInline(t *testing.T) {
 		checkCallCount(t, src, 0, 0)
 		eval(t, src, big.NewInt(221))
 	})
+	t.Run("locals, alias", func(t *testing.T) {
+		src := fmt.Sprintf(srcTmpl, `num := 1; return inline.Concat(num)`)
+		checkCallCount(t, src, 0, 1)
+		eval(t, src, big.NewInt(221))
+	})
 }
 
 func TestInlineInLoop(t *testing.T) {

--- a/pkg/compiler/syscall_test.go
+++ b/pkg/compiler/syscall_test.go
@@ -191,6 +191,8 @@ func TestNotify(t *testing.T) {
 }
 
 func TestSyscallInGlobalInit(t *testing.T) {
+	// FIXME(fyrchik): count auxiliary inline locals for INITSLOT in global context
+	t.Skip()
 	src := `package foo
 		import "github.com/nspcc-dev/neo-go/pkg/interop/runtime"
 		var a = runtime.CheckWitness([]byte("5T"))

--- a/pkg/compiler/syscall_test.go
+++ b/pkg/compiler/syscall_test.go
@@ -191,8 +191,6 @@ func TestNotify(t *testing.T) {
 }
 
 func TestSyscallInGlobalInit(t *testing.T) {
-	// FIXME(fyrchik): count auxiliary inline locals for INITSLOT in global context
-	t.Skip()
 	src := `package foo
 		import "github.com/nspcc-dev/neo-go/pkg/interop/runtime"
 		var a = runtime.CheckWitness([]byte("5T"))


### PR DESCRIPTION
There are multiple cases:
1. For simple functions and `_deploy` their locals count is updated in `writeJumps`.
2. For `init` functions we accumulate locals count across the calls.
3. In addition to (2) when globals are initialized using inlined function, auxiliary locals need to be added as well.

Close #1878 .