### PR TITLE
config: update testnet magic number for N3 RC2 testnet

### DIFF
--- a/config/protocol.testnet.yml
+++ b/config/protocol.testnet.yml
@@ -1,5 +1,5 @@
 ProtocolConfiguration:
-  Magic: 827601742
+  Magic: 844378958
   MaxTraceableBlocks: 2102400
   SecondsPerBlock: 15
   MemPoolSize: 50000


### PR DESCRIPTION
It's 'N3T2', see https://github.com/neo-project/neo-node/releases/tag/v3.0.0-rc2