### PR TITLE
workflows: run Tests workflow on every push

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,10 +1,7 @@
 name: Tests
 
 on:
-  pull_request:
-    branches:
-      - master
-    types: [opened, synchronize]
+  push:
     paths-ignore:
       - 'scripts/**'
       - '**/*.md'


### PR DESCRIPTION
It's useful when someone wants to test changes without creating a PR.
Our circle-ci tests act like this, so let's unify the behaviour.