### PR TITLE
compiler: disallow `runtime.Notify` in `Verify` function

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -337,6 +337,12 @@ func isInitFunc(decl *ast.FuncDecl) bool {
 		decl.Type.Results.NumFields() == 0
 }
 
+func (c *codegen) isVerifyFunc(decl *ast.FuncDecl) bool {
+	return decl.Name.Name == "Verify" && decl.Recv == nil &&
+		decl.Type.Results.NumFields() == 1 &&
+		isBool(c.typeOf(decl.Type.Results.List[0].Type))
+}
+
 func (c *codegen) clearSlots(n int) {
 	for i := 0; i < n; i++ {
 		emit.Opcodes(c.prog.BinWriter, opcode.PUSHNULL)

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -59,6 +59,7 @@ type Options struct {
 type buildInfo struct {
 	initialPackage string
 	program        *loader.Program
+	options        *Options
 }
 
 // ForEachPackage executes fn on each package used in the current program
@@ -153,10 +154,18 @@ func Compile(name string, r io.Reader) ([]byte, error) {
 
 // CompileWithDebugInfo compiles a Go program into bytecode and emits debug info.
 func CompileWithDebugInfo(name string, r io.Reader) ([]byte, *DebugInfo, error) {
+	return CompileWithOptions(name, r, &Options{
+		NoEventsCheck: true,
+	})
+}
+
+// CompileWithOptions compiles a Go program into bytecode with provided compiler options.
+func CompileWithOptions(name string, r io.Reader, o *Options) ([]byte, *DebugInfo, error) {
 	ctx, err := getBuildInfo(name, r)
 	if err != nil {
 		return nil, nil, err
 	}
+	ctx.options = o
 	return CodeGen(ctx)
 }
 
@@ -173,7 +182,7 @@ func CompileAndSave(src string, o *Options) ([]byte, error) {
 	if len(o.Ext) == 0 {
 		o.Ext = fileExt
 	}
-	b, di, err := CompileWithDebugInfo(src, nil)
+	b, di, err := CompileWithOptions(src, nil, o)
 	if err != nil {
 		return nil, fmt.Errorf("error while trying to compile smart contract file: %w", err)
 	}


### PR DESCRIPTION
Only direct invocations are considered. The check can be disabled
with '--no-events' compiler option.

Close #1994 .

I have been thinking about introducing generic warnings mechanism but stopped, because our compiler doesn't seem _that_ complicated. It could be used e.g. in #1990, but I haven't yet come up with more cases for it to be useful.
