### PR TITLE
network: drop useless flag check

### DIFF
--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -171,9 +171,7 @@ func newServerFromConstructors(config ServerConfig, chain blockchainer.Blockchai
 		return nil, errors.New("P2PSigExtensions are disabled, but Notary service is enable")
 	}
 	s.bQueue = newBlockQueue(maxBlockBatch, chain, log, func(b *block.Block) {
-		if !s.syncReached.Load() {
-			s.tryStartServices()
-		}
+		s.tryStartServices()
 	})
 
 	if config.StateRootCfg.Enabled && chain.GetConfig().StateRootInHeader {


### PR DESCRIPTION
It's the first thing done in tryStartServices(), so checking it here doesn't
make much sense.