### PR TITLE
rpc: wrap calculatenetworkfee result in a structure

### DIFF
--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -34,12 +34,12 @@ var errNetworkNotInitialized = errors.New("RPC client network is not initialized
 func (c *Client) CalculateNetworkFee(tx *transaction.Transaction) (int64, error) {
 	var (
 		params = request.NewRawParams(tx.Bytes())
-		resp   int64
+		resp   = new(result.NetworkFee)
 	)
-	if err := c.performRequest("calculatenetworkfee", params, &resp); err != nil {
+	if err := c.performRequest("calculatenetworkfee", params, resp); err != nil {
 		return 0, err
 	}
-	return resp, nil
+	return resp.Value, nil
 }
 
 // GetApplicationLog returns the contract log based on the specified txid.

--- a/pkg/rpc/response/result/netfee.go
+++ b/pkg/rpc/response/result/netfee.go
@@ -1,0 +1,6 @@
+package result
+
+// NetworkFee represents a result of calculatenetworkfee RPC call.
+type NetworkFee struct {
+	Value int64 `json:"networkfee,string"`
+}

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -630,7 +630,7 @@ func (s *Server) calculateNetworkFee(reqParams request.Params) (interface{}, *re
 	}
 	fee := s.chain.GetPolicer().FeePerByte()
 	netFee += int64(size) * fee
-	return netFee, nil
+	return result.NetworkFee{Value: netFee}, nil
 }
 
 // getApplicationLog returns the contract log based on the specified txid or blockid.


### PR DESCRIPTION
C#:
{
  "jsonrpc": "2.0",
  "id": 2,
  "result": {
    "networkfee": "1185120"
  }
}

Go:
{
  "id": 2,
  "jsonrpc": "2.0",
  "result": 1185120
}

Thanks @csmuller for finding it.
