### PR TITLE
examples: use base64 encoding to create HASHY token ID

### DIFF
--- a/cli/nep11_test.go
+++ b/cli/nep11_test.go
@@ -125,7 +125,6 @@ func TestNEP11_OwnerOf_BalanceOf_Transfer(t *testing.T) {
 		e.Run(t, "neo-go", "wallet", "nep17", "transfer",
 			"--rpc-endpoint", "http://"+e.RPC.Addr,
 			"--wallet", wall,
-			"--gas", "0.001", // test fails sometimes running out of GAS
 			"--to", h.StringLE(),
 			"--token", "GAS",
 			"--amount", "10",

--- a/cli/nep11_test.go
+++ b/cli/nep11_test.go
@@ -214,7 +214,7 @@ func TestNEP11_OwnerOf_BalanceOf_Transfer(t *testing.T) {
 
 	// tokensOf: good
 	e.Run(t, cmdTokensOf...)
-	e.checkNextLine(t, string(tokenID))
+	require.Equal(t, string(tokenID), e.getNextLine(t))
 
 	// properties: no contract
 	cmdProperties := []string{
@@ -240,8 +240,8 @@ func TestNEP11_OwnerOf_BalanceOf_Transfer(t *testing.T) {
 		fst, snd = snd, fst
 	}
 
-	e.checkNextLine(t, string(fst))
-	e.checkNextLine(t, string(snd))
+	require.Equal(t, string(fst), e.getNextLine(t))
+	require.Equal(t, string(snd), e.getNextLine(t))
 
 	// tokens: missing contract hash
 	cmdTokens := []string{"neo-go", "wallet", "nep11", "tokens",
@@ -252,8 +252,8 @@ func TestNEP11_OwnerOf_BalanceOf_Transfer(t *testing.T) {
 
 	// tokens: good, several tokens
 	e.Run(t, cmdTokens...)
-	e.checkNextLine(t, string(fst))
-	e.checkNextLine(t, string(snd))
+	require.Equal(t, string(fst), e.getNextLine(t))
+	require.Equal(t, string(snd), e.getNextLine(t))
 
 	// balance check: several tokens, ok
 	e.Run(t, append(cmdCheckBalance, "--token", h.StringLE())...)

--- a/examples/nft-nd/nft.go
+++ b/examples/nft-nd/nft.go
@@ -2,7 +2,7 @@
 Package nft contains non-divisible non-fungible NEP11-compatible token
 implementation. This token can be minted with GAS transfer to contract address,
 it will hash some data (including data provided in transfer) and produce
-base58-encoded string that is your NFT. Since it's based on hashing and basically
+base64-encoded string that is your NFT. Since it's based on hashing and basically
 you own a hash it's HASHY.
 */
 package nft
@@ -230,7 +230,7 @@ func OnNEP17Payment(from interop.Hash160, amount int, data interface{}) {
 	}
 
 	tokenHash := crypto.Ripemd160(tokIn)
-	token := std.Base58Encode(tokenHash)
+	token := std.Base64Encode(tokenHash)
 
 	addToken(ctx, from, []byte(token))
 	setOwnerOf(ctx, []byte(token), from)


### PR DESCRIPTION
### Problem

Test `TestNEP11_OwnerOf_BalanceOf_Transfer` fails due to insufficient system fee while minting HASHY token.

### Solution

Use constant-length token IDs.
