### PR TITLE
core, network: implement P2P state exchange

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -114,7 +114,11 @@ balance won't be shown in the list of NEP17 balances returned by the neo-go node
 (unlike the C# node behavior). However, transfer logs of such token are still
 available via `getnep17transfers` RPC call.
 
-The behaviour of the `LastUpdatedBlock` tracking matches the C# node's one.
+The behaviour of the `LastUpdatedBlock` tracking for archival nodes as far as for
+governing token balances matches the C# node's one. For non-archival nodes and
+other NEP17-compliant tokens if transfer's `LastUpdatedBlock` is lower than the
+latest state synchronization point P the node working against, then
+`LastUpdatedBlock` equals P.
 
 ### Unsupported methods
 

--- a/internal/fakechain/fakechain.go
+++ b/internal/fakechain/fakechain.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/blockchainer/services"
 	"github.com/nspcc-dev/neo-go/pkg/core/interop"
 	"github.com/nspcc-dev/neo-go/pkg/core/mempool"
+	"github.com/nspcc-dev/neo-go/pkg/core/mpt"
 	"github.com/nspcc-dev/neo-go/pkg/core/native"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
@@ -40,6 +41,13 @@ type FakeChain struct {
 	NotaryDepositExpiration  uint32
 	PostBlock                []func(blockchainer.Blockchainer, *mempool.Pool, *block.Block)
 	UtilityTokenBalance      *big.Int
+}
+
+// FakeStateSync implements StateSync interface.
+type FakeStateSync struct {
+	IsActiveFlag      bool
+	IsInitializedFlag bool
+	InitFunc          func(h uint32) error
 }
 
 // NewFakeChain returns new FakeChain structure.
@@ -294,6 +302,16 @@ func (chain *FakeChain) GetStateModule() blockchainer.StateRoot {
 	return nil
 }
 
+// GetStateSyncModule implements Blockchainer interface.
+func (chain *FakeChain) GetStateSyncModule() blockchainer.StateSync {
+	return &FakeStateSync{}
+}
+
+// JumpToState implements Blockchainer interface.
+func (chain *FakeChain) JumpToState(module blockchainer.StateSync) error {
+	panic("TODO")
+}
+
 // GetStorageItem implements Blockchainer interface.
 func (chain *FakeChain) GetStorageItem(id int32, key []byte) state.StorageItem {
 	panic("TODO")
@@ -434,5 +452,59 @@ func (chain *FakeChain) UnsubscribeFromNotifications(ch chan<- *state.Notificati
 
 // UnsubscribeFromTransactions implements Blockchainer interface.
 func (chain *FakeChain) UnsubscribeFromTransactions(ch chan<- *transaction.Transaction) {
+	panic("TODO")
+}
+
+// AddBlock implements StateSync interface.
+func (s *FakeStateSync) AddBlock(block *block.Block) error {
+	panic("TODO")
+}
+
+// AddHeaders implements StateSync interface.
+func (s *FakeStateSync) AddHeaders(...*block.Header) error {
+	panic("TODO")
+}
+
+// AddMPTNodes implements StateSync interface.
+func (s *FakeStateSync) AddMPTNodes([][]byte) error {
+	panic("TODO")
+}
+
+// BlockHeight implements StateSync interface.
+func (s *FakeStateSync) BlockHeight() uint32 {
+	panic("TODO")
+}
+
+// IsActive implements StateSync interface.
+func (s *FakeStateSync) IsActive() bool { return s.IsActiveFlag }
+
+// IsInitialized implements StateSync interface.
+func (s *FakeStateSync) IsInitialized() bool {
+	return s.IsInitializedFlag
+}
+
+// Init implements StateSync interface.
+func (s *FakeStateSync) Init(currChainHeight uint32) error {
+	if s.InitFunc != nil {
+		return s.InitFunc(currChainHeight)
+	}
+	panic("TODO")
+}
+
+// NeedHeaders implements StateSync interface.
+func (s *FakeStateSync) NeedHeaders() bool { return false }
+
+// NeedMPTNodes implements StateSync interface.
+func (s *FakeStateSync) NeedMPTNodes() bool {
+	panic("TODO")
+}
+
+// Traverse implements StateSync interface.
+func (s *FakeStateSync) Traverse(root util.Uint256, process func(node mpt.Node, nodeBytes []byte) bool) error {
+	panic("TODO")
+}
+
+// GetJumpHeight implements StateSync interface.
+func (s *FakeStateSync) GetJumpHeight() (uint32, error) {
 	panic("TODO")
 }

--- a/internal/fakechain/fakechain.go
+++ b/internal/fakechain/fakechain.go
@@ -307,11 +307,6 @@ func (chain *FakeChain) GetStateSyncModule() blockchainer.StateSync {
 	return &FakeStateSync{}
 }
 
-// JumpToState implements Blockchainer interface.
-func (chain *FakeChain) JumpToState(module blockchainer.StateSync) error {
-	panic("TODO")
-}
-
 // GetStorageItem implements Blockchainer interface.
 func (chain *FakeChain) GetStorageItem(id int32, key []byte) state.StorageItem {
 	panic("TODO")
@@ -501,11 +496,6 @@ func (s *FakeStateSync) NeedMPTNodes() bool {
 
 // Traverse implements StateSync interface.
 func (s *FakeStateSync) Traverse(root util.Uint256, process func(node mpt.Node, nodeBytes []byte) bool) error {
-	panic("TODO")
-}
-
-// GetJumpHeight implements StateSync interface.
-func (s *FakeStateSync) GetJumpHeight() (uint32, error) {
 	panic("TODO")
 }
 

--- a/internal/fakechain/fakechain.go
+++ b/internal/fakechain/fakechain.go
@@ -508,3 +508,8 @@ func (s *FakeStateSync) Traverse(root util.Uint256, process func(node mpt.Node, 
 func (s *FakeStateSync) GetJumpHeight() (uint32, error) {
 	panic("TODO")
 }
+
+// GetUnknownMPTNodesBatch implements StateSync interface.
+func (s *FakeStateSync) GetUnknownMPTNodesBatch(limit int) []util.Uint256 {
+	panic("TODO")
+}

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -310,16 +310,6 @@ func (bc *Blockchain) init() error {
 	// and the genesis block as first block.
 	bc.log.Info("restoring blockchain", zap.String("version", version))
 
-	bHeight, err := bc.dao.GetCurrentBlockHeight()
-	if err != nil {
-		return err
-	}
-	bc.blockHeight = bHeight
-	bc.persistedHeight = bHeight
-	if err = bc.stateRoot.Init(bHeight, bc.config.KeepOnlyLatestState); err != nil {
-		return fmt.Errorf("can't init MPT at height %d: %w", bHeight, err)
-	}
-
 	bc.headerHashes, err = bc.dao.GetHeaderHashes()
 	if err != nil {
 		return err
@@ -365,6 +355,16 @@ func (bc *Blockchain) init() error {
 		for _, h := range headers {
 			bc.headerHashes = append(bc.headerHashes, h.Hash())
 		}
+	}
+
+	bHeight, err := bc.dao.GetCurrentBlockHeight()
+	if err != nil {
+		return err
+	}
+	bc.blockHeight = bHeight
+	bc.persistedHeight = bHeight
+	if err = bc.stateRoot.Init(bHeight, bc.config.KeepOnlyLatestState); err != nil {
+		return fmt.Errorf("can't init MPT at height %d: %w", bHeight, err)
 	}
 
 	err = bc.contracts.NEO.InitializeCache(bc, bc.dao)

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -411,17 +411,13 @@ func (bc *Blockchain) init() error {
 	return bc.updateExtensibleWhitelist(bHeight)
 }
 
-// JumpToState is an atomic operation that changes Blockchain state to the one
+// jumpToState is an atomic operation that changes Blockchain state to the one
 // specified by the state sync point p. All the data needed for the jump must be
 // collected by the state sync module.
-func (bc *Blockchain) JumpToState(module blockchainer.StateSync) error {
+func (bc *Blockchain) jumpToState(p uint32) error {
 	bc.lock.Lock()
 	defer bc.lock.Unlock()
 
-	p, err := module.GetJumpHeight()
-	if err != nil {
-		return fmt.Errorf("failed to get jump height: %w", err)
-	}
 	if p+1 >= uint32(len(bc.headerHashes)) {
 		return fmt.Errorf("invalid state sync point")
 	}
@@ -792,7 +788,7 @@ func (bc *Blockchain) GetStateModule() blockchainer.StateRoot {
 
 // GetStateSyncModule returns new state sync service instance.
 func (bc *Blockchain) GetStateSyncModule() blockchainer.StateSync {
-	return statesync.NewModule(bc, bc.log, bc.dao)
+	return statesync.NewModule(bc, bc.log, bc.dao, bc.jumpToState)
 }
 
 // storeBlock performs chain update using the block given, it executes all

--- a/pkg/core/blockchainer/blockchainer.go
+++ b/pkg/core/blockchainer/blockchainer.go
@@ -60,7 +60,6 @@ type Blockchainer interface {
 	GetStorageItems(id int32) (map[string]state.StorageItem, error)
 	GetTestVM(t trigger.Type, tx *transaction.Transaction, b *block.Block) *vm.VM
 	GetTransaction(util.Uint256) (*transaction.Transaction, uint32, error)
-	JumpToState(module StateSync) error
 	SetOracle(service services.Oracle)
 	mempool.Feer // fee interface
 	ManagementContractHash() util.Uint160

--- a/pkg/core/blockchainer/blockchainer.go
+++ b/pkg/core/blockchainer/blockchainer.go
@@ -21,7 +21,6 @@ import (
 type Blockchainer interface {
 	ApplyPolicyToTxSet([]*transaction.Transaction) []*transaction.Transaction
 	GetConfig() config.ProtocolConfiguration
-	AddHeaders(...*block.Header) error
 	Blockqueuer // Blockqueuer interface
 	CalculateClaimable(h util.Uint160, endHeight uint32) (*big.Int, error)
 	Close()
@@ -56,10 +55,12 @@ type Blockchainer interface {
 	GetStandByCommittee() keys.PublicKeys
 	GetStandByValidators() keys.PublicKeys
 	GetStateModule() StateRoot
+	GetStateSyncModule() StateSync
 	GetStorageItem(id int32, key []byte) state.StorageItem
 	GetStorageItems(id int32) (map[string]state.StorageItem, error)
 	GetTestVM(t trigger.Type, tx *transaction.Transaction, b *block.Block) *vm.VM
 	GetTransaction(util.Uint256) (*transaction.Transaction, uint32, error)
+	JumpToState(module StateSync) error
 	SetOracle(service services.Oracle)
 	mempool.Feer // fee interface
 	ManagementContractHash() util.Uint160

--- a/pkg/core/blockchainer/blockqueuer.go
+++ b/pkg/core/blockchainer/blockqueuer.go
@@ -5,5 +5,6 @@ import "github.com/nspcc-dev/neo-go/pkg/core/block"
 // Blockqueuer is an interface for blockqueue.
 type Blockqueuer interface {
 	AddBlock(block *block.Block) error
+	AddHeaders(...*block.Header) error
 	BlockHeight() uint32
 }

--- a/pkg/core/blockchainer/state_root.go
+++ b/pkg/core/blockchainer/state_root.go
@@ -9,6 +9,7 @@ import (
 // StateRoot represents local state root module.
 type StateRoot interface {
 	AddStateRoot(root *state.MPTRoot) error
+	CurrentLocalHeight() uint32
 	CurrentLocalStateRoot() util.Uint256
 	CurrentValidatedHeight() uint32
 	GetStateProof(root util.Uint256, key []byte) ([][]byte, error)

--- a/pkg/core/blockchainer/state_root.go
+++ b/pkg/core/blockchainer/state_root.go
@@ -9,6 +9,7 @@ import (
 // StateRoot represents local state root module.
 type StateRoot interface {
 	AddStateRoot(root *state.MPTRoot) error
+	CleanStorage() error
 	CurrentLocalHeight() uint32
 	CurrentLocalStateRoot() util.Uint256
 	CurrentValidatedHeight() uint32

--- a/pkg/core/blockchainer/state_sync.go
+++ b/pkg/core/blockchainer/state_sync.go
@@ -13,6 +13,7 @@ type StateSync interface {
 	IsActive() bool
 	IsInitialized() bool
 	GetJumpHeight() (uint32, error)
+	GetUnknownMPTNodesBatch(limit int) []util.Uint256
 	NeedHeaders() bool
 	NeedMPTNodes() bool
 	Traverse(root util.Uint256, process func(node mpt.Node, nodeBytes []byte) bool) error

--- a/pkg/core/blockchainer/state_sync.go
+++ b/pkg/core/blockchainer/state_sync.go
@@ -12,7 +12,6 @@ type StateSync interface {
 	Init(currChainHeight uint32) error
 	IsActive() bool
 	IsInitialized() bool
-	GetJumpHeight() (uint32, error)
 	GetUnknownMPTNodesBatch(limit int) []util.Uint256
 	NeedHeaders() bool
 	NeedMPTNodes() bool

--- a/pkg/core/blockchainer/state_sync.go
+++ b/pkg/core/blockchainer/state_sync.go
@@ -1,0 +1,19 @@
+package blockchainer
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/core/mpt"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+// StateSync represents state sync module.
+type StateSync interface {
+	AddMPTNodes([][]byte) error
+	Blockqueuer // Blockqueuer interface
+	Init(currChainHeight uint32) error
+	IsActive() bool
+	IsInitialized() bool
+	GetJumpHeight() (uint32, error)
+	NeedHeaders() bool
+	NeedMPTNodes() bool
+	Traverse(root util.Uint256, process func(node mpt.Node, nodeBytes []byte) bool) error
+}

--- a/pkg/core/mpt/billet.go
+++ b/pkg/core/mpt/billet.go
@@ -215,7 +215,7 @@ func (b *Billet) traverse(curr Node, process func(node Node, nodeBytes []byte) b
 		return curr, nil
 	}
 	if hn, ok := curr.(*HashNode); ok {
-		r, err := b.getFromStore(hn.Hash())
+		r, err := b.GetFromStore(hn.Hash())
 		if err != nil {
 			if ignoreStorageErr && errors.Is(err, storage.ErrKeyNotFound) {
 				return hn, nil
@@ -292,7 +292,8 @@ func (b *Billet) tryCollapseBranch(curr *BranchNode) Node {
 	return res
 }
 
-func (b *Billet) getFromStore(h util.Uint256) (Node, error) {
+// GetFromStore returns MPT node from the storage.
+func (b *Billet) GetFromStore(h util.Uint256) (Node, error) {
 	data, err := b.Store.Get(makeStorageKey(h.BytesBE()))
 	if err != nil {
 		return nil, err

--- a/pkg/core/mpt/billet.go
+++ b/pkg/core/mpt/billet.go
@@ -62,9 +62,9 @@ func (b *Billet) RestoreHashNode(path []byte, node Node) error {
 	}
 	b.root = r
 
-	// If it's a leaf, then put into contract storage.
+	// If it's a leaf, then put into temporary contract storage.
 	if leaf, ok := node.(*LeafNode); ok {
-		k := append([]byte{byte(storage.STStorage)}, fromNibbles(path)...)
+		k := append([]byte{byte(storage.STTempStorage)}, fromNibbles(path)...)
 		_ = b.Store.Put(k, leaf.value)
 	}
 	return nil

--- a/pkg/core/mpt/billet.go
+++ b/pkg/core/mpt/billet.go
@@ -1,0 +1,261 @@
+package mpt
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/nspcc-dev/neo-go/pkg/core/storage"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/util/slice"
+)
+
+var (
+	// ErrRestoreFailed is returned when replacing HashNode by its "unhashed"
+	// candidate fails.
+	ErrRestoreFailed = errors.New("failed to restore MPT node")
+	errStop          = errors.New("stop condition is met")
+)
+
+// Billet is a part of MPT trie with missing hash nodes that need to be restored.
+// Billet is based on the following assumptions:
+// 1. Refcount can only be incremented (we don't change MPT structure during restore,
+//    thus don't need to decrease refcount).
+// 2. TODO: Each time the part of Billet is completely restored, it is collapsed into HashNode.
+type Billet struct {
+	Store *storage.MemCachedStore
+
+	root            Node
+	refcountEnabled bool
+}
+
+// NewBillet returns new billet for MPT trie restoring. It accepts a MemCachedStore
+// to decouple storage errors from logic errors so that all storage errors are
+// processed during `store.Persist()` at the caller. This also has the benefit,
+// that every `Put` can be considered an atomic operation.
+func NewBillet(rootHash util.Uint256, enableRefCount bool, store *storage.MemCachedStore) *Billet {
+	return &Billet{
+		Store:           store,
+		root:            NewHashNode(rootHash),
+		refcountEnabled: enableRefCount,
+	}
+}
+
+// RestoreHashNode replaces HashNode located at the provided path by the specified Node
+// and stores it.
+// TODO: It also maintains MPT as small as possible by collapsing those parts
+// of MPT that have been completely restored.
+func (b *Billet) RestoreHashNode(path []byte, node Node) error {
+	if _, ok := node.(*HashNode); ok {
+		return fmt.Errorf("%w: unable to restore node into HashNode", ErrRestoreFailed)
+	}
+	if _, ok := node.(EmptyNode); ok {
+		return fmt.Errorf("%w: unable to restore node into EmptyNode", ErrRestoreFailed)
+	}
+	r, err := b.putIntoNode(b.root, path, node)
+	if err != nil {
+		return err
+	}
+	b.root = r
+
+	// If it's a leaf, then put into contract storage.
+	if leaf, ok := node.(*LeafNode); ok {
+		k := append([]byte{byte(storage.STStorage)}, fromNibbles(path)...)
+		_ = b.Store.Put(k, leaf.value)
+	}
+	return nil
+}
+
+// putIntoNode puts val with provided path inside curr and returns updated node.
+// Reference counters are updated for both curr and returned value.
+func (b *Billet) putIntoNode(curr Node, path []byte, val Node) (Node, error) {
+	switch n := curr.(type) {
+	case *LeafNode:
+		return b.putIntoLeaf(n, path, val)
+	case *BranchNode:
+		return b.putIntoBranch(n, path, val)
+	case *ExtensionNode:
+		return b.putIntoExtension(n, path, val)
+	case *HashNode:
+		return b.putIntoHash(n, path, val)
+	case EmptyNode:
+		return nil, fmt.Errorf("%w: can't modify EmptyNode during restore", ErrRestoreFailed)
+	default:
+		panic("invalid MPT node type")
+	}
+}
+
+func (b *Billet) putIntoLeaf(curr *LeafNode, path []byte, val Node) (Node, error) {
+	if len(path) != 0 {
+		return nil, fmt.Errorf("%w: can't modify LeafNode during restore", ErrRestoreFailed)
+	}
+	if curr.Hash() != val.Hash() {
+		return nil, fmt.Errorf("%w: bad Leaf node hash: expected %s, got %s", ErrRestoreFailed, curr.Hash().StringBE(), val.Hash().StringBE())
+	}
+	// this node has already been restored, no refcount changes required
+	return curr, nil
+}
+
+func (b *Billet) putIntoBranch(curr *BranchNode, path []byte, val Node) (Node, error) {
+	if len(path) == 0 && curr.Hash().Equals(val.Hash()) {
+		// this node has already been restored, no refcount changes required
+		return curr, nil
+	}
+	i, path := splitPath(path)
+	r, err := b.putIntoNode(curr.Children[i], path, val)
+	if err != nil {
+		return nil, err
+	}
+	curr.Children[i] = r
+	return curr, nil
+}
+
+func (b *Billet) putIntoExtension(curr *ExtensionNode, path []byte, val Node) (Node, error) {
+	if len(path) == 0 {
+		if curr.Hash() != val.Hash() {
+			return nil, fmt.Errorf("%w: bad Extension node hash: expected %s, got %s", ErrRestoreFailed, curr.Hash().StringBE(), val.Hash().StringBE())
+		}
+		// this node has already been restored, no refcount changes required
+		return curr, nil
+	}
+	if !bytes.HasPrefix(path, curr.key) {
+		return nil, fmt.Errorf("%w: can't modify ExtensionNode during restore", ErrRestoreFailed)
+	}
+
+	r, err := b.putIntoNode(curr.next, path[len(curr.key):], val)
+	if err != nil {
+		return nil, err
+	}
+	curr.next = r
+	return curr, nil
+}
+
+func (b *Billet) putIntoHash(curr *HashNode, path []byte, val Node) (Node, error) {
+	// Once the part of MPT Billet is completely restored, it will be collapsed forever, so
+	// it's an MPT pool duty to avoid duplicating restore requests.
+	if len(path) != 0 {
+		return nil, fmt.Errorf("%w: node has already been collapsed", ErrRestoreFailed)
+	}
+
+	// `curr` hash node can be either of
+	// 1) saved in storage (i.g. if we've already restored node with the same hash from the
+	//    other part of MPT), so just add it to local in-memory MPT.
+	// 2) missing from the storage. It's OK because we're syncing MPT state, and the purpose
+	//    is to store missing hash nodes.
+	// both cases are OK, but we still need to validate `val` against `curr`.
+	if val.Hash() != curr.Hash() {
+		return nil, fmt.Errorf("%w: can't restore HashNode: expected and actual hashes mismatch (%s vs %s)", ErrRestoreFailed, curr.Hash().StringBE(), val.Hash().StringBE())
+	}
+	// We also need to increment refcount in both cases. That's the only place where refcount
+	// is changed during restore process. Also flush right now, because sync process can be
+	// interrupted at any time.
+	b.incrementRefAndStore(val.Hash(), val.Bytes())
+	return val, nil
+}
+
+func (b *Billet) incrementRefAndStore(h util.Uint256, bs []byte) {
+	key := makeStorageKey(h.BytesBE())
+	if b.refcountEnabled {
+		var (
+			err  error
+			data []byte
+			cnt  int32
+		)
+		// An item may already be in store.
+		data, err = b.Store.Get(key)
+		if err == nil {
+			cnt = int32(binary.LittleEndian.Uint32(data[len(data)-4:]))
+		}
+		cnt++
+		if len(data) == 0 {
+			data = append(bs, 0, 0, 0, 0)
+		}
+		binary.LittleEndian.PutUint32(data[len(data)-4:], uint32(cnt))
+		_ = b.Store.Put(key, data)
+	} else {
+		_ = b.Store.Put(key, bs)
+	}
+}
+
+// Traverse traverses MPT nodes (pre-order) starting from the billet root down
+// to its children calling `process` for each serialised node until true is
+// returned from `process` function. It also replaces all HashNodes to their
+// "unhashed" counterparts until the stop condition is satisfied.
+func (b *Billet) Traverse(process func(node Node, nodeBytes []byte) bool, ignoreStorageErr bool) error {
+	r, err := b.traverse(b.root, process, ignoreStorageErr)
+	if err != nil && !errors.Is(err, errStop) {
+		return err
+	}
+	b.root = r
+	return nil
+}
+
+func (b *Billet) traverse(curr Node, process func(node Node, nodeBytes []byte) bool, ignoreStorageErr bool) (Node, error) {
+	if _, ok := curr.(EmptyNode); ok {
+		// We're not interested in EmptyNodes, and they do not affect the
+		// traversal process, thus remain them untouched.
+		return curr, nil
+	}
+	if hn, ok := curr.(*HashNode); ok {
+		r, err := b.getFromStore(hn.Hash())
+		if err != nil {
+			if ignoreStorageErr && errors.Is(err, storage.ErrKeyNotFound) {
+				return hn, nil
+			}
+			return nil, err
+		}
+		return b.traverse(r, process, ignoreStorageErr)
+	}
+	bytes := slice.Copy(curr.Bytes())
+	if process(curr, bytes) {
+		return curr, errStop
+	}
+	switch n := curr.(type) {
+	case *LeafNode:
+		return n, nil
+	case *BranchNode:
+		for i := range n.Children {
+			r, err := b.traverse(n.Children[i], process, ignoreStorageErr)
+			if err != nil {
+				if !errors.Is(err, errStop) {
+					return nil, err
+				}
+				n.Children[i] = r
+				return n, err
+			}
+			n.Children[i] = r
+		}
+		return n, nil
+	case *ExtensionNode:
+		r, err := b.traverse(n.next, process, ignoreStorageErr)
+		if err != nil && !errors.Is(err, errStop) {
+			return nil, err
+		}
+		n.next = r
+		return n, err
+	default:
+		return nil, ErrNotFound
+	}
+}
+
+func (b *Billet) getFromStore(h util.Uint256) (Node, error) {
+	data, err := b.Store.Get(makeStorageKey(h.BytesBE()))
+	if err != nil {
+		return nil, err
+	}
+
+	var n NodeObject
+	r := io.NewBinReaderFromBuf(data)
+	n.DecodeBinary(r)
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	if b.refcountEnabled {
+		data = data[:len(data)-4]
+	}
+	n.Node.(flushedNode).setCache(data, h)
+	return n.Node, nil
+}

--- a/pkg/core/mpt/billet_test.go
+++ b/pkg/core/mpt/billet_test.go
@@ -1,0 +1,211 @@
+package mpt
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/core/storage"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBillet_RestoreHashNode(t *testing.T) {
+	check := func(t *testing.T, tr *Billet, expectedRoot Node, expectedNode Node, expectedRefCount uint32) {
+		_ = expectedRoot.Hash()
+		_ = tr.root.Hash()
+		require.Equal(t, expectedRoot, tr.root)
+		expectedBytes, err := tr.Store.Get(makeStorageKey(expectedNode.Hash().BytesBE()))
+		if expectedRefCount != 0 {
+			require.NoError(t, err)
+			require.Equal(t, expectedRefCount, binary.LittleEndian.Uint32(expectedBytes[len(expectedBytes)-4:]))
+		} else {
+			require.True(t, errors.Is(err, storage.ErrKeyNotFound))
+		}
+	}
+
+	t.Run("parent is Extension", func(t *testing.T) {
+		t.Run("restore Branch", func(t *testing.T) {
+			b := NewBranchNode()
+			b.Children[0] = NewExtensionNode([]byte{0x01}, NewLeafNode([]byte{0xAB, 0xCD}))
+			b.Children[5] = NewExtensionNode([]byte{0x01}, NewLeafNode([]byte{0xAB, 0xDE}))
+			path := toNibbles([]byte{0xAC})
+			e := NewExtensionNode(path, NewHashNode(b.Hash()))
+			tr := NewBillet(e.Hash(), true, newTestStore())
+			tr.root = e
+
+			// OK
+			n := new(NodeObject)
+			n.DecodeBinary(io.NewBinReaderFromBuf(b.Bytes()))
+			require.NoError(t, tr.RestoreHashNode(path, n.Node))
+			expected := NewExtensionNode(path, n.Node)
+			check(t, tr, expected, n.Node, 1)
+
+			// One more time (already restored) => panic expected, no refcount changes
+			require.Panics(t, func() {
+				_ = tr.RestoreHashNode(path, n.Node)
+			})
+			check(t, tr, expected, n.Node, 1)
+
+			// Same path, but wrong hash => error expected, no refcount changes
+			require.True(t, errors.Is(tr.RestoreHashNode(path, NewBranchNode()), ErrRestoreFailed))
+			check(t, tr, expected, n.Node, 1)
+
+			// New path (changes in the MPT structure are not allowed) => error expected, no refcount changes
+			require.True(t, errors.Is(tr.RestoreHashNode(toNibbles([]byte{0xAB}), n.Node), ErrRestoreFailed))
+			check(t, tr, expected, n.Node, 1)
+		})
+
+		t.Run("restore Leaf", func(t *testing.T) {
+			l := NewLeafNode([]byte{0xAB, 0xCD})
+			path := toNibbles([]byte{0xAC})
+			e := NewExtensionNode(path, NewHashNode(l.Hash()))
+			tr := NewBillet(e.Hash(), true, newTestStore())
+			tr.root = e
+
+			// OK
+			require.NoError(t, tr.RestoreHashNode(path, l))
+			expected := NewHashNode(e.Hash()) // leaf should be collapsed immediately => extension should also be collapsed
+			expected.Collapsed = true
+			check(t, tr, expected, l, 1)
+
+			// One more time (already restored and collapsed) => error expected, no refcount changes
+			require.Error(t, tr.RestoreHashNode(path, l))
+			check(t, tr, expected, l, 1)
+
+			// Same path, but wrong hash => error expected, no refcount changes
+			require.True(t, errors.Is(tr.RestoreHashNode(path, NewLeafNode([]byte{0xAB, 0xEF})), ErrRestoreFailed))
+			check(t, tr, expected, l, 1)
+
+			// New path (changes in the MPT structure are not allowed) => error expected, no refcount changes
+			require.True(t, errors.Is(tr.RestoreHashNode(toNibbles([]byte{0xAB}), l), ErrRestoreFailed))
+			check(t, tr, expected, l, 1)
+		})
+
+		t.Run("restore Hash", func(t *testing.T) {
+			h := NewHashNode(util.Uint256{1, 2, 3})
+			path := toNibbles([]byte{0xAC})
+			e := NewExtensionNode(path, h)
+			tr := NewBillet(e.Hash(), true, newTestStore())
+			tr.root = e
+
+			// no-op
+			require.True(t, errors.Is(tr.RestoreHashNode(path, h), ErrRestoreFailed))
+			check(t, tr, e, h, 0)
+		})
+	})
+
+	t.Run("parent is Leaf", func(t *testing.T) {
+		l := NewLeafNode([]byte{0xAB, 0xCD})
+		path := []byte{}
+		tr := NewBillet(l.Hash(), true, newTestStore())
+		tr.root = l
+
+		// Already restored => panic expected
+		require.Panics(t, func() {
+			_ = tr.RestoreHashNode(path, l)
+		})
+
+		// Same path, but wrong hash => error expected, no refcount changes
+		require.True(t, errors.Is(tr.RestoreHashNode(path, NewLeafNode([]byte{0xAB, 0xEF})), ErrRestoreFailed))
+
+		// Non-nil path, but MPT structure can't be changed => error expected, no refcount changes
+		require.True(t, errors.Is(tr.RestoreHashNode(toNibbles([]byte{0xAC}), NewLeafNode([]byte{0xAB, 0xEF})), ErrRestoreFailed))
+	})
+
+	t.Run("parent is Branch", func(t *testing.T) {
+		t.Run("middle child", func(t *testing.T) {
+			l1 := NewLeafNode([]byte{0xAB, 0xCD})
+			l2 := NewLeafNode([]byte{0xAB, 0xDE})
+			b := NewBranchNode()
+			b.Children[5] = NewHashNode(l1.Hash())
+			b.Children[lastChild] = NewHashNode(l2.Hash())
+			tr := NewBillet(b.Hash(), true, newTestStore())
+			tr.root = b
+
+			// OK
+			path := []byte{0x05}
+			require.NoError(t, tr.RestoreHashNode(path, l1))
+			check(t, tr, b, l1, 1)
+
+			// One more time (already restored) => panic expected.
+			// It's an MPT pool duty to avoid such situations during real restore process.
+			require.Panics(t, func() {
+				_ = tr.RestoreHashNode(path, l1)
+			})
+			// No refcount changes expected.
+			check(t, tr, b, l1, 1)
+
+			// Same path, but wrong hash => error expected, no refcount changes
+			require.True(t, errors.Is(tr.RestoreHashNode(path, NewLeafNode([]byte{0xAD})), ErrRestoreFailed))
+			check(t, tr, b, l1, 1)
+
+			// New path pointing to the empty HashNode (changes in the MPT structure are not allowed) => error expected, no refcount changes
+			require.True(t, errors.Is(tr.RestoreHashNode([]byte{0x01}, l1), ErrRestoreFailed))
+			check(t, tr, b, l1, 1)
+		})
+
+		t.Run("last child", func(t *testing.T) {
+			l1 := NewLeafNode([]byte{0xAB, 0xCD})
+			l2 := NewLeafNode([]byte{0xAB, 0xDE})
+			b := NewBranchNode()
+			b.Children[5] = NewHashNode(l1.Hash())
+			b.Children[lastChild] = NewHashNode(l2.Hash())
+			tr := NewBillet(b.Hash(), true, newTestStore())
+			tr.root = b
+
+			// OK
+			path := []byte{}
+			require.NoError(t, tr.RestoreHashNode(path, l2))
+			check(t, tr, b, l2, 1)
+
+			// One more time (already restored) => panic expected.
+			// It's an MPT pool duty to avoid such situations during real restore process.
+			require.Panics(t, func() {
+				_ = tr.RestoreHashNode(path, l2)
+			})
+			// No refcount changes expected.
+			check(t, tr, b, l2, 1)
+
+			// Same path, but wrong hash => error expected, no refcount changes
+			require.True(t, errors.Is(tr.RestoreHashNode(path, NewLeafNode([]byte{0xAD})), ErrRestoreFailed))
+			check(t, tr, b, l2, 1)
+		})
+
+		t.Run("two children with same hash", func(t *testing.T) {
+			l := NewLeafNode([]byte{0xAB, 0xCD})
+			b := NewBranchNode()
+			// two same hashnodes => leaf's refcount expected to be 2 in the end.
+			b.Children[3] = NewHashNode(l.Hash())
+			b.Children[4] = NewHashNode(l.Hash())
+			tr := NewBillet(b.Hash(), true, newTestStore())
+			tr.root = b
+
+			// OK
+			require.NoError(t, tr.RestoreHashNode([]byte{0x03}, l))
+			expected := b
+			expected.Children[3].(*HashNode).Collapsed = true
+			check(t, tr, b, l, 1)
+
+			// Restore another node with the same hash => no error expected, refcount should be incremented.
+			// Branch node should be collapsed.
+			require.NoError(t, tr.RestoreHashNode([]byte{0x04}, l))
+			res := NewHashNode(b.Hash())
+			res.Collapsed = true
+			check(t, tr, res, l, 2)
+		})
+	})
+
+	t.Run("parent is Hash", func(t *testing.T) {
+		l := NewLeafNode([]byte{0xAB, 0xCD})
+		b := NewBranchNode()
+		b.Children[3] = NewHashNode(l.Hash())
+		b.Children[4] = NewHashNode(l.Hash())
+		tr := NewBillet(b.Hash(), true, newTestStore())
+
+		// Should fail, because if it's a hash node with non-empty path, then the node
+		// has already been collapsed.
+		require.Error(t, tr.RestoreHashNode([]byte{0x03}, l))
+	})
+}

--- a/pkg/core/mpt/branch.go
+++ b/pkg/core/mpt/branch.go
@@ -89,6 +89,12 @@ func (b *BranchNode) UnmarshalJSON(data []byte) error {
 	return errors.New("expected branch node")
 }
 
+// Clone implements Node interface.
+func (b *BranchNode) Clone() Node {
+	res := *b
+	return &res
+}
+
 // splitPath splits path for a branch node.
 func splitPath(path []byte) (byte, []byte) {
 	if len(path) != 0 {

--- a/pkg/core/mpt/empty.go
+++ b/pkg/core/mpt/empty.go
@@ -54,3 +54,6 @@ func (e EmptyNode) Type() NodeType {
 func (e EmptyNode) Bytes() []byte {
 	return nil
 }
+
+// Clone implements Node interface.
+func (EmptyNode) Clone() Node { return EmptyNode{} }

--- a/pkg/core/mpt/extension.go
+++ b/pkg/core/mpt/extension.go
@@ -98,3 +98,9 @@ func (e *ExtensionNode) UnmarshalJSON(data []byte) error {
 	}
 	return errors.New("expected extension node")
 }
+
+// Clone implements Node interface.
+func (e *ExtensionNode) Clone() Node {
+	res := *e
+	return &res
+}

--- a/pkg/core/mpt/hash.go
+++ b/pkg/core/mpt/hash.go
@@ -77,3 +77,10 @@ func (h *HashNode) UnmarshalJSON(data []byte) error {
 	}
 	return errors.New("expected hash node")
 }
+
+// Clone implements Node interface.
+func (h *HashNode) Clone() Node {
+	res := *h
+	res.Collapsed = false
+	return &res
+}

--- a/pkg/core/mpt/hash.go
+++ b/pkg/core/mpt/hash.go
@@ -10,6 +10,7 @@ import (
 // HashNode represents MPT's hash node.
 type HashNode struct {
 	BaseNode
+	Collapsed bool
 }
 
 var _ Node = (*HashNode)(nil)

--- a/pkg/core/mpt/helpers.go
+++ b/pkg/core/mpt/helpers.go
@@ -40,3 +40,12 @@ func toNibbles(path []byte) []byte {
 	}
 	return result
 }
+
+// fromNibbles performs operation opposite to toNibbles and does no path validity checks.
+func fromNibbles(path []byte) []byte {
+	result := make([]byte, len(path)/2)
+	for i := range result {
+		result[i] = path[2*i]<<4 + path[2*i+1]
+	}
+	return result
+}

--- a/pkg/core/mpt/helpers.go
+++ b/pkg/core/mpt/helpers.go
@@ -1,5 +1,7 @@
 package mpt
 
+import "github.com/nspcc-dev/neo-go/pkg/util"
+
 // lcp returns longest common prefix of a and b.
 // Note: it does no allocations.
 func lcp(a, b []byte) []byte {
@@ -48,4 +50,37 @@ func fromNibbles(path []byte) []byte {
 		result[i] = path[2*i]<<4 + path[2*i+1]
 	}
 	return result
+}
+
+// GetChildrenPaths returns a set of paths to node's children who are non-empty HashNodes
+// based on the node's path.
+func GetChildrenPaths(path []byte, node Node) map[util.Uint256][][]byte {
+	res := make(map[util.Uint256][][]byte)
+	switch n := node.(type) {
+	case *LeafNode, *HashNode, EmptyNode:
+		return nil
+	case *BranchNode:
+		for i, child := range n.Children {
+			if child.Type() == HashT {
+				cPath := make([]byte, len(path), len(path)+1)
+				copy(cPath, path)
+				if i != lastChild {
+					cPath = append(cPath, byte(i))
+				}
+				paths := res[child.Hash()]
+				paths = append(paths, cPath)
+				res[child.Hash()] = paths
+			}
+		}
+	case *ExtensionNode:
+		if n.next.Type() == HashT {
+			cPath := make([]byte, len(path)+len(n.key))
+			copy(cPath, path)
+			copy(cPath[len(path):], n.key)
+			res[n.next.Hash()] = [][]byte{cPath}
+		}
+	default:
+		panic("unknown Node type")
+	}
+	return res
 }

--- a/pkg/core/mpt/helpers_test.go
+++ b/pkg/core/mpt/helpers_test.go
@@ -1,0 +1,20 @@
+package mpt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToNibblesFromNibbles(t *testing.T) {
+	check := func(t *testing.T, expected []byte) {
+		actual := fromNibbles(toNibbles(expected))
+		require.Equal(t, expected, actual)
+	}
+	t.Run("empty path", func(t *testing.T) {
+		check(t, []byte{})
+	})
+	t.Run("non-empty path", func(t *testing.T) {
+		check(t, []byte{0x01, 0xAC, 0x8d, 0x04, 0xFF})
+	})
+}

--- a/pkg/core/mpt/helpers_test.go
+++ b/pkg/core/mpt/helpers_test.go
@@ -3,6 +3,7 @@ package mpt
 import (
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,4 +18,50 @@ func TestToNibblesFromNibbles(t *testing.T) {
 	t.Run("non-empty path", func(t *testing.T) {
 		check(t, []byte{0x01, 0xAC, 0x8d, 0x04, 0xFF})
 	})
+}
+
+func TestGetChildrenPaths(t *testing.T) {
+	h1 := NewHashNode(util.Uint256{1, 2, 3})
+	h2 := NewHashNode(util.Uint256{4, 5, 6})
+	h3 := NewHashNode(util.Uint256{7, 8, 9})
+	l := NewLeafNode([]byte{1, 2, 3})
+	ext1 := NewExtensionNode([]byte{8, 9}, h1)
+	ext2 := NewExtensionNode([]byte{7, 6}, l)
+	branch := NewBranchNode()
+	branch.Children[3] = h1
+	branch.Children[5] = l
+	branch.Children[6] = h1 // 3-th and 6-th children have the same hash
+	branch.Children[7] = h3
+	branch.Children[lastChild] = h2
+	testCases := map[string]struct {
+		node     Node
+		expected map[util.Uint256][][]byte
+	}{
+		"Hash":                         {h1, nil},
+		"Leaf":                         {l, nil},
+		"Extension with next Hash":     {ext1, map[util.Uint256][][]byte{h1.Hash(): {ext1.key}}},
+		"Extension with next non-Hash": {ext2, map[util.Uint256][][]byte{}},
+		"Branch": {branch, map[util.Uint256][][]byte{
+			h1.Hash(): {{0x03}, {0x06}},
+			h2.Hash(): {{}},
+			h3.Hash(): {{0x07}},
+		}},
+	}
+	parentPath := []byte{4, 5, 6}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, GetChildrenPaths([]byte{}, testCase.node))
+			if testCase.expected != nil {
+				expectedWithPrefix := make(map[util.Uint256][][]byte, len(testCase.expected))
+				for h, paths := range testCase.expected {
+					var res [][]byte
+					for _, path := range paths {
+						res = append(res, append(parentPath, path...))
+					}
+					expectedWithPrefix[h] = res
+				}
+				require.Equal(t, expectedWithPrefix, GetChildrenPaths(parentPath, testCase.node))
+			}
+		})
+	}
 }

--- a/pkg/core/mpt/leaf.go
+++ b/pkg/core/mpt/leaf.go
@@ -77,3 +77,9 @@ func (n *LeafNode) UnmarshalJSON(data []byte) error {
 	}
 	return errors.New("expected leaf node")
 }
+
+// Clone implements Node interface.
+func (n *LeafNode) Clone() Node {
+	res := *n
+	return &res
+}

--- a/pkg/core/mpt/node.go
+++ b/pkg/core/mpt/node.go
@@ -34,6 +34,7 @@ type Node interface {
 	json.Marshaler
 	json.Unmarshaler
 	Size() int
+	Clone() Node
 	BaseNodeIface
 }
 

--- a/pkg/core/mpt/proof_test.go
+++ b/pkg/core/mpt/proof_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newProofTrie(t *testing.T) *Trie {
+func newProofTrie(t *testing.T, missingHashNode bool) *Trie {
 	l := NewLeafNode([]byte("somevalue"))
 	e := NewExtensionNode([]byte{0x05, 0x06, 0x07}, l)
 	l2 := NewLeafNode([]byte("invalid"))
@@ -20,11 +20,14 @@ func newProofTrie(t *testing.T) *Trie {
 	require.NoError(t, tr.Put([]byte{0x12, 0x32}, []byte("value2")))
 	tr.putToStore(l)
 	tr.putToStore(e)
+	if !missingHashNode {
+		tr.putToStore(l2)
+	}
 	return tr
 }
 
 func TestTrie_GetProof(t *testing.T) {
-	tr := newProofTrie(t)
+	tr := newProofTrie(t, true)
 
 	t.Run("MissingKey", func(t *testing.T) {
 		_, err := tr.GetProof([]byte{0x12})
@@ -43,7 +46,7 @@ func TestTrie_GetProof(t *testing.T) {
 }
 
 func TestVerifyProof(t *testing.T) {
-	tr := newProofTrie(t)
+	tr := newProofTrie(t, true)
 
 	t.Run("Simple", func(t *testing.T) {
 		proof, err := tr.GetProof([]byte{0x12, 0x32})

--- a/pkg/core/native/designate.go
+++ b/pkg/core/native/designate.go
@@ -353,3 +353,8 @@ func (s *Designate) getRole(item stackitem.Item) (noderoles.Role, bool) {
 	u := bi.Uint64()
 	return noderoles.Role(u), u <= math.MaxUint8 && s.isValidRole(noderoles.Role(u))
 }
+
+// InitializeCache invalidates native Designate cache.
+func (s *Designate) InitializeCache() {
+	s.rolesChangedFlag.Store(true)
+}

--- a/pkg/core/statesync/module.go
+++ b/pkg/core/statesync/module.go
@@ -371,7 +371,9 @@ func (s *Module) restoreNode(n mpt.Node) error {
 	}
 	var childrenPaths = make(map[util.Uint256][][]byte)
 	for _, path := range nPaths {
-		err := s.billet.RestoreHashNode(path, n)
+		// Must clone here in order to avoid future collapse collisions. If the node's refcount>1 then MPT pool
+		// will manage all paths for this node and call RestoreHashNode separately for each of the paths.
+		err := s.billet.RestoreHashNode(path, n.Clone())
 		if err != nil {
 			return fmt.Errorf("failed to restore MPT node with hash %s and path %s: %w", n.Hash().StringBE(), hex.EncodeToString(path), err)
 		}

--- a/pkg/core/statesync/module.go
+++ b/pkg/core/statesync/module.go
@@ -1,0 +1,440 @@
+/*
+Package statesync implements module for the P2P state synchronisation process. The
+module manages state synchronisation for non-archival nodes which are joining the
+network and don't have the ability to resync from the genesis block.
+
+Given the currently available state synchronisation point P, sate sync process
+includes the following stages:
+
+1. Fetching headers starting from height 0 up to P+1.
+2. Fetching MPT nodes for height P stating from the corresponding state root.
+3. Fetching blocks starting from height P-MaxTraceableBlocks (or 0) up to P.
+
+Steps 2 and 3 are being performed in parallel. Once all the data are collected
+and stored in the db, an atomic state jump is occurred to the state sync point P.
+Further node operation process is performed using standard sync mechanism until
+the node reaches synchronised state.
+*/
+package statesync
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/nspcc-dev/neo-go/pkg/core/block"
+	"github.com/nspcc-dev/neo-go/pkg/core/blockchainer"
+	"github.com/nspcc-dev/neo-go/pkg/core/dao"
+	"github.com/nspcc-dev/neo-go/pkg/core/mpt"
+	"github.com/nspcc-dev/neo-go/pkg/core/storage"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"go.uber.org/zap"
+)
+
+// stateSyncStage is a type of state synchronisation stage.
+type stateSyncStage uint8
+
+const (
+	// inactive means that state exchange is disabled by the protocol configuration.
+	// Can't be combined with other states.
+	inactive stateSyncStage = 1 << iota
+	// none means that state exchange is enabled in the configuration, but
+	// initialisation of the state sync module wasn't yet performed, i.e.
+	// (*Module).Init wasn't called. Can't be combined with other states.
+	none
+	// initialized means that (*Module).Init was called, but other sync stages
+	// are not yet reached (i.e. that headers are requested, but not yet fetched).
+	// Can't be combined with other states.
+	initialized
+	// headersSynced means that headers for the current state sync point are fetched.
+	// May be combined with mptSynced and/or blocksSynced.
+	headersSynced
+	// mptSynced means that MPT nodes for the current state sync point are fetched.
+	// Always combined with headersSynced; may be combined with blocksSynced.
+	mptSynced
+	// blocksSynced means that blocks up to the current state sync point are stored.
+	// Always combined with headersSynced; may be combined with mptSynced.
+	blocksSynced
+)
+
+// Module represents state sync module and aimed to gather state-related data to
+// perform an atomic state jump.
+type Module struct {
+	lock sync.RWMutex
+	log  *zap.Logger
+
+	// syncPoint is the state synchronisation point P we're currently working against.
+	syncPoint uint32
+	// syncStage is the stage of the sync process.
+	syncStage stateSyncStage
+	// syncInterval is the delta between two adjacent state sync points.
+	syncInterval uint32
+	// blockHeight is the index of the latest stored block.
+	blockHeight uint32
+
+	dao     *dao.Simple
+	bc      blockchainer.Blockchainer
+	mptpool *Pool
+
+	billet *mpt.Billet
+}
+
+// NewModule returns new instance of statesync module.
+func NewModule(bc blockchainer.Blockchainer, log *zap.Logger, s *dao.Simple) *Module {
+	if !(bc.GetConfig().P2PStateExchangeExtensions && bc.GetConfig().RemoveUntraceableBlocks) {
+		return &Module{
+			dao:       s,
+			bc:        bc,
+			syncStage: inactive,
+		}
+	}
+	return &Module{
+		dao:          s,
+		bc:           bc,
+		log:          log,
+		syncInterval: uint32(bc.GetConfig().StateSyncInterval),
+		mptpool:      NewPool(),
+		syncStage:    none,
+	}
+}
+
+// Init initializes state sync module for the current chain's height with given
+// callback for MPT nodes requests.
+func (s *Module) Init(currChainHeight uint32) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.syncStage != none {
+		return errors.New("already initialized or inactive")
+	}
+
+	p := (currChainHeight / s.syncInterval) * s.syncInterval
+	if p < 2*s.syncInterval {
+		// chain is too low to start state exchange process, use the standard sync mechanism
+		s.syncStage = inactive
+		return nil
+	}
+	pOld, err := s.dao.GetStateSyncPoint()
+	if err == nil && pOld >= p-s.syncInterval {
+		// old point is still valid, so try to resync states for this point.
+		p = pOld
+	} else if s.bc.BlockHeight() > p-2*s.syncInterval {
+		// chain has already been synchronised up to old state sync point and regular blocks processing was started
+		s.syncStage = inactive
+		return nil
+	}
+
+	s.syncPoint = p
+	err = s.dao.PutStateSyncPoint(p)
+	if err != nil {
+		return fmt.Errorf("failed to store state synchronisation point %d: %w", p, err)
+	}
+	s.syncStage = initialized
+	s.log.Info("try to sync state for the latest state synchronisation point",
+		zap.Uint32("point", p),
+		zap.Uint32("evaluated chain's blockHeight", currChainHeight))
+
+	// check headers sync state first
+	ltstHeaderHeight := s.bc.HeaderHeight()
+	if ltstHeaderHeight > p {
+		s.syncStage = headersSynced
+		s.log.Info("headers are in sync",
+			zap.Uint32("headerHeight", s.bc.HeaderHeight()))
+	}
+
+	// check blocks sync state
+	s.blockHeight = s.getLatestSavedBlock(p)
+	if s.blockHeight >= p {
+		s.syncStage |= blocksSynced
+		s.log.Info("blocks are in sync",
+			zap.Uint32("blockHeight", s.blockHeight))
+	}
+
+	// check MPT sync state
+	if s.blockHeight > p {
+		s.syncStage |= mptSynced
+		s.log.Info("MPT is in sync",
+			zap.Uint32("stateroot height", s.bc.GetStateModule().CurrentLocalHeight()))
+	} else if s.syncStage&headersSynced != 0 {
+		header, err := s.bc.GetHeader(s.bc.GetHeaderHash(int(p + 1)))
+		if err != nil {
+			return fmt.Errorf("failed to get header to initialize MPT billet: %w", err)
+		}
+		s.billet = mpt.NewBillet(header.PrevStateRoot, s.bc.GetConfig().KeepOnlyLatestState, s.dao.Store)
+		s.log.Info("MPT billet initialized",
+			zap.Uint32("height", s.syncPoint),
+			zap.String("state root", header.PrevStateRoot.StringBE()))
+		pool := NewPool()
+		pool.Add(header.PrevStateRoot, []byte{})
+		err = s.billet.Traverse(func(n mpt.Node, _ []byte) bool {
+			nPaths, ok := pool.TryGet(n.Hash())
+			if !ok {
+				// if this situation occurs, then it's a bug in MPT pool or Traverse.
+				panic("failed to get MPT node from the pool")
+			}
+			pool.Remove(n.Hash())
+			childrenPaths := make(map[util.Uint256][][]byte)
+			for _, path := range nPaths {
+				nChildrenPaths := mpt.GetChildrenPaths(path, n)
+				for hash, paths := range nChildrenPaths {
+					childrenPaths[hash] = append(childrenPaths[hash], paths...) // it's OK to have duplicates, they'll be handled by mempool
+				}
+			}
+			pool.Update(nil, childrenPaths)
+			return false
+		}, true)
+		if err != nil {
+			return fmt.Errorf("failed to traverse MPT while initialization: %w", err)
+		}
+		s.mptpool.Update(nil, pool.GetAll())
+		if s.mptpool.Count() == 0 {
+			s.syncStage |= mptSynced
+			s.log.Info("MPT is in sync",
+				zap.Uint32("stateroot height", p))
+		}
+	}
+
+	if s.syncStage == headersSynced|blocksSynced|mptSynced {
+		s.log.Info("state is in sync, starting regular blocks processing")
+		s.syncStage = inactive
+	}
+	return nil
+}
+
+// getLatestSavedBlock returns either current block index (if it's still relevant
+// to continue state sync process) or H-1 where H is the index of the earliest
+// block that should be saved next.
+func (s *Module) getLatestSavedBlock(p uint32) uint32 {
+	var result uint32
+	mtb := s.bc.GetConfig().MaxTraceableBlocks
+	if p > mtb {
+		result = p - mtb
+	}
+	storedH, err := s.dao.GetStateSyncCurrentBlockHeight()
+	if err == nil && storedH > result {
+		result = storedH
+	}
+	actualH := s.bc.BlockHeight()
+	if actualH > result {
+		result = actualH
+	}
+	return result
+}
+
+// AddHeaders validates and adds specified headers to the chain.
+func (s *Module) AddHeaders(hdrs ...*block.Header) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.syncStage != initialized {
+		return errors.New("headers were not requested")
+	}
+
+	hdrsErr := s.bc.AddHeaders(hdrs...)
+	if s.bc.HeaderHeight() > s.syncPoint {
+		s.syncStage = headersSynced
+		s.log.Info("headers for state sync are fetched",
+			zap.Uint32("header height", s.bc.HeaderHeight()))
+
+		header, err := s.bc.GetHeader(s.bc.GetHeaderHash(int(s.syncPoint) + 1))
+		if err != nil {
+			s.log.Fatal("failed to get header to initialize MPT billet",
+				zap.Uint32("height", s.syncPoint+1),
+				zap.Error(err))
+		}
+		s.billet = mpt.NewBillet(header.PrevStateRoot, s.bc.GetConfig().KeepOnlyLatestState, s.dao.Store)
+		s.mptpool.Add(header.PrevStateRoot, []byte{})
+		s.log.Info("MPT billet initialized",
+			zap.Uint32("height", s.syncPoint),
+			zap.String("state root", header.PrevStateRoot.StringBE()))
+	}
+	return hdrsErr
+}
+
+// AddBlock verifies and saves block skipping executable scripts.
+func (s *Module) AddBlock(block *block.Block) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.syncStage&headersSynced == 0 || s.syncStage&blocksSynced != 0 {
+		return nil
+	}
+
+	if s.blockHeight == s.syncPoint {
+		return nil
+	}
+	expectedHeight := s.blockHeight + 1
+	if expectedHeight != block.Index {
+		return fmt.Errorf("expected %d, got %d: invalid block index", expectedHeight, block.Index)
+	}
+	if s.bc.GetConfig().StateRootInHeader != block.StateRootEnabled {
+		return fmt.Errorf("stateroot setting mismatch: %v != %v", s.bc.GetConfig().StateRootInHeader, block.StateRootEnabled)
+	}
+	if s.bc.GetConfig().VerifyBlocks {
+		merkle := block.ComputeMerkleRoot()
+		if !block.MerkleRoot.Equals(merkle) {
+			return errors.New("invalid block: MerkleRoot mismatch")
+		}
+	}
+	cache := s.dao.GetWrapped()
+	writeBuf := io.NewBufBinWriter()
+	if err := cache.StoreAsBlock(block, writeBuf); err != nil {
+		return err
+	}
+	writeBuf.Reset()
+
+	err := cache.PutStateSyncCurrentBlockHeight(block.Index)
+	if err != nil {
+		return fmt.Errorf("failed to store current block height: %w", err)
+	}
+
+	for _, tx := range block.Transactions {
+		if err := cache.StoreAsTransaction(tx, block.Index, writeBuf); err != nil {
+			return err
+		}
+		writeBuf.Reset()
+	}
+
+	_, err = cache.Persist()
+	if err != nil {
+		return fmt.Errorf("failed to persist results: %w", err)
+	}
+	s.blockHeight = block.Index
+	if s.blockHeight == s.syncPoint {
+		s.syncStage |= blocksSynced
+		s.log.Info("blocks are in sync",
+			zap.Uint32("blockHeight", s.blockHeight))
+		s.checkSyncIsCompleted()
+	}
+	return nil
+}
+
+// AddMPTNodes tries to add provided set of MPT nodes to the MPT billet if they are
+// not yet collected.
+func (s *Module) AddMPTNodes(nodes [][]byte) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.syncStage&headersSynced == 0 || s.syncStage&mptSynced != 0 {
+		return errors.New("MPT nodes were not requested")
+	}
+
+	for _, nBytes := range nodes {
+		var n mpt.NodeObject
+		r := io.NewBinReaderFromBuf(nBytes)
+		n.DecodeBinary(r)
+		if r.Err != nil {
+			return fmt.Errorf("failed to decode MPT node: %w", r.Err)
+		}
+		nPaths, ok := s.mptpool.TryGet(n.Hash())
+		if !ok {
+			// it can easily happen after receiving the same data from different peers.
+			return nil
+		}
+
+		var childrenPaths = make(map[util.Uint256][][]byte)
+		for _, path := range nPaths {
+			err := s.billet.RestoreHashNode(path, n.Node)
+			if err != nil {
+				return fmt.Errorf("failed to add MPT node with hash %s and path %s: %w", n.Hash().StringBE(), hex.EncodeToString(path), err)
+			}
+			for h, paths := range mpt.GetChildrenPaths(path, n.Node) {
+				childrenPaths[h] = append(childrenPaths[h], paths...) // it's OK to have duplicates, they'll be handled by mempool
+			}
+		}
+
+		s.mptpool.Update(map[util.Uint256][][]byte{n.Hash(): nPaths}, childrenPaths)
+	}
+	if s.mptpool.Count() == 0 {
+		s.syncStage |= mptSynced
+		s.log.Info("MPT is in sync",
+			zap.Uint32("height", s.syncPoint))
+		s.checkSyncIsCompleted()
+	}
+	return nil
+}
+
+// checkSyncIsCompleted checks whether state sync process is completed, i.e. headers up to P+1
+// height are fetched, blocks up to P height are stored and MPT nodes for P height are stored.
+// If so, then jumping to P state sync point occurs. It is not protected by lock, thus caller
+// should take care of it.
+func (s *Module) checkSyncIsCompleted() {
+	if s.syncStage != headersSynced|mptSynced|blocksSynced {
+		return
+	}
+	s.log.Info("state is in sync",
+		zap.Uint32("state sync point", s.syncPoint))
+	err := s.bc.JumpToState(s)
+	if err != nil {
+		s.log.Fatal("failed to jump to the latest state sync point", zap.Error(err))
+	}
+	s.syncStage = inactive
+	s.dispose()
+}
+
+func (s *Module) dispose() {
+	s.billet = nil
+}
+
+// BlockHeight returns index of the last stored block.
+func (s *Module) BlockHeight() uint32 {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.blockHeight
+}
+
+// IsActive tells whether state sync module is on and still gathering state
+// synchronisation data (headers, blocks or MPT nodes).
+func (s *Module) IsActive() bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return !(s.syncStage == inactive || (s.syncStage == headersSynced|mptSynced|blocksSynced))
+}
+
+// IsInitialized tells whether state sync module does not require initialization.
+// If `false` is returned then Init can be safely called.
+func (s *Module) IsInitialized() bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.syncStage != none
+}
+
+// NeedHeaders tells whether the module hasn't completed headers synchronisation.
+func (s *Module) NeedHeaders() bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.syncStage == initialized
+}
+
+// NeedMPTNodes returns whether the module hasn't completed MPT synchronisation.
+func (s *Module) NeedMPTNodes() bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.syncStage&headersSynced != 0 && s.syncStage&mptSynced == 0
+}
+
+// Traverse traverses local MPT nodes starting from the specified root down to its
+// children calling `process` for each serialised node until stop condition is satisfied.
+func (s *Module) Traverse(root util.Uint256, process func(node mpt.Node, nodeBytes []byte) bool) error {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	b := mpt.NewBillet(root, s.bc.GetConfig().KeepOnlyLatestState, storage.NewMemCachedStore(s.dao.Store))
+	return b.Traverse(process, false)
+}
+
+// GetJumpHeight returns state sync point to jump to. It is not protected by mutex and should be called
+// under the module lock.
+func (s *Module) GetJumpHeight() (uint32, error) {
+	if s.syncStage != headersSynced|mptSynced|blocksSynced {
+		return 0, errors.New("state sync module has wong state to perform state jump")
+	}
+	return s.syncPoint, nil
+}

--- a/pkg/core/statesync/module_test.go
+++ b/pkg/core/statesync/module_test.go
@@ -1,0 +1,106 @@
+package statesync
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/core/dao"
+	"github.com/nspcc-dev/neo-go/pkg/core/mpt"
+	"github.com/nspcc-dev/neo-go/pkg/core/storage"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/util/slice"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestModule_PR2019_discussion_r689629704(t *testing.T) {
+	expectedStorage := storage.NewMemCachedStore(storage.NewMemoryStore())
+	tr := mpt.NewTrie(nil, true, expectedStorage)
+	require.NoError(t, tr.Put([]byte{0x03}, []byte("leaf1")))
+	require.NoError(t, tr.Put([]byte{0x01, 0xab, 0x02}, []byte("leaf2")))
+	require.NoError(t, tr.Put([]byte{0x01, 0xab, 0x04}, []byte("leaf3")))
+	require.NoError(t, tr.Put([]byte{0x06, 0x01, 0xde, 0x02}, []byte("leaf2"))) // <-- the same `leaf2` and `leaf3` values are put in the storage,
+	require.NoError(t, tr.Put([]byte{0x06, 0x01, 0xde, 0x04}, []byte("leaf3"))) // <-- but the path should differ.
+	require.NoError(t, tr.Put([]byte{0x06, 0x03}, []byte("leaf4")))
+
+	sr := tr.StateRoot()
+	tr.Flush()
+
+	// Keep MPT nodes in a map in order not to repeat them. We'll use `nodes` map to ask
+	// state sync module to restore the nodes.
+	var (
+		nodes         = make(map[util.Uint256][]byte)
+		expectedItems []storage.KeyValue
+	)
+	expectedStorage.Seek(storage.DataMPT.Bytes(), func(k, v []byte) {
+		key := slice.Copy(k)
+		value := slice.Copy(v)
+		expectedItems = append(expectedItems, storage.KeyValue{
+			Key:   key,
+			Value: value,
+		})
+		hash, err := util.Uint256DecodeBytesBE(key[1:])
+		require.NoError(t, err)
+		nodeBytes := value[:len(value)-4]
+		nodes[hash] = nodeBytes
+	})
+
+	actualStorage := storage.NewMemCachedStore(storage.NewMemoryStore())
+	// These actions are done in module.Init(), but it's not the point of the test.
+	// Here we want to test only MPT restoring process.
+	stateSync := &Module{
+		log:          zaptest.NewLogger(t),
+		syncPoint:    1000500,
+		syncStage:    headersSynced,
+		syncInterval: 100500,
+		dao:          dao.NewSimple(actualStorage, true, false),
+		mptpool:      NewPool(),
+	}
+	stateSync.billet = mpt.NewBillet(sr, true, actualStorage)
+	stateSync.mptpool.Add(sr, []byte{})
+
+	// The test itself: we'll ask state sync module to restore each node exactly once.
+	// After that storage content (including storage items and refcounts) must
+	// match exactly the one got from real MPT trie. MPT pool must be empty.
+	// State sync module must have mptSynced state in the end.
+	// MPT Billet root must become a collapsed hashnode (it was checked manually).
+	requested := make(map[util.Uint256]struct{})
+	for {
+		unknownHashes := stateSync.GetUnknownMPTNodesBatch(1) // restore nodes one-by-one
+		if len(unknownHashes) == 0 {
+			break
+		}
+		h := unknownHashes[0]
+		node, ok := nodes[h]
+		if !ok {
+			if _, ok = requested[h]; ok {
+				t.Fatal("node was requested twice")
+			}
+			t.Fatal("unknown node was requested")
+		}
+		require.NotPanics(t, func() {
+			err := stateSync.AddMPTNodes([][]byte{node})
+			require.NoError(t, err)
+		}, fmt.Errorf("hash=%s, value=%s", h.StringBE(), string(node)))
+		requested[h] = struct{}{}
+		delete(nodes, h)
+		if len(nodes) == 0 {
+			break
+		}
+	}
+	require.Equal(t, headersSynced|mptSynced, stateSync.syncStage, "all nodes were sent exactly ones, but MPT wasn't restored")
+	require.Equal(t, 0, len(nodes), "not all nodes were requested by state sync module")
+	require.Equal(t, 0, stateSync.mptpool.Count(), "MPT was restored, but MPT pool still contains items")
+
+	// Compare resulting storage items and refcounts.
+	var actualItems []storage.KeyValue
+	expectedStorage.Seek(storage.DataMPT.Bytes(), func(k, v []byte) {
+		key := slice.Copy(k)
+		value := slice.Copy(v)
+		actualItems = append(actualItems, storage.KeyValue{
+			Key:   key,
+			Value: value,
+		})
+	})
+	require.ElementsMatch(t, expectedItems, actualItems)
+}

--- a/pkg/core/statesync/mptpool.go
+++ b/pkg/core/statesync/mptpool.go
@@ -37,7 +37,10 @@ func (mp *Pool) TryGet(hash util.Uint256) ([][]byte, bool) {
 	defer mp.lock.RUnlock()
 
 	paths, ok := mp.hashes[hash]
-	return paths, ok
+	// need to copy here, because we can modify existing array of paths inside the pool.
+	res := make([][]byte, len(paths))
+	copy(res, paths)
+	return res, ok
 }
 
 // GetAll returns all MPT nodes with the corresponding paths from the pool.

--- a/pkg/core/statesync/mptpool.go
+++ b/pkg/core/statesync/mptpool.go
@@ -1,0 +1,119 @@
+package statesync
+
+import (
+	"bytes"
+	"sort"
+	"sync"
+
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+// Pool stores unknown MPT nodes along with the corresponding paths (single node is
+// allowed to have multiple MPT paths).
+type Pool struct {
+	lock   sync.RWMutex
+	hashes map[util.Uint256][][]byte
+}
+
+// NewPool returns new MPT node hashes pool.
+func NewPool() *Pool {
+	return &Pool{
+		hashes: make(map[util.Uint256][][]byte),
+	}
+}
+
+// ContainsKey checks if MPT node with the specified hash is in the Pool.
+func (mp *Pool) ContainsKey(hash util.Uint256) bool {
+	mp.lock.RLock()
+	defer mp.lock.RUnlock()
+
+	_, ok := mp.hashes[hash]
+	return ok
+}
+
+// TryGet returns a set of MPT paths for the specified HashNode.
+func (mp *Pool) TryGet(hash util.Uint256) ([][]byte, bool) {
+	mp.lock.RLock()
+	defer mp.lock.RUnlock()
+
+	paths, ok := mp.hashes[hash]
+	return paths, ok
+}
+
+// GetAll returns all MPT nodes with the corresponding paths from the pool.
+func (mp *Pool) GetAll() map[util.Uint256][][]byte {
+	mp.lock.RLock()
+	defer mp.lock.RUnlock()
+
+	return mp.hashes
+}
+
+// Remove removes MPT node from the pool by the specified hash.
+func (mp *Pool) Remove(hash util.Uint256) {
+	mp.lock.Lock()
+	defer mp.lock.Unlock()
+
+	delete(mp.hashes, hash)
+}
+
+// Add adds path to the set of paths for the specified node.
+func (mp *Pool) Add(hash util.Uint256, path []byte) {
+	mp.lock.Lock()
+	defer mp.lock.Unlock()
+
+	mp.addPaths(hash, [][]byte{path})
+}
+
+// Update is an atomic operation and removes/adds specified nodes from/to the pool.
+func (mp *Pool) Update(remove map[util.Uint256][][]byte, add map[util.Uint256][][]byte) {
+	mp.lock.Lock()
+	defer mp.lock.Unlock()
+
+	for h, paths := range remove {
+		old := mp.hashes[h]
+		for _, path := range paths {
+			i := sort.Search(len(old), func(i int) bool {
+				return bytes.Compare(old[i], path) >= 0
+			})
+			if i < len(old) && bytes.Equal(old[i], path) {
+				old = append(old[:i], old[i+1:]...)
+			}
+		}
+		if len(old) == 0 {
+			delete(mp.hashes, h)
+		} else {
+			mp.hashes[h] = old
+		}
+	}
+	for h, paths := range add {
+		mp.addPaths(h, paths)
+	}
+}
+
+// addPaths adds set of the specified node paths to the pool.
+func (mp *Pool) addPaths(nodeHash util.Uint256, paths [][]byte) {
+	old := mp.hashes[nodeHash]
+	for _, path := range paths {
+		i := sort.Search(len(old), func(i int) bool {
+			return bytes.Compare(old[i], path) >= 0
+		})
+		if i < len(old) && bytes.Equal(old[i], path) {
+			// then path is already added
+			continue
+		}
+		old = append(old, path)
+		if i != len(old)-1 {
+			copy(old[i+1:], old[i:])
+			old[i] = path
+		}
+	}
+	mp.hashes[nodeHash] = old
+}
+
+// Count returns the number of nodes in the pool.
+func (mp *Pool) Count() int {
+	mp.lock.RLock()
+	defer mp.lock.RUnlock()
+
+	return len(mp.hashes)
+}

--- a/pkg/core/statesync/mptpool.go
+++ b/pkg/core/statesync/mptpool.go
@@ -48,6 +48,26 @@ func (mp *Pool) GetAll() map[util.Uint256][][]byte {
 	return mp.hashes
 }
 
+// GetBatch returns set of unknown MPT nodes hashes (`limit` at max).
+func (mp *Pool) GetBatch(limit int) []util.Uint256 {
+	mp.lock.RLock()
+	defer mp.lock.RUnlock()
+
+	count := len(mp.hashes)
+	if count > limit {
+		count = limit
+	}
+	result := make([]util.Uint256, 0, limit)
+	for h := range mp.hashes {
+		if count == 0 {
+			break
+		}
+		result = append(result, h)
+		count--
+	}
+	return result
+}
+
 // Remove removes MPT node from the pool by the specified hash.
 func (mp *Pool) Remove(hash util.Uint256) {
 	mp.lock.Lock()

--- a/pkg/core/statesync/mptpool_test.go
+++ b/pkg/core/statesync/mptpool_test.go
@@ -1,0 +1,104 @@
+package statesync
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/internal/random"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPool_AddRemoveUpdate(t *testing.T) {
+	mp := NewPool()
+
+	i1 := []byte{1, 2, 3}
+	i1h := util.Uint256{1, 2, 3}
+	i2 := []byte{2, 3, 4}
+	i2h := util.Uint256{2, 3, 4}
+	i3 := []byte{4, 5, 6}
+	i3h := util.Uint256{3, 4, 5}
+	i4 := []byte{3, 4, 5} // has the same hash as i3
+	i5 := []byte{6, 7, 8} // has the same hash as i3
+	mapAll := map[util.Uint256][][]byte{i1h: {i1}, i2h: {i2}, i3h: {i4, i3}}
+
+	// No items
+	_, ok := mp.TryGet(i1h)
+	require.False(t, ok)
+	require.False(t, mp.ContainsKey(i1h))
+	require.Equal(t, 0, mp.Count())
+	require.Equal(t, map[util.Uint256][][]byte{}, mp.GetAll())
+
+	// Add i1, i2, check OK
+	mp.Add(i1h, i1)
+	mp.Add(i2h, i2)
+	itm, ok := mp.TryGet(i1h)
+	require.True(t, ok)
+	require.Equal(t, [][]byte{i1}, itm)
+	require.True(t, mp.ContainsKey(i1h))
+	require.True(t, mp.ContainsKey(i2h))
+	require.Equal(t, map[util.Uint256][][]byte{i1h: {i1}, i2h: {i2}}, mp.GetAll())
+	require.Equal(t, 2, mp.Count())
+
+	// Remove i1 and unexisting item
+	mp.Remove(i3h)
+	mp.Remove(i1h)
+	require.False(t, mp.ContainsKey(i1h))
+	require.True(t, mp.ContainsKey(i2h))
+	require.Equal(t, map[util.Uint256][][]byte{i2h: {i2}}, mp.GetAll())
+	require.Equal(t, 1, mp.Count())
+
+	// Update: remove nothing, add all
+	mp.Update(nil, mapAll)
+	require.Equal(t, mapAll, mp.GetAll())
+	require.Equal(t, 3, mp.Count())
+	// Update: remove all, add all
+	mp.Update(mapAll, mapAll)
+	require.Equal(t, mapAll, mp.GetAll()) // deletion first, addition after that
+	require.Equal(t, 3, mp.Count())
+	// Update: remove all, add nothing
+	mp.Update(mapAll, nil)
+	require.Equal(t, map[util.Uint256][][]byte{}, mp.GetAll())
+	require.Equal(t, 0, mp.Count())
+	// Update: remove several, add several
+	mp.Update(map[util.Uint256][][]byte{i1h: {i1}, i2h: {i2}}, map[util.Uint256][][]byte{i2h: {i2}, i3h: {i3}})
+	require.Equal(t, map[util.Uint256][][]byte{i2h: {i2}, i3h: {i3}}, mp.GetAll())
+	require.Equal(t, 2, mp.Count())
+
+	// Update: remove nothing, add several with same hashes
+	mp.Update(nil, map[util.Uint256][][]byte{i3h: {i5, i4}}) // should be sorted by the pool
+	require.Equal(t, map[util.Uint256][][]byte{i2h: {i2}, i3h: {i4, i3, i5}}, mp.GetAll())
+	require.Equal(t, 2, mp.Count())
+	// Update: remove several with same hashes, add nothing
+	mp.Update(map[util.Uint256][][]byte{i3h: {i5, i4}}, nil)
+	require.Equal(t, map[util.Uint256][][]byte{i2h: {i2}, i3h: {i3}}, mp.GetAll())
+	require.Equal(t, 2, mp.Count())
+	// Update: remove several with same hashes, add several with same hashes
+	mp.Update(map[util.Uint256][][]byte{i3h: {i5, i3}}, map[util.Uint256][][]byte{i3h: {i5, i4}})
+	require.Equal(t, map[util.Uint256][][]byte{i2h: {i2}, i3h: {i4, i5}}, mp.GetAll())
+	require.Equal(t, 2, mp.Count())
+}
+
+func TestPool_GetBatch(t *testing.T) {
+	check := func(t *testing.T, limit int, itemsCount int) {
+		mp := NewPool()
+		for i := 0; i < itemsCount; i++ {
+			mp.Add(random.Uint256(), []byte{0x01})
+		}
+		batch := mp.GetBatch(limit)
+		if limit < itemsCount {
+			require.Equal(t, limit, len(batch))
+		} else {
+			require.Equal(t, itemsCount, len(batch))
+		}
+	}
+
+	t.Run("limit less than items count", func(t *testing.T) {
+		check(t, 5, 6)
+	})
+	t.Run("limit more than items count", func(t *testing.T) {
+		check(t, 6, 5)
+	})
+	t.Run("items count limit", func(t *testing.T) {
+		check(t, 5, 5)
+	})
+}

--- a/pkg/core/statesync/mptpool_test.go
+++ b/pkg/core/statesync/mptpool_test.go
@@ -1,6 +1,7 @@
 package statesync
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/internal/random"
@@ -101,4 +102,22 @@ func TestPool_GetBatch(t *testing.T) {
 	t.Run("items count limit", func(t *testing.T) {
 		check(t, 5, 5)
 	})
+}
+
+func TestPool_UpdateUsingSliceFromPool(t *testing.T) {
+	mp := NewPool()
+	p1, _ := hex.DecodeString("0f0a0f0f0f0f0f0f0104020b02080c0a06050e070b050404060206060d07080602030b04040b050e040406030f0708060c05")
+	p2, _ := hex.DecodeString("0f0a0f0f0f0f0f0f01040a0b000f04000b03090b02090b0e040f0d0b060d070e0b0b090b0906080602060c0d0f0e0d04070e")
+	p3, _ := hex.DecodeString("0f0a0f0f0f0f0f0f01040b010d01080f050f000a0d0e08060c040b050800050904060f050807080a080c07040d0107080007")
+	h, _ := util.Uint256DecodeStringBE("57e197679ef031bf2f0b466b20afe3f67ac04dcff80a1dc4d12dd98dd21a2511")
+	mp.Add(h, p1)
+	mp.Add(h, p2)
+	mp.Add(h, p3)
+
+	toBeRemoved, ok := mp.TryGet(h)
+	require.True(t, ok)
+
+	mp.Update(map[util.Uint256][][]byte{h: toBeRemoved}, nil)
+	// test that all items were successfully removed.
+	require.Equal(t, 0, len(mp.GetAll()))
 }

--- a/pkg/core/statesync_test.go
+++ b/pkg/core/statesync_test.go
@@ -1,0 +1,435 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/config"
+	"github.com/nspcc-dev/neo-go/pkg/core/block"
+	"github.com/nspcc-dev/neo-go/pkg/core/mpt"
+	"github.com/nspcc-dev/neo-go/pkg/core/storage"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/util/slice"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateSyncModule_Init(t *testing.T) {
+	var (
+		stateSyncInterval        = 2
+		maxTraceable      uint32 = 3
+	)
+	spoutCfg := func(c *config.Config) {
+		c.ProtocolConfiguration.StateRootInHeader = true
+		c.ProtocolConfiguration.P2PStateExchangeExtensions = true
+		c.ProtocolConfiguration.StateSyncInterval = stateSyncInterval
+		c.ProtocolConfiguration.MaxTraceableBlocks = maxTraceable
+	}
+	bcSpout := newTestChainWithCustomCfg(t, spoutCfg)
+	for i := 0; i <= 2*stateSyncInterval+int(maxTraceable)+1; i++ {
+		require.NoError(t, bcSpout.AddBlock(bcSpout.newBlock()))
+	}
+
+	boltCfg := func(c *config.Config) {
+		spoutCfg(c)
+		c.ProtocolConfiguration.KeepOnlyLatestState = true
+		c.ProtocolConfiguration.RemoveUntraceableBlocks = true
+	}
+	t.Run("error: module disabled by config", func(t *testing.T) {
+		bcBolt := newTestChainWithCustomCfg(t, func(c *config.Config) {
+			boltCfg(c)
+			c.ProtocolConfiguration.RemoveUntraceableBlocks = false
+		})
+		module := bcBolt.GetStateSyncModule()
+		require.Error(t, module.Init(bcSpout.BlockHeight())) // module inactive (non-archival node)
+	})
+
+	t.Run("inactive: spout chain is too low to start state sync process", func(t *testing.T) {
+		bcBolt := newTestChainWithCustomCfg(t, boltCfg)
+		module := bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(uint32(2*stateSyncInterval-1)))
+		require.False(t, module.IsActive())
+	})
+
+	t.Run("inactive: bolt chain height is close enough to spout chain height", func(t *testing.T) {
+		bcBolt := newTestChainWithCustomCfg(t, boltCfg)
+		for i := 1; i < int(bcSpout.BlockHeight())-stateSyncInterval; i++ {
+			b, err := bcSpout.GetBlock(bcSpout.GetHeaderHash(i))
+			require.NoError(t, err)
+			require.NoError(t, bcBolt.AddBlock(b))
+		}
+		module := bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+		require.False(t, module.IsActive())
+	})
+
+	t.Run("error: bolt chain is too low to start state sync process", func(t *testing.T) {
+		bcBolt := newTestChainWithCustomCfg(t, boltCfg)
+		require.NoError(t, bcBolt.AddBlock(bcBolt.newBlock()))
+
+		module := bcBolt.GetStateSyncModule()
+		require.Error(t, module.Init(uint32(3*stateSyncInterval)))
+	})
+
+	t.Run("initialized: no previous state sync point", func(t *testing.T) {
+		bcBolt := newTestChainWithCustomCfg(t, boltCfg)
+
+		module := bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+		require.True(t, module.IsActive())
+		require.True(t, module.IsInitialized())
+		require.True(t, module.NeedHeaders())
+		require.False(t, module.NeedMPTNodes())
+	})
+
+	t.Run("error: outdated state sync point in the storage", func(t *testing.T) {
+		bcBolt := newTestChainWithCustomCfg(t, boltCfg)
+		module := bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+
+		module = bcBolt.GetStateSyncModule()
+		require.Error(t, module.Init(bcSpout.BlockHeight()+2*uint32(stateSyncInterval)))
+	})
+
+	t.Run("initialized: valid previous state sync point in the storage", func(t *testing.T) {
+		bcBolt := newTestChainWithCustomCfg(t, boltCfg)
+		module := bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+
+		module = bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+		require.True(t, module.IsActive())
+		require.True(t, module.IsInitialized())
+		require.True(t, module.NeedHeaders())
+		require.False(t, module.NeedMPTNodes())
+	})
+
+	t.Run("initialization from headers/blocks/mpt synced stages", func(t *testing.T) {
+		bcBolt := newTestChainWithCustomCfg(t, boltCfg)
+		module := bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+
+		// firstly, fetch all headers to create proper DB state (where headers are in sync)
+		stateSyncPoint := (int(bcSpout.BlockHeight()) / stateSyncInterval) * stateSyncInterval
+		var expectedHeader *block.Header
+		for i := 1; i <= int(bcSpout.HeaderHeight()); i++ {
+			header, err := bcSpout.GetHeader(bcSpout.GetHeaderHash(i))
+			require.NoError(t, err)
+			require.NoError(t, module.AddHeaders(header))
+			if i == stateSyncPoint+1 {
+				expectedHeader = header
+			}
+		}
+		require.True(t, module.IsActive())
+		require.True(t, module.IsInitialized())
+		require.False(t, module.NeedHeaders())
+		require.True(t, module.NeedMPTNodes())
+
+		// then create new statesync module with the same DB and check that state is proper
+		// (headers are in sync)
+		module = bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+		require.True(t, module.IsActive())
+		require.True(t, module.IsInitialized())
+		require.False(t, module.NeedHeaders())
+		require.True(t, module.NeedMPTNodes())
+		unknownNodes := module.GetUnknownMPTNodesBatch(2)
+		require.Equal(t, 1, len(unknownNodes))
+		require.Equal(t, expectedHeader.PrevStateRoot, unknownNodes[0])
+
+		// add several blocks to create DB state where blocks are not in sync yet, but it's not a genesis.
+		for i := stateSyncPoint - int(maxTraceable) + 1; i <= stateSyncPoint-stateSyncInterval-1; i++ {
+			block, err := bcSpout.GetBlock(bcSpout.GetHeaderHash(i))
+			require.NoError(t, err)
+			require.NoError(t, module.AddBlock(block))
+		}
+		require.True(t, module.IsActive())
+		require.True(t, module.IsInitialized())
+		require.False(t, module.NeedHeaders())
+		require.True(t, module.NeedMPTNodes())
+		require.Equal(t, uint32(stateSyncPoint-stateSyncInterval-1), module.BlockHeight())
+
+		// then create new statesync module with the same DB and check that state is proper
+		// (blocks are not in sync yet)
+		module = bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+		require.True(t, module.IsActive())
+		require.True(t, module.IsInitialized())
+		require.False(t, module.NeedHeaders())
+		require.True(t, module.NeedMPTNodes())
+		unknownNodes = module.GetUnknownMPTNodesBatch(2)
+		require.Equal(t, 1, len(unknownNodes))
+		require.Equal(t, expectedHeader.PrevStateRoot, unknownNodes[0])
+		require.Equal(t, uint32(stateSyncPoint-stateSyncInterval-1), module.BlockHeight())
+
+		// add rest of blocks to create DB state where blocks are in sync
+		for i := stateSyncPoint - stateSyncInterval; i <= stateSyncPoint; i++ {
+			block, err := bcSpout.GetBlock(bcSpout.GetHeaderHash(i))
+			require.NoError(t, err)
+			require.NoError(t, module.AddBlock(block))
+		}
+		require.True(t, module.IsActive())
+		require.True(t, module.IsInitialized())
+		require.False(t, module.NeedHeaders())
+		require.True(t, module.NeedMPTNodes())
+		lastBlock, err := bcBolt.GetBlock(expectedHeader.PrevHash)
+		require.NoError(t, err)
+		require.Equal(t, uint32(stateSyncPoint), lastBlock.Index)
+		require.Equal(t, uint32(stateSyncPoint), module.BlockHeight())
+
+		// then create new statesync module with the same DB and check that state is proper
+		// (headers and blocks are in sync)
+		module = bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+		require.True(t, module.IsActive())
+		require.True(t, module.IsInitialized())
+		require.False(t, module.NeedHeaders())
+		require.True(t, module.NeedMPTNodes())
+		unknownNodes = module.GetUnknownMPTNodesBatch(2)
+		require.Equal(t, 1, len(unknownNodes))
+		require.Equal(t, expectedHeader.PrevStateRoot, unknownNodes[0])
+		require.Equal(t, uint32(stateSyncPoint), module.BlockHeight())
+
+		// add a few MPT nodes to create DB state where some of MPT nodes are missing
+		count := 5
+		for {
+			unknownHashes := module.GetUnknownMPTNodesBatch(1) // restore nodes one-by-one
+			if len(unknownHashes) == 0 {
+				break
+			}
+			err := bcSpout.GetStateSyncModule().Traverse(unknownHashes[0], func(node mpt.Node, nodeBytes []byte) bool {
+				require.NoError(t, module.AddMPTNodes([][]byte{nodeBytes}))
+				return true // add nodes one-by-one
+			})
+			require.NoError(t, err)
+			count--
+			if count < 0 {
+				break
+			}
+		}
+
+		// then create new statesync module with the same DB and check that state is proper
+		// (headers and blocks are in sync, mpt is not yet synced)
+		module = bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+		require.True(t, module.IsActive())
+		require.True(t, module.IsInitialized())
+		require.False(t, module.NeedHeaders())
+		require.True(t, module.NeedMPTNodes())
+		unknownNodes = module.GetUnknownMPTNodesBatch(100)
+		require.True(t, len(unknownNodes) > 0)
+		require.NotContains(t, unknownNodes, expectedHeader.PrevStateRoot)
+		require.Equal(t, uint32(stateSyncPoint), module.BlockHeight())
+
+		// add the rest of MPT nodes and jump to state
+		for {
+			unknownHashes := module.GetUnknownMPTNodesBatch(1) // restore nodes one-by-one
+			if len(unknownHashes) == 0 {
+				break
+			}
+			err := bcSpout.GetStateSyncModule().Traverse(unknownHashes[0], func(node mpt.Node, nodeBytes []byte) bool {
+				require.NoError(t, module.AddMPTNodes([][]byte{slice.Copy(nodeBytes)}))
+				return true // add nodes one-by-one
+			})
+			require.NoError(t, err)
+		}
+
+		// check that module is inactive and statejump is completed
+		require.False(t, module.IsActive())
+		require.False(t, module.NeedHeaders())
+		require.False(t, module.NeedMPTNodes())
+		unknownNodes = module.GetUnknownMPTNodesBatch(1)
+		require.True(t, len(unknownNodes) == 0)
+		require.Equal(t, uint32(stateSyncPoint), module.BlockHeight())
+		require.Equal(t, uint32(stateSyncPoint), bcBolt.BlockHeight())
+
+		// create new module from completed state: the module should recognise that state sync is completed
+		module = bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+		require.False(t, module.IsActive())
+		require.False(t, module.NeedHeaders())
+		require.False(t, module.NeedMPTNodes())
+		unknownNodes = module.GetUnknownMPTNodesBatch(1)
+		require.True(t, len(unknownNodes) == 0)
+		require.Equal(t, uint32(stateSyncPoint), module.BlockHeight())
+		require.Equal(t, uint32(stateSyncPoint), bcBolt.BlockHeight())
+
+		// add one more block to the restored chain and start new module: the module should recognise state sync is completed
+		// and regular blocks processing was started
+		require.NoError(t, bcBolt.AddBlock(bcBolt.newBlock()))
+		module = bcBolt.GetStateSyncModule()
+		require.NoError(t, module.Init(bcSpout.BlockHeight()))
+		require.False(t, module.IsActive())
+		require.False(t, module.NeedHeaders())
+		require.False(t, module.NeedMPTNodes())
+		unknownNodes = module.GetUnknownMPTNodesBatch(1)
+		require.True(t, len(unknownNodes) == 0)
+		require.Equal(t, uint32(stateSyncPoint)+1, module.BlockHeight())
+		require.Equal(t, uint32(stateSyncPoint)+1, bcBolt.BlockHeight())
+	})
+}
+
+func TestStateSyncModule_RestoreBasicChain(t *testing.T) {
+	var (
+		stateSyncInterval        = 4
+		maxTraceable      uint32 = 6
+		stateSyncPoint           = 16
+	)
+	spoutCfg := func(c *config.Config) {
+		c.ProtocolConfiguration.StateRootInHeader = true
+		c.ProtocolConfiguration.P2PStateExchangeExtensions = true
+		c.ProtocolConfiguration.StateSyncInterval = stateSyncInterval
+		c.ProtocolConfiguration.MaxTraceableBlocks = maxTraceable
+	}
+	bcSpout := newTestChainWithCustomCfg(t, spoutCfg)
+	initBasicChain(t, bcSpout)
+
+	// make spout chain higher that latest state sync point
+	require.NoError(t, bcSpout.AddBlock(bcSpout.newBlock()))
+	require.NoError(t, bcSpout.AddBlock(bcSpout.newBlock()))
+	require.NoError(t, bcSpout.AddBlock(bcSpout.newBlock()))
+	require.Equal(t, uint32(stateSyncPoint+2), bcSpout.BlockHeight())
+
+	boltCfg := func(c *config.Config) {
+		spoutCfg(c)
+		c.ProtocolConfiguration.KeepOnlyLatestState = true
+		c.ProtocolConfiguration.RemoveUntraceableBlocks = true
+	}
+	bcBolt := newTestChainWithCustomCfg(t, boltCfg)
+	module := bcBolt.GetStateSyncModule()
+
+	t.Run("error: add headers before initialisation", func(t *testing.T) {
+		h, err := bcSpout.GetHeader(bcSpout.GetHeaderHash(1))
+		require.NoError(t, err)
+		require.Error(t, module.AddHeaders(h))
+	})
+	t.Run("no error: add blocks before initialisation", func(t *testing.T) {
+		b, err := bcSpout.GetBlock(bcSpout.GetHeaderHash(1))
+		require.NoError(t, err)
+		require.NoError(t, module.AddBlock(b))
+	})
+	t.Run("error: add MPT nodes without initialisation", func(t *testing.T) {
+		require.Error(t, module.AddMPTNodes([][]byte{}))
+	})
+
+	require.NoError(t, module.Init(bcSpout.BlockHeight()))
+	require.True(t, module.IsActive())
+	require.True(t, module.IsInitialized())
+	require.True(t, module.NeedHeaders())
+	require.False(t, module.NeedMPTNodes())
+
+	// add headers to module
+	headers := make([]*block.Header, 0, bcSpout.HeaderHeight())
+	for i := uint32(1); i <= bcSpout.HeaderHeight(); i++ {
+		h, err := bcSpout.GetHeader(bcSpout.GetHeaderHash(int(i)))
+		require.NoError(t, err)
+		headers = append(headers, h)
+	}
+	require.NoError(t, module.AddHeaders(headers...))
+	require.True(t, module.IsActive())
+	require.True(t, module.IsInitialized())
+	require.False(t, module.NeedHeaders())
+	require.True(t, module.NeedMPTNodes())
+	require.Equal(t, bcSpout.HeaderHeight(), bcBolt.HeaderHeight())
+
+	// add blocks
+	t.Run("error: unexpected block index", func(t *testing.T) {
+		b, err := bcSpout.GetBlock(bcSpout.GetHeaderHash(stateSyncPoint - int(maxTraceable)))
+		require.NoError(t, err)
+		require.Error(t, module.AddBlock(b))
+	})
+	t.Run("error: missing state root in block header", func(t *testing.T) {
+		b := &block.Block{
+			Header: block.Header{
+				Index:            uint32(stateSyncPoint) - maxTraceable + 1,
+				StateRootEnabled: false,
+			},
+		}
+		require.Error(t, module.AddBlock(b))
+	})
+	t.Run("error: invalid block merkle root", func(t *testing.T) {
+		b := &block.Block{
+			Header: block.Header{
+				Index:            uint32(stateSyncPoint) - maxTraceable + 1,
+				StateRootEnabled: true,
+				MerkleRoot:       util.Uint256{1, 2, 3},
+			},
+		}
+		require.Error(t, module.AddBlock(b))
+	})
+
+	for i := stateSyncPoint - int(maxTraceable) + 1; i <= stateSyncPoint; i++ {
+		b, err := bcSpout.GetBlock(bcSpout.GetHeaderHash(i))
+		require.NoError(t, err)
+		require.NoError(t, module.AddBlock(b))
+	}
+	require.True(t, module.IsActive())
+	require.True(t, module.IsInitialized())
+	require.False(t, module.NeedHeaders())
+	require.True(t, module.NeedMPTNodes())
+	require.Equal(t, uint32(stateSyncPoint), module.BlockHeight())
+
+	// add MPT nodes in batches
+	h, err := bcSpout.GetHeader(bcSpout.GetHeaderHash(stateSyncPoint + 1))
+	require.NoError(t, err)
+	unknownHashes := module.GetUnknownMPTNodesBatch(100)
+	require.Equal(t, 1, len(unknownHashes))
+	require.Equal(t, h.PrevStateRoot, unknownHashes[0])
+	nodesMap := make(map[util.Uint256][]byte)
+	err = bcSpout.GetStateSyncModule().Traverse(h.PrevStateRoot, func(n mpt.Node, nodeBytes []byte) bool {
+		nodesMap[n.Hash()] = nodeBytes
+		return false
+	})
+	require.NoError(t, err)
+	for {
+		need := module.GetUnknownMPTNodesBatch(10)
+		if len(need) == 0 {
+			break
+		}
+		add := make([][]byte, len(need))
+		for i, h := range need {
+			nodeBytes, ok := nodesMap[h]
+			if !ok {
+				t.Fatal("unknown or restored node requested")
+			}
+			add[i] = nodeBytes
+			delete(nodesMap, h)
+		}
+		require.NoError(t, module.AddMPTNodes(add))
+	}
+	require.False(t, module.IsActive())
+	require.False(t, module.NeedHeaders())
+	require.False(t, module.NeedMPTNodes())
+	unknownNodes := module.GetUnknownMPTNodesBatch(1)
+	require.True(t, len(unknownNodes) == 0)
+	require.Equal(t, uint32(stateSyncPoint), module.BlockHeight())
+	require.Equal(t, uint32(stateSyncPoint), bcBolt.BlockHeight())
+
+	// add missing blocks to bcBolt: should be ok, because state is synced
+	for i := stateSyncPoint + 1; i <= int(bcSpout.BlockHeight()); i++ {
+		b, err := bcSpout.GetBlock(bcSpout.GetHeaderHash(i))
+		require.NoError(t, err)
+		require.NoError(t, bcBolt.AddBlock(b))
+	}
+	require.Equal(t, bcSpout.BlockHeight(), bcBolt.BlockHeight())
+
+	// compare storage states
+	fetchStorage := func(bc *Blockchain) []storage.KeyValue {
+		var kv []storage.KeyValue
+		bc.dao.Store.Seek(storage.STStorage.Bytes(), func(k, v []byte) {
+			key := slice.Copy(k)
+			value := slice.Copy(v)
+			kv = append(kv, storage.KeyValue{
+				Key:   key,
+				Value: value,
+			})
+		})
+		return kv
+	}
+	expected := fetchStorage(bcSpout)
+	actual := fetchStorage(bcBolt)
+	require.ElementsMatch(t, expected, actual)
+
+	// no temp items should be left
+	bcBolt.dao.Store.Seek(storage.STTempStorage.Bytes(), func(k, v []byte) {
+		t.Fatal("temp storage items are found")
+	})
+}

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -27,6 +27,7 @@ const (
 	SYSCurrentHeader               KeyPrefix = 0xc1
 	SYSStateSyncCurrentBlockHeight KeyPrefix = 0xc2
 	SYSStateSyncPoint              KeyPrefix = 0xc3
+	SYSStateJumpStage              KeyPrefix = 0xc4
 	SYSVersion                     KeyPrefix = 0xf0
 )
 

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -8,13 +8,18 @@ import (
 
 // KeyPrefix constants.
 const (
-	DataBlock                      KeyPrefix = 0x01
-	DataTransaction                KeyPrefix = 0x02
-	DataMPT                        KeyPrefix = 0x03
-	STAccount                      KeyPrefix = 0x40
-	STNotification                 KeyPrefix = 0x4d
-	STContractID                   KeyPrefix = 0x51
-	STStorage                      KeyPrefix = 0x70
+	DataBlock       KeyPrefix = 0x01
+	DataTransaction KeyPrefix = 0x02
+	DataMPT         KeyPrefix = 0x03
+	STAccount       KeyPrefix = 0x40
+	STNotification  KeyPrefix = 0x4d
+	STContractID    KeyPrefix = 0x51
+	STStorage       KeyPrefix = 0x70
+	// STTempStorage is used to store contract storage items during state sync process
+	// in order not to mess up the previous state which has its own items stored by
+	// STStorage prefix. Once state exchange process is completed, all items with
+	// STStorage prefix will be replaced with STTempStorage-prefixed ones.
+	STTempStorage                  KeyPrefix = 0x71
 	STNEP17Transfers               KeyPrefix = 0x72
 	STNEP17TransferInfo            KeyPrefix = 0x73
 	IXHeaderHashList               KeyPrefix = 0x80

--- a/pkg/network/message.go
+++ b/pkg/network/message.go
@@ -71,6 +71,8 @@ const (
 	CMDBlock                        = CommandType(payload.BlockType)
 	CMDExtensible                   = CommandType(payload.ExtensibleType)
 	CMDP2PNotaryRequest             = CommandType(payload.P2PNotaryRequestType)
+	CMDGetMPTData       CommandType = 0x51 // 0x5.. commands are used for extensions (P2PNotary, state exchange cmds)
+	CMDMPTData          CommandType = 0x52
 	CMDReject           CommandType = 0x2f
 
 	// SPV protocol.
@@ -136,6 +138,10 @@ func (m *Message) decodePayload() error {
 		p = &payload.Version{}
 	case CMDInv, CMDGetData:
 		p = &payload.Inventory{}
+	case CMDGetMPTData:
+		p = &payload.MPTInventory{}
+	case CMDMPTData:
+		p = &payload.MPTData{}
 	case CMDAddr:
 		p = &payload.AddressList{}
 	case CMDBlock:
@@ -221,7 +227,7 @@ func (m *Message) tryCompressPayload() error {
 	if m.Flags&Compressed == 0 {
 		switch m.Payload.(type) {
 		case *payload.Headers, *payload.MerkleBlock, payload.NullPayload,
-			*payload.Inventory:
+			*payload.Inventory, *payload.MPTInventory:
 			break
 		default:
 			size := len(compressedPayload)

--- a/pkg/network/message_string.go
+++ b/pkg/network/message_string.go
@@ -26,6 +26,8 @@ func _() {
 	_ = x[CMDBlock-44]
 	_ = x[CMDExtensible-46]
 	_ = x[CMDP2PNotaryRequest-80]
+	_ = x[CMDGetMPTData-81]
+	_ = x[CMDMPTData-82]
 	_ = x[CMDReject-47]
 	_ = x[CMDFilterLoad-48]
 	_ = x[CMDFilterAdd-49]
@@ -44,7 +46,7 @@ const (
 	_CommandType_name_6 = "CMDExtensibleCMDRejectCMDFilterLoadCMDFilterAddCMDFilterClear"
 	_CommandType_name_7 = "CMDMerkleBlock"
 	_CommandType_name_8 = "CMDAlert"
-	_CommandType_name_9 = "CMDP2PNotaryRequest"
+	_CommandType_name_9 = "CMDP2PNotaryRequestCMDGetMPTDataCMDMPTData"
 )
 
 var (
@@ -55,6 +57,7 @@ var (
 	_CommandType_index_4 = [...]uint8{0, 12, 22}
 	_CommandType_index_5 = [...]uint8{0, 6, 16, 34, 45, 50, 58}
 	_CommandType_index_6 = [...]uint8{0, 13, 22, 35, 47, 61}
+	_CommandType_index_9 = [...]uint8{0, 19, 32, 42}
 )
 
 func (i CommandType) String() string {
@@ -83,8 +86,9 @@ func (i CommandType) String() string {
 		return _CommandType_name_7
 	case i == 64:
 		return _CommandType_name_8
-	case i == 80:
-		return _CommandType_name_9
+	case 80 <= i && i <= 82:
+		i -= 80
+		return _CommandType_name_9[_CommandType_index_9[i]:_CommandType_index_9[i+1]]
 	default:
 		return "CommandType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/pkg/network/message_test.go
+++ b/pkg/network/message_test.go
@@ -258,6 +258,21 @@ func TestEncodeDecodeNotFound(t *testing.T) {
 	})
 }
 
+func TestEncodeDecodeGetMPTData(t *testing.T) {
+	testEncodeDecode(t, CMDGetMPTData, &payload.MPTInventory{
+		Hashes: []util.Uint256{
+			{1, 2, 3},
+			{4, 5, 6},
+		},
+	})
+}
+
+func TestEncodeDecodeMPTData(t *testing.T) {
+	testEncodeDecode(t, CMDMPTData, &payload.MPTData{
+		Nodes: [][]byte{{1, 2, 3}, {4, 5, 6}},
+	})
+}
+
 func TestInvalidMessages(t *testing.T) {
 	t.Run("CMDBlock, empty payload", func(t *testing.T) {
 		testEncodeDecodeFail(t, CMDBlock, payload.NullPayload{})

--- a/pkg/network/payload/mptdata.go
+++ b/pkg/network/payload/mptdata.go
@@ -1,0 +1,35 @@
+package payload
+
+import (
+	"errors"
+
+	"github.com/nspcc-dev/neo-go/pkg/io"
+)
+
+// MPTData represents the set of serialized MPT nodes.
+type MPTData struct {
+	Nodes [][]byte
+}
+
+// EncodeBinary implements io.Serializable.
+func (d *MPTData) EncodeBinary(w *io.BinWriter) {
+	w.WriteVarUint(uint64(len(d.Nodes)))
+	for _, n := range d.Nodes {
+		w.WriteVarBytes(n)
+	}
+}
+
+// DecodeBinary implements io.Serializable.
+func (d *MPTData) DecodeBinary(r *io.BinReader) {
+	sz := r.ReadVarUint()
+	if sz == 0 {
+		r.Err = errors.New("empty MPT nodes list")
+		return
+	}
+	for i := uint64(0); i < sz; i++ {
+		d.Nodes = append(d.Nodes, r.ReadVarBytes())
+		if r.Err != nil {
+			return
+		}
+	}
+}

--- a/pkg/network/payload/mptdata_test.go
+++ b/pkg/network/payload/mptdata_test.go
@@ -1,0 +1,24 @@
+package payload
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/internal/testserdes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMPTData_EncodeDecodeBinary(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		d := new(MPTData)
+		bytes, err := testserdes.EncodeBinary(d)
+		require.NoError(t, err)
+		require.Error(t, testserdes.DecodeBinary(bytes, new(MPTData)))
+	})
+
+	t.Run("good", func(t *testing.T) {
+		d := &MPTData{
+			Nodes: [][]byte{{}, {1}, {1, 2, 3}},
+		}
+		testserdes.EncodeDecodeBinary(t, d, new(MPTData))
+	})
+}

--- a/pkg/network/payload/mptinventory.go
+++ b/pkg/network/payload/mptinventory.go
@@ -1,0 +1,32 @@
+package payload
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+// MaxMPTHashesCount is the maximum number of requested MPT nodes hashes.
+const MaxMPTHashesCount = 32
+
+// MPTInventory payload.
+type MPTInventory struct {
+	// A list of requested MPT nodes hashes.
+	Hashes []util.Uint256
+}
+
+// NewMPTInventory return a pointer to an MPTInventory.
+func NewMPTInventory(hashes []util.Uint256) *MPTInventory {
+	return &MPTInventory{
+		Hashes: hashes,
+	}
+}
+
+// DecodeBinary implements Serializable interface.
+func (p *MPTInventory) DecodeBinary(br *io.BinReader) {
+	br.ReadArray(&p.Hashes, MaxMPTHashesCount)
+}
+
+// EncodeBinary implements Serializable interface.
+func (p *MPTInventory) EncodeBinary(bw *io.BinWriter) {
+	bw.WriteArray(p.Hashes)
+}

--- a/pkg/network/payload/mptinventory_test.go
+++ b/pkg/network/payload/mptinventory_test.go
@@ -1,0 +1,38 @@
+package payload
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/internal/testserdes"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMPTInventory_EncodeDecodeBinary(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		testserdes.EncodeDecodeBinary(t, NewMPTInventory([]util.Uint256{}), new(MPTInventory))
+	})
+
+	t.Run("good", func(t *testing.T) {
+		inv := NewMPTInventory([]util.Uint256{{1, 2, 3}, {2, 3, 4}})
+		testserdes.EncodeDecodeBinary(t, inv, new(MPTInventory))
+	})
+
+	t.Run("too large", func(t *testing.T) {
+		check := func(t *testing.T, count int, fail bool) {
+			h := make([]util.Uint256, count)
+			for i := range h {
+				h[i] = util.Uint256{1, 2, 3}
+			}
+			if fail {
+				bytes, err := testserdes.EncodeBinary(NewMPTInventory(h))
+				require.NoError(t, err)
+				require.Error(t, testserdes.DecodeBinary(bytes, new(MPTInventory)))
+			} else {
+				testserdes.EncodeDecodeBinary(t, NewMPTInventory(h), new(MPTInventory))
+			}
+		}
+		check(t, MaxMPTHashesCount, false)
+		check(t, MaxMPTHashesCount+1, true)
+	})
+}

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	mrand "math/rand"
 	"net"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -17,7 +18,9 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/blockchainer"
 	"github.com/nspcc-dev/neo-go/pkg/core/mempool"
 	"github.com/nspcc-dev/neo-go/pkg/core/mempoolevent"
+	"github.com/nspcc-dev/neo-go/pkg/core/mpt"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
+	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/network/capability"
 	"github.com/nspcc-dev/neo-go/pkg/network/extpool"
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
@@ -67,6 +70,7 @@ type (
 		discovery         Discoverer
 		chain             blockchainer.Blockchainer
 		bQueue            *blockQueue
+		bSyncQueue        *blockQueue
 		consensus         consensus.Service
 		mempool           *mempool.Pool
 		notaryRequestPool *mempool.Pool
@@ -93,6 +97,7 @@ type (
 
 		oracle    *oracle.Oracle
 		stateRoot stateroot.Service
+		stateSync blockchainer.StateSync
 
 		log *zap.Logger
 	}
@@ -191,6 +196,10 @@ func newServerFromConstructors(config ServerConfig, chain blockchainer.Blockchai
 	}
 	s.stateRoot = sr
 
+	sSync := chain.GetStateSyncModule()
+	s.stateSync = sSync
+	s.bSyncQueue = newBlockQueue(maxBlockBatch, sSync, log, nil)
+
 	if config.OracleCfg.Enabled {
 		orcCfg := oracle.Config{
 			Log:     log,
@@ -277,6 +286,7 @@ func (s *Server) Start(errChan chan error) {
 	go s.broadcastTxLoop()
 	go s.relayBlocksLoop()
 	go s.bQueue.run()
+	go s.bSyncQueue.run()
 	go s.transport.Accept()
 	setServerAndNodeVersions(s.UserAgent, strconv.FormatUint(uint64(s.id), 10))
 	s.run()
@@ -292,6 +302,7 @@ func (s *Server) Shutdown() {
 		p.Disconnect(errServerShutdown)
 	}
 	s.bQueue.discard()
+	s.bSyncQueue.discard()
 	if s.StateRootCfg.Enabled {
 		s.stateRoot.Shutdown()
 	}
@@ -573,6 +584,10 @@ func (s *Server) IsInSync() bool {
 	var peersNumber int
 	var notHigher int
 
+	if s.stateSync.IsActive() {
+		return false
+	}
+
 	if s.MinPeers == 0 {
 		return true
 	}
@@ -630,6 +645,9 @@ func (s *Server) handleVersionCmd(p Peer, version *payload.Version) error {
 
 // handleBlockCmd processes the received block received from its peer.
 func (s *Server) handleBlockCmd(p Peer, block *block.Block) error {
+	if s.stateSync.IsActive() {
+		return s.bSyncQueue.putBlock(block)
+	}
 	return s.bQueue.putBlock(block)
 }
 
@@ -639,13 +657,37 @@ func (s *Server) handlePing(p Peer, ping *payload.Ping) error {
 	if err != nil {
 		return err
 	}
-	if s.chain.BlockHeight() < ping.LastBlockIndex {
-		err = s.requestBlocks(p)
-		if err != nil {
-			return err
-		}
+	err = s.requestBlocksOrHeaders(p)
+	if err != nil {
+		return err
 	}
 	return p.EnqueueP2PMessage(NewMessage(CMDPong, payload.NewPing(s.chain.BlockHeight(), s.id)))
+}
+
+func (s *Server) requestBlocksOrHeaders(p Peer) error {
+	if s.stateSync.NeedHeaders() {
+		if s.chain.HeaderHeight() < p.LastBlockIndex() {
+			return s.requestHeaders(p)
+		}
+		return nil
+	}
+	var bq blockchainer.Blockqueuer = s.chain
+	if s.stateSync.IsActive() {
+		bq = s.stateSync
+	}
+	if bq.BlockHeight() < p.LastBlockIndex() {
+		return s.requestBlocks(bq, p)
+	}
+	return nil
+}
+
+// requestHeaders sends a CMDGetHeaders message to the peer to sync up in headers.
+func (s *Server) requestHeaders(p Peer) error {
+	// TODO: optimize
+	currHeight := s.chain.HeaderHeight()
+	needHeight := currHeight + 1
+	payload := payload.NewGetBlockByIndex(needHeight, -1)
+	return p.EnqueueP2PMessage(NewMessage(CMDGetHeaders, payload))
 }
 
 // handlePing processes pong request.
@@ -654,10 +696,7 @@ func (s *Server) handlePong(p Peer, pong *payload.Ping) error {
 	if err != nil {
 		return err
 	}
-	if s.chain.BlockHeight() < pong.LastBlockIndex {
-		return s.requestBlocks(p)
-	}
-	return nil
+	return s.requestBlocksOrHeaders(p)
 }
 
 // handleInvCmd processes the received inventory.
@@ -766,6 +805,50 @@ func (s *Server) handleGetDataCmd(p Peer, inv *payload.Inventory) error {
 	return nil
 }
 
+// handleGetMPTDataCmd processes the received MPT inventory.
+func (s *Server) handleGetMPTDataCmd(p Peer, inv *payload.MPTInventory) error {
+	if !s.chain.GetConfig().P2PStateExchangeExtensions {
+		return errors.New("GetMPTDataCMD was received, but P2PStateExchangeExtensions are disabled")
+	}
+	if s.chain.GetConfig().KeepOnlyLatestState {
+		// TODO: implement keeping MPT states for P1 and P2 height (#2095, #2152 related)
+		return errors.New("GetMPTDataCMD was received, but only latest MPT state is supported")
+	}
+	resp := payload.MPTData{}
+	capLeft := payload.MaxSize - 8 // max(io.GetVarSize(len(resp.Nodes)))
+	for _, h := range inv.Hashes {
+		if capLeft <= 2 { // at least 1 byte for len(nodeBytes) and 1 byte for node type
+			break
+		}
+		err := s.stateSync.Traverse(h,
+			func(_ mpt.Node, node []byte) bool {
+				l := len(node)
+				size := l + io.GetVarSize(l)
+				if size > capLeft {
+					return true
+				}
+				resp.Nodes = append(resp.Nodes, node)
+				capLeft -= size
+				return false
+			})
+		if err != nil {
+			return fmt.Errorf("failed to traverse MPT starting from %s: %w", h.StringBE(), err)
+		}
+	}
+	if len(resp.Nodes) > 0 {
+		msg := NewMessage(CMDMPTData, &resp)
+		return p.EnqueueP2PMessage(msg)
+	}
+	return nil
+}
+
+func (s *Server) handleMPTDataCmd(p Peer, data *payload.MPTData) error {
+	if !s.chain.GetConfig().P2PStateExchangeExtensions {
+		return errors.New("MPTDataCMD was received, but P2PStateExchangeExtensions are disabled")
+	}
+	return s.stateSync.AddMPTNodes(data.Nodes)
+}
+
 // handleGetBlocksCmd processes the getblocks request.
 func (s *Server) handleGetBlocksCmd(p Peer, gb *payload.GetBlocks) error {
 	count := gb.Count
@@ -843,6 +926,11 @@ func (s *Server) handleGetHeadersCmd(p Peer, gh *payload.GetBlockByIndex) error 
 	}
 	msg := NewMessage(CMDHeaders, &resp)
 	return p.EnqueueP2PMessage(msg)
+}
+
+// handleHeadersCmd processes headers payload.
+func (s *Server) handleHeadersCmd(p Peer, h *payload.Headers) error {
+	return s.stateSync.AddHeaders(h.Hdrs...)
 }
 
 // handleExtensibleCmd processes received extensible payload.
@@ -993,8 +1081,8 @@ func (s *Server) handleGetAddrCmd(p Peer) error {
 // 1. Block range is divided into chunks of payload.MaxHashesCount.
 // 2. Send requests for chunk in increasing order.
 // 3. After all requests were sent, request random height.
-func (s *Server) requestBlocks(p Peer) error {
-	var currHeight = s.chain.BlockHeight()
+func (s *Server) requestBlocks(bq blockchainer.Blockqueuer, p Peer) error {
+	var currHeight = bq.BlockHeight()
 	var peerHeight = p.LastBlockIndex()
 	var needHeight uint32
 	// lastRequestedHeight can only be increased.
@@ -1051,9 +1139,18 @@ func (s *Server) handleMessage(peer Peer, msg *Message) error {
 		case CMDGetData:
 			inv := msg.Payload.(*payload.Inventory)
 			return s.handleGetDataCmd(peer, inv)
+		case CMDGetMPTData:
+			inv := msg.Payload.(*payload.MPTInventory)
+			return s.handleGetMPTDataCmd(peer, inv)
+		case CMDMPTData:
+			inv := msg.Payload.(*payload.MPTData)
+			return s.handleMPTDataCmd(peer, inv)
 		case CMDGetHeaders:
 			gh := msg.Payload.(*payload.GetBlockByIndex)
 			return s.handleGetHeadersCmd(peer, gh)
+		case CMDHeaders:
+			h := msg.Payload.(*payload.Headers)
+			return s.handleHeadersCmd(peer, h)
 		case CMDInv:
 			inventory := msg.Payload.(*payload.Inventory)
 			return s.handleInvCmd(peer, inventory)
@@ -1093,6 +1190,7 @@ func (s *Server) handleMessage(peer Peer, msg *Message) error {
 			}
 			go peer.StartProtocol()
 
+			s.tryInitStateSync()
 			s.tryStartServices()
 		default:
 			return fmt.Errorf("received '%s' during handshake", msg.Command.String())
@@ -1101,6 +1199,52 @@ func (s *Server) handleMessage(peer Peer, msg *Message) error {
 	return nil
 }
 
+func (s *Server) tryInitStateSync() {
+	if !s.stateSync.IsActive() {
+		s.bSyncQueue.discard()
+		return
+	}
+
+	if s.stateSync.IsInitialized() {
+		return
+	}
+
+	var peersNumber int
+	s.lock.RLock()
+	heights := make([]uint32, 0)
+	for p := range s.peers {
+		if p.Handshaked() {
+			peersNumber++
+			peerLastBlock := p.LastBlockIndex()
+			i := sort.Search(len(heights), func(i int) bool {
+				return heights[i] >= peerLastBlock
+			})
+			heights = append(heights, peerLastBlock)
+			if i != len(heights)-1 {
+				copy(heights[i+1:], heights[i:])
+				heights[i] = peerLastBlock
+			}
+		}
+	}
+	s.lock.RUnlock()
+	if peersNumber >= s.MinPeers && len(heights) > 0 {
+		// choose the height of the median peer as current chain's height
+		h := heights[len(heights)/2]
+		err := s.stateSync.Init(h)
+		if err != nil {
+			s.log.Fatal("failed to init state sync module",
+				zap.Uint32("evaluated chain's blockHeight", h),
+				zap.Uint32("blockHeight", s.chain.BlockHeight()),
+				zap.Uint32("headerHeight", s.chain.HeaderHeight()),
+				zap.Error(err))
+		}
+
+		// module can be inactive after init (i.e. full state is collected and ordinary block processing is needed)
+		if !s.stateSync.IsActive() {
+			s.bSyncQueue.discard()
+		}
+	}
+}
 func (s *Server) handleNewPayload(p *payload.Extensible) {
 	_, err := s.extensiblePool.Add(p)
 	if err != nil {


### PR DESCRIPTION
Close #1992.
Depends on #2143.

TODO:
- [x] Tests
- [x] Do not request those nodes that are in storage already.
- [x] ~~Keep MPT state for two latest sync points with `KeepOnlyLatestState` setting on.~~ This should be done in https://github.com/nspcc-dev/neo-go/issues/2095. All we need after that is to adjust server's `handleGetMPTDataCmd` behaviour (see https://github.com/nspcc-dev/neo-go/issues/2152)