### PR TITLE
Fix permissions in example manifests

### DIFF
--- a/examples/nft-nd-nns/nns.yml
+++ b/examples/nft-nd-nns/nns.yml
@@ -14,4 +14,6 @@ events:
       - name: tokenId
         type: ByteArray
 permissions:
+  - hash: fffdc93764dbaddd97c48f252a53ea4643faa3fd
+    methods: ["update"]
   - methods: ["onNEP11Payment"]

--- a/examples/nft-nd-nns/nns.yml
+++ b/examples/nft-nd-nns/nns.yml
@@ -14,4 +14,4 @@ events:
       - name: tokenId
         type: ByteArray
 permissions:
-  - methods: ["onNEP11Transfer"]
+  - methods: ["onNEP11Payment"]

--- a/examples/nft-nd/nft.yml
+++ b/examples/nft-nd/nft.yml
@@ -13,4 +13,4 @@ events:
       - name: tokenId
         type: ByteArray
 permissions:
-  - methods: ["onNEP11Transfer"]
+  - methods: ["onNEP11Payment"]

--- a/examples/nft-nd/nft.yml
+++ b/examples/nft-nd/nft.yml
@@ -13,4 +13,6 @@ events:
       - name: tokenId
         type: ByteArray
 permissions:
+  - hash: fffdc93764dbaddd97c48f252a53ea4643faa3fd
+    methods: ["update", "destroy"]
   - methods: ["onNEP11Payment"]

--- a/examples/oracle/oracle.yml
+++ b/examples/oracle/oracle.yml
@@ -1,3 +1,5 @@
 name: "Oracle example"
 supportedstandards: []
 events:
+permissions:
+  - methods: ["request"]

--- a/examples/timer/timer.yml
+++ b/examples/timer/timer.yml
@@ -1,3 +1,5 @@
 name: "Timer example"
 supportedstandards: []
 events: []
+permissions:
+  - methods: '*'

--- a/examples/token/token.yml
+++ b/examples/token/token.yml
@@ -10,3 +10,5 @@ events:
         type: Hash160
       - name: amount
         type: Integer
+permissions:
+  - methods: ["onNEP17Payment"]


### PR DESCRIPTION
### Problem
Manifest files should contain permission section if contract makes invocations with writing scope. However not every example contracts adopted this change.