### PR TITLE
Fix manifest `Extra` field marshaling

### DIFF
--- a/cli/nep11_test.go
+++ b/cli/nep11_test.go
@@ -312,7 +312,7 @@ func TestNEP11_OwnerOf_BalanceOf_Transfer(t *testing.T) {
 		ScriptHash: verifyH,
 		Name:       "OnNEP11Payment",
 		Item: stackitem.NewArray([]stackitem.Item{
-			stackitem.NewByteArray(nftOwnerHash.BytesBE()),
+			stackitem.NewBuffer(nftOwnerHash.BytesBE()),
 			stackitem.NewBigInteger(big.NewInt(1)),
 			stackitem.NewByteArray(tokenID1),
 			stackitem.NewByteArray([]byte("some_data")),

--- a/pkg/smartcontract/manifest/manifest_test.go
+++ b/pkg/smartcontract/manifest/manifest_test.go
@@ -289,7 +289,7 @@ func TestManifestToStackItem(t *testing.T) {
 					},
 				},
 			},
-			Extra: []byte(`even not a json allowed`),
+			Extra: []byte(`"even string allowed"`),
 		}
 		check(t, expected)
 	})
@@ -393,5 +393,27 @@ func TestABI_FromStackItemErrors(t *testing.T) {
 			p := new(ABI)
 			require.Error(t, p.FromStackItem(errCase))
 		})
+	}
+}
+
+func TestExtraToStackItem(t *testing.T) {
+	testCases := []struct {
+		raw, expected string
+	}{
+		{"null", "null"},
+		{"1", "1"},
+		{"1.23456789101112131415", "1.23456789101112131415"},
+		{`"string with space"`, `"string with space"`},
+		{`{ "a":1, "sss" : {"m" : 1, "a" : 2} , "x"  :  2  ,"c" :3,"z":4,  "s":"5"}`,
+			`{"a":1,"sss":{"m":1,"a":2},"x":2,"c":3,"z":4,"s":"5"}`},
+		{`  [ 1, "array", { "d": "z", "a":"x",  "c" : "y",  "b":3}]`,
+			`[1,"array",{"d":"z","a":"x","c":"y","b":3}]`},
+	}
+
+	for _, tc := range testCases {
+		res := extraToStackItem([]byte(tc.raw))
+		actual, ok := res.Value().([]byte)
+		require.True(t, ok)
+		require.Equal(t, tc.expected, string(actual))
 	}
 }

--- a/pkg/vm/stackitem/serialization.go
+++ b/pkg/vm/stackitem/serialization.go
@@ -129,7 +129,10 @@ func decodeBinaryStackItem(r *io.BinReader, allowInvalid bool) Item {
 	switch t {
 	case ByteArrayT, BufferT:
 		data := r.ReadVarBytes(MaxSize)
-		return NewByteArray(data)
+		if t == ByteArrayT {
+			return NewByteArray(data)
+		}
+		return NewBuffer(data)
 	case BooleanT:
 		var b = r.ReadBool()
 		return NewBool(b)


### PR DESCRIPTION
Close #2021. 

State root at that height matches the one specified in task.

Also found and fixed another bug which affected `getapplicationlog` response.