### PR TITLE
core: allow to add several headers with StateRootInHeader on

### DIFF
--- a/pkg/core/stateroot/module.go
+++ b/pkg/core/stateroot/module.go
@@ -70,6 +70,11 @@ func (s *Module) CurrentLocalStateRoot() util.Uint256 {
 	return s.currentLocal.Load().(util.Uint256)
 }
 
+// CurrentLocalHeight returns height of the local state root.
+func (s *Module) CurrentLocalHeight() uint32 {
+	return s.localHeight.Load()
+}
+
 // CurrentValidatedHeight returns current state root validated height.
 func (s *Module) CurrentValidatedHeight() uint32 {
 	return s.validatedHeight.Load()


### PR DESCRIPTION
### Problem

With StateRootInHeader setting on only one header of height N+1
can be added to the chain of height N, because we need local stateroot
to verify headers (which is calculated for the last stored block N).
Thus, adding chunk of headers starting from the current chain's heigh
is impossible and (*Blockchain).AddHeaders doesn't have much sense.

### Solution

Verify header.PrevStateRoot only for header N+1. Rest of the
headers should be added without PrevStateRoot verification.