### PR TITLE
circleci: fix image build with latest alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,13 +97,14 @@ jobs:
       - run: apk update && apk add git make curl tar
       - checkout
       - gomod
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.6
       - run:
           name: Install Docker client
           command: |
             set -x
-            VER="17.03.0-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz
+            VER="20.10.6"
+            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
             tar -xz -C /tmp -f /tmp/docker-$VER.tgz
             mv /tmp/docker/* /usr/bin
       - run: make image


### PR DESCRIPTION
Upgrade Docker, see
https://discuss.circleci.com/t/unable-to-use-make/40552
https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396
