### PR TITLE
vm: copy integers for unary operations, fix #2051

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -831,7 +831,7 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 		// inplace
 		e := v.estack.Peek(0)
 		i := e.BigInt()
-		e.value = stackitem.Make(i.Not(i))
+		e.value = stackitem.Make(new(big.Int).Not(i))
 
 	case opcode.AND:
 		b := v.estack.Pop().BigInt()
@@ -866,11 +866,11 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 
 	case opcode.ABS:
 		x := v.estack.Pop().BigInt()
-		v.estack.PushVal(x.Abs(x))
+		v.estack.PushVal(new(big.Int).Abs(x))
 
 	case opcode.NEGATE:
 		x := v.estack.Pop().BigInt()
-		v.estack.PushVal(x.Neg(x))
+		v.estack.PushVal(new(big.Int).Neg(x))
 
 	case opcode.INC:
 		x := v.estack.Pop().BigInt()

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -2050,6 +2050,18 @@ func TestDupInt(t *testing.T) {
 	assert.Equal(t, int64(-1), vm.estack.Pop().BigInt().Int64())
 }
 
+func TestNegateCopy(t *testing.T) {
+	prog := makeProgram(opcode.NEGATE)
+	v := load(prog)
+	bi := stackitem.Make(-1)
+	v.estack.PushVal(bi)
+	v.estack.PushVal(bi)
+	runVM(t, v)
+	assert.Equal(t, 2, v.estack.Len())
+	assert.Equal(t, int64(1), v.estack.Pop().BigInt().Int64())
+	assert.Equal(t, int64(-1), v.estack.Pop().BigInt().Int64())
+}
+
 func TestDupByteArray(t *testing.T) {
 	prog := makeProgram(opcode.PUSHDATA1, 2, 1, 0,
 		opcode.DUP,


### PR DESCRIPTION
We should copy all primitive types, so it is a DUP essentially.
The bug is quite severe, e.g. this function compiled will return 2:
```
func minus2() int {
	x := 1
	return -x + (-x)
}
```

This fixes state difference at height 275663
for tx 3c498317684d63849b03e4c58ad57ce4b19bb206b7b01bcc64233de3b3e207f4

Signed-off-by: Evgeniy Stratonikov <evgeniy@nspcc.ru>

