### PR TITLE
Speedup stackitem json serialization

### DIFF
--- a/pkg/vm/stackitem/json.go
+++ b/pkg/vm/stackitem/json.go
@@ -68,8 +68,14 @@ func toJSON(data []byte, seen map[Item]sliceNoPointer, item Item) ([]byte, error
 
 	switch it := item.(type) {
 	case *Array, *Struct:
+		var items []Item
+		if a, ok := it.(*Array); ok {
+			items = a.value
+		} else {
+			items = it.(*Struct).value
+		}
+
 		data = append(data, '[')
-		items := it.Value().([]Item)
 		for i, v := range items {
 			data, err = toJSON(data, seen, v)
 			if err != nil {

--- a/pkg/vm/stackitem/json.go
+++ b/pkg/vm/stackitem/json.go
@@ -9,8 +9,6 @@ import (
 	gio "io"
 	"math"
 	"math/big"
-
-	"github.com/nspcc-dev/neo-go/pkg/io"
 )
 
 // decoder is a wrapper around json.Decoder helping to mimic C# json decoder behaviour.
@@ -43,87 +41,106 @@ var ErrTooDeep = errors.New("too deep")
 //   Array, Struct -> array
 //   Map -> map with keys as UTF-8 bytes
 func ToJSON(item Item) ([]byte, error) {
-	buf := io.NewBufBinWriter()
-	toJSON(buf, item)
-	if buf.Err != nil {
-		return nil, buf.Err
-	}
-	return buf.Bytes(), nil
+	seen := make(map[Item]sliceNoPointer)
+	return toJSON(nil, seen, item)
 }
 
-func toJSON(buf *io.BufBinWriter, item Item) {
-	w := buf.BinWriter
-	if w.Err != nil {
-		return
-	} else if buf.Len() > MaxSize {
-		w.Err = errTooBigSize
+// sliceNoPointer represents sub-slice of a known slice.
+// It doesn't contain pointer and uses less memory than `[]byte`.
+type sliceNoPointer struct {
+	start, end int
+}
+
+func toJSON(data []byte, seen map[Item]sliceNoPointer, item Item) ([]byte, error) {
+	if len(data) > MaxSize {
+		return nil, errTooBigSize
 	}
+
+	if old, ok := seen[item]; ok {
+		if len(data)+old.end-old.start > MaxSize {
+			return nil, errTooBigSize
+		}
+		return append(data, data[old.start:old.end]...), nil
+	}
+
+	start := len(data)
+	var err error
+
 	switch it := item.(type) {
 	case *Array, *Struct:
-		w.WriteB('[')
+		data = append(data, '[')
 		items := it.Value().([]Item)
 		for i, v := range items {
-			toJSON(buf, v)
+			data, err = toJSON(data, seen, v)
+			if err != nil {
+				return nil, err
+			}
 			if i < len(items)-1 {
-				w.WriteB(',')
+				data = append(data, ',')
 			}
 		}
-		w.WriteB(']')
+		data = append(data, ']')
+		seen[item] = sliceNoPointer{start, len(data)}
 	case *Map:
-		w.WriteB('{')
+		data = append(data, '{')
 		for i := range it.value {
 			// map key can always be converted to []byte
 			// but are not always a valid UTF-8.
-			writeJSONString(buf.BinWriter, it.value[i].Key)
-			w.WriteBytes([]byte(`:`))
-			toJSON(buf, it.value[i].Value)
+			raw, err := itemToJSONString(it.value[i].Key)
+			if err != nil {
+				return nil, err
+			}
+			data = append(data, raw...)
+			data = append(data, ':')
+			data, err = toJSON(data, seen, it.value[i].Value)
+			if err != nil {
+				return nil, err
+			}
 			if i < len(it.value)-1 {
-				w.WriteB(',')
+				data = append(data, ',')
 			}
 		}
-		w.WriteB('}')
+		data = append(data, '}')
+		seen[item] = sliceNoPointer{start, len(data)}
 	case *BigInteger:
 		if it.value.CmpAbs(big.NewInt(MaxAllowedInteger)) == 1 {
-			w.Err = fmt.Errorf("%w (MaxAllowedInteger)", ErrInvalidValue)
-			return
+			return nil, fmt.Errorf("%w (MaxAllowedInteger)", ErrInvalidValue)
 		}
-		w.WriteBytes([]byte(it.value.String()))
+		data = append(data, it.value.String()...)
 	case *ByteArray, *Buffer:
-		writeJSONString(w, it)
+		raw, err := itemToJSONString(it)
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, raw...)
 	case *Bool:
 		if it.value {
-			w.WriteBytes([]byte("true"))
+			data = append(data, "true"...)
 		} else {
-			w.WriteBytes([]byte("false"))
+			data = append(data, "false"...)
 		}
 	case Null:
-		w.WriteBytes([]byte("null"))
+		data = append(data, "null"...)
 	default:
-		w.Err = fmt.Errorf("%w: %s", ErrUnserializable, it.String())
-		return
+		return nil, fmt.Errorf("%w: %s", ErrUnserializable, it.String())
 	}
-	if w.Err == nil && buf.Len() > MaxSize {
-		w.Err = errTooBigSize
+	if len(data) > MaxSize {
+		return nil, errTooBigSize
 	}
+	return data, nil
 }
 
-// writeJSONString converts it to string and writes it to w as JSON value
+// itemToJSONString converts it to string
 // surrounded in quotes with control characters escaped.
-func writeJSONString(w *io.BinWriter, it Item) {
-	if w.Err != nil {
-		return
-	}
+func itemToJSONString(it Item) ([]byte, error) {
 	s, err := ToString(it)
 	if err != nil {
-		w.Err = err
-		return
+		return nil, err
 	}
 	data, _ := json.Marshal(s) // error never occurs because `ToString` checks for validity
 
 	// ref https://github.com/neo-project/neo-modules/issues/375 and https://github.com/dotnet/runtime/issues/35281
-	data = bytes.Replace(data, []byte{'+'}, []byte("\\u002B"), -1)
-
-	w.WriteBytes(data)
+	return bytes.Replace(data, []byte{'+'}, []byte("\\u002B"), -1), nil
 }
 
 // FromJSON decodes Item from JSON.

--- a/pkg/vm/stackitem/json_test.go
+++ b/pkg/vm/stackitem/json_test.go
@@ -105,6 +105,28 @@ func TestFromToJSON(t *testing.T) {
 	})
 }
 
+// getBigArray returns array takes up a lot of storage when serialized.
+func getBigArray(depth int) *Array {
+	arr := NewArray([]Item{})
+	for i := 0; i < depth; i++ {
+		arr = NewArray([]Item{arr, arr})
+	}
+	return arr
+}
+
+func BenchmarkToJSON(b *testing.B) {
+	arr := getBigArray(15)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := ToJSON(arr)
+		if err != nil {
+			b.FailNow()
+		}
+	}
+}
+
 // This test is taken from the C# code
 // https://github.com/neo-project/neo/blob/master/tests/neo.UnitTests/VM/UT_Helper.cs#L30
 func TestToJSONWithTypeCompat(t *testing.T) {

--- a/pkg/vm/stackitem/serialization.go
+++ b/pkg/vm/stackitem/serialization.go
@@ -19,38 +19,35 @@ var ErrUnserializable = errors.New("unserializable")
 
 // serContext is an internal serialization context.
 type serContext struct {
-	*io.BinWriter
-	buf          *io.BufBinWriter
+	uv           [9]byte
+	data         []byte
 	allowInvalid bool
 	seen         map[Item]bool
 }
 
 // Serialize encodes given Item into the byte slice.
 func Serialize(item Item) ([]byte, error) {
-	w := io.NewBufBinWriter()
 	sc := serContext{
-		BinWriter:    w.BinWriter,
-		buf:          w,
 		allowInvalid: false,
 		seen:         make(map[Item]bool),
 	}
-	sc.serialize(item)
-	if w.Err != nil {
-		return nil, w.Err
+	err := sc.serialize(item)
+	if err != nil {
+		return nil, err
 	}
-	return w.Bytes(), nil
+	return sc.data, nil
 }
 
 // EncodeBinary encodes given Item into the given BinWriter. It's
 // similar to io.Serializable's EncodeBinary, but works with Item
 // interface.
 func EncodeBinary(item Item, w *io.BinWriter) {
-	sc := serContext{
-		BinWriter:    w,
-		allowInvalid: false,
-		seen:         make(map[Item]bool),
+	data, err := Serialize(item)
+	if err != nil {
+		w.Err = err
+		return
 	}
-	sc.serialize(item)
+	w.WriteBytes(data)
 }
 
 // EncodeBinaryProtected encodes given Item into the given BinWriter. It's
@@ -59,88 +56,104 @@ func EncodeBinary(item Item, w *io.BinWriter) {
 // (like recursive array) is encountered it just writes special InvalidT
 // type of element to w.
 func EncodeBinaryProtected(item Item, w *io.BinWriter) {
-	bw := io.NewBufBinWriter()
 	sc := serContext{
-		BinWriter:    bw.BinWriter,
-		buf:          bw,
 		allowInvalid: true,
 		seen:         make(map[Item]bool),
 	}
-	sc.serialize(item)
-	if bw.Err != nil {
+	err := sc.serialize(item)
+	if err != nil {
 		w.WriteBytes([]byte{byte(InvalidT)})
 		return
 	}
-	w.WriteBytes(bw.Bytes())
+	w.WriteBytes(sc.data)
 }
 
-func (w *serContext) serialize(item Item) {
-	if w.Err != nil {
-		return
-	}
+func (w *serContext) serialize(item Item) error {
 	if w.seen[item] {
-		w.Err = ErrRecursive
-		return
+		return ErrRecursive
 	}
 
 	switch t := item.(type) {
 	case *ByteArray:
-		w.WriteBytes([]byte{byte(ByteArrayT)})
-		w.WriteVarBytes(t.Value().([]byte))
+		w.data = append(w.data, byte(ByteArrayT))
+		data := t.Value().([]byte)
+		w.appendVarUint(uint64(len(data)))
+		w.data = append(w.data, data...)
 	case *Buffer:
-		w.WriteBytes([]byte{byte(BufferT)})
-		w.WriteVarBytes(t.Value().([]byte))
+		w.data = append(w.data, byte(BufferT))
+		data := t.Value().([]byte)
+		w.appendVarUint(uint64(len(data)))
+		w.data = append(w.data, data...)
 	case *Bool:
-		w.WriteBytes([]byte{byte(BooleanT)})
-		w.WriteBool(t.Value().(bool))
+		w.data = append(w.data, byte(BooleanT))
+		if t.Value().(bool) {
+			w.data = append(w.data, 1)
+		} else {
+			w.data = append(w.data, 0)
+		}
 	case *BigInteger:
-		w.WriteBytes([]byte{byte(IntegerT)})
-		w.WriteVarBytes(bigint.ToBytes(t.Value().(*big.Int)))
+		w.data = append(w.data, byte(IntegerT))
+		data := bigint.ToBytes(t.Value().(*big.Int))
+		w.appendVarUint(uint64(len(data)))
+		w.data = append(w.data, data...)
 	case *Interop:
 		if w.allowInvalid {
-			w.WriteBytes([]byte{byte(InteropT)})
+			w.data = append(w.data, byte(InteropT))
 		} else {
-			w.Err = fmt.Errorf("%w: Interop", ErrUnserializable)
+			return fmt.Errorf("%w: Interop", ErrUnserializable)
 		}
 	case *Array, *Struct:
 		w.seen[item] = true
 
 		_, isArray := t.(*Array)
 		if isArray {
-			w.WriteBytes([]byte{byte(ArrayT)})
+			w.data = append(w.data, byte(ArrayT))
 		} else {
-			w.WriteBytes([]byte{byte(StructT)})
+			w.data = append(w.data, byte(StructT))
 		}
 
 		arr := t.Value().([]Item)
-		w.WriteVarUint(uint64(len(arr)))
+		w.appendVarUint(uint64(len(arr)))
 		for i := range arr {
-			w.serialize(arr[i])
+			if err := w.serialize(arr[i]); err != nil {
+				return err
+			}
 		}
 		delete(w.seen, item)
 	case *Map:
 		w.seen[item] = true
 
-		w.WriteBytes([]byte{byte(MapT)})
-		w.WriteVarUint(uint64(len(t.Value().([]MapElement))))
-		for i := range t.Value().([]MapElement) {
-			w.serialize(t.Value().([]MapElement)[i].Key)
-			w.serialize(t.Value().([]MapElement)[i].Value)
+		elems := t.Value().([]MapElement)
+		w.data = append(w.data, byte(MapT))
+		w.appendVarUint(uint64(len(elems)))
+		for i := range elems {
+			if err := w.serialize(elems[i].Key); err != nil {
+				return err
+			}
+			if err := w.serialize(elems[i].Value); err != nil {
+				return err
+			}
 		}
 		delete(w.seen, item)
 	case Null:
-		w.WriteB(byte(AnyT))
+		w.data = append(w.data, byte(AnyT))
 	case nil:
 		if w.allowInvalid {
-			w.WriteBytes([]byte{byte(InvalidT)})
+			w.data = append(w.data, byte(InvalidT))
 		} else {
-			w.Err = fmt.Errorf("%w: nil", ErrUnserializable)
+			return fmt.Errorf("%w: nil", ErrUnserializable)
 		}
 	}
 
-	if w.Err == nil && w.buf != nil && w.buf.Len() > MaxSize {
-		w.Err = errTooBigSize
+	if len(w.data) > MaxSize {
+		return errTooBigSize
 	}
+	return nil
+}
+
+func (w *serContext) appendVarUint(val uint64) {
+	n := io.PutVarUint(w.uv[:], val)
+	w.data = append(w.data, w.uv[:n]...)
 }
 
 // Deserialize decodes Item from the given byte slice.

--- a/pkg/vm/stackitem/serialization_test.go
+++ b/pkg/vm/stackitem/serialization_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,4 +21,20 @@ func TestSerializationMaxErr(t *testing.T) {
 
 	_, err = Serialize(aitem)
 	require.True(t, errors.Is(err, ErrTooBig), err)
+}
+
+func BenchmarkEncodeBinary(b *testing.B) {
+	arr := getBigArray(15)
+
+	w := io.NewBufBinWriter()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		w.Reset()
+		EncodeBinary(arr, w.BinWriter)
+		if w.Err != nil {
+			b.FailNow()
+		}
+	}
 }


### PR DESCRIPTION
Cache already marshaled values.
The expected memory overhead is linear (map itself + living references to the old buffer memory in case it grows with reallocation).