### PR TITLE
Support incremental dumps

### DIFF
--- a/cli/dump_test.go
+++ b/cli/dump_test.go
@@ -40,17 +40,14 @@ func TestDBRestore(t *testing.T) {
 	// First 15 blocks.
 	e.Run(t, append(baseArgs, "--count", "15")...)
 
-	// Invalid skips.
-	e.RunWithError(t, append(baseArgs, "--count", "10", "--skip", "14")...)
-	e.RunWithError(t, append(baseArgs, "--count", "10", "--skip", "16")...)
 	// Big count.
-	e.RunWithError(t, append(baseArgs, "--count", "1000", "--skip", "15")...)
+	e.RunWithError(t, append(baseArgs, "--count", "1000")...)
 
 	// Continue 15..25
-	e.Run(t, append(baseArgs, "--count", "10", "--skip", "15")...)
+	e.Run(t, append(baseArgs, "--count", "10")...)
 
 	// Continue till end.
-	e.Run(t, append(baseArgs, "--skip", "25")...)
+	e.Run(t, baseArgs...)
 
 	// Dump and compare.
 	dumpPath := path.Join(tmpDir, "testdump.acc")

--- a/cli/server/server_test.go
+++ b/cli/server/server_test.go
@@ -164,7 +164,6 @@ func TestRestoreDB(t *testing.T) {
 
 	// and then restore
 	set.String("in", testDump, "")
-	set.Int("skip", 0, "")
 	set.String("dump", saveDump, "")
 	require.NoError(t, restoreDB(ctx))
 }


### PR DESCRIPTION
Close #1991 .

Testing done:
1. Restore from ground for neo-go emitted dump + incremental dump from C# node (link in task).
2. Restore from specific height for both kinds of dumps.

For incremental dumps `skip` value is overridden. I propose to remove it completely, as essentialy it isn't a parameter, it has only 1 possible value (that is `chain height + 1`) with some peculiarities for genesis block.