### PR TITLE
consensus: fix nonce handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/mr-tron/base58 v1.1.2
-	github.com/nspcc-dev/dbft v0.0.0-20210302103605-cc75991b7cfb
+	github.com/nspcc-dev/dbft v0.0.0-20210721160347-1b03241391ac
 	github.com/nspcc-dev/neofs-api-go v1.27.1
 	github.com/nspcc-dev/rfc6979 v0.2.0
 	github.com/pierrec/lz4 v2.5.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,9 @@ github.com/nspcc-dev/dbft v0.0.0-20191209120240-0d6b7568d9ae/go.mod h1:3FjXOoHmA
 github.com/nspcc-dev/dbft v0.0.0-20200117124306-478e5cfbf03a/go.mod h1:/YFK+XOxxg0Bfm6P92lY5eDSLYfp06XOdL8KAVgXjVk=
 github.com/nspcc-dev/dbft v0.0.0-20200219114139-199d286ed6c1/go.mod h1:O0qtn62prQSqizzoagHmuuKoz8QMkU3SzBoKdEvm3aQ=
 github.com/nspcc-dev/dbft v0.0.0-20200711144034-c526ccc6f570/go.mod h1:1FYQXSbb6/9HQIkoF8XO7W/S8N7AZRkBsgwbcXRvk0E=
-github.com/nspcc-dev/dbft v0.0.0-20210302103605-cc75991b7cfb h1:UJRsgW5V0Td5oFLumYH3DepidjmH6Ek1uxWEkhe9RI8=
 github.com/nspcc-dev/dbft v0.0.0-20210302103605-cc75991b7cfb/go.mod h1:U8MSnEShH+o5hexfWJdze6uMFJteP0ko7J2frO7Yu1Y=
+github.com/nspcc-dev/dbft v0.0.0-20210721160347-1b03241391ac h1:nrewxmpns7GE0nO2DyGkrYfpZd/nMF7bN7DGvT8ljp0=
+github.com/nspcc-dev/dbft v0.0.0-20210721160347-1b03241391ac/go.mod h1:U8MSnEShH+o5hexfWJdze6uMFJteP0ko7J2frO7Yu1Y=
 github.com/nspcc-dev/hrw v1.0.9 h1:17VcAuTtrstmFppBjfRiia4K2wA/ukXZhLFS8Y8rz5Y=
 github.com/nspcc-dev/hrw v1.0.9/go.mod h1:l/W2vx83vMQo6aStyx2AuZrJ+07lGv2JQGlVkPG06MU=
 github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:pPYwPZ2ks+uMnlRLUyXOpLieaDQSEaf4NM3zHVbRjmg=

--- a/pkg/consensus/block.go
+++ b/pkg/consensus/block.go
@@ -73,7 +73,7 @@ func (n *neoBlock) Timestamp() uint64 { return n.Block.Timestamp * nsInMs }
 func (n *neoBlock) Index() uint32 { return n.Block.Index }
 
 // ConsensusData implements block.Block interface.
-func (n *neoBlock) ConsensusData() uint64 { return 0 }
+func (n *neoBlock) ConsensusData() uint64 { return n.Block.Nonce }
 
 // NextConsensus implements block.Block interface.
 func (n *neoBlock) NextConsensus() util.Uint160 { return n.Block.NextConsensus }

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -1,8 +1,6 @@
 package consensus
 
 import (
-	"crypto/rand"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"sort"
@@ -241,17 +239,7 @@ func (s *service) newPrepareRequest() payload.PrepareRequest {
 			panic(err)
 		}
 	}
-	r.nonce = s.getNonce()
 	return r
-}
-
-func (s *service) getNonce() uint64 {
-	b := make([]byte, 8)
-	_, err := rand.Read(b)
-	if err != nil {
-		panic(err)
-	}
-	return binary.LittleEndian.Uint64(b)
 }
 
 func (s *service) Start() {
@@ -661,7 +649,7 @@ func (s *service) newBlockFromContext(ctx *dbft.Context) block.Block {
 	block := &neoBlock{network: s.ProtocolConfiguration.Magic}
 
 	block.Block.Timestamp = ctx.Timestamp / nsInMs
-	block.Block.Nonce = ctx.PreparationPayloads[ctx.PrimaryIndex].GetPrepareRequest().Nonce()
+	block.Block.Nonce = ctx.Nonce
 	block.Block.Index = ctx.BlockIndex
 	if s.ProtocolConfiguration.StateRootInHeader {
 		sr, err := s.Chain.GetStateModule().GetStateRoot(ctx.BlockIndex - 1)


### PR DESCRIPTION
It was broken somewhere between 2f490a3403fea308a80609c0086b331deca4b1ba and
85ce207f4065c642de314b2c0cf9851627d552fa leading to panic on watch only node:

2021-07-21T16:21:39.201+0200    INFO    received Commit {"validator": 3}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xbcc59e]

goroutine 486 [running]:
github.com/nspcc-dev/neo-go/pkg/consensus.(*service).newBlockFromContext(0xc0001629a0, 0xc000308000, 0xc0010fa000, 0x2cb417800)
        github.com/nspcc-dev/neo-go/pkg/consensus/consensus.go:664 +0xbe
github.com/nspcc-dev/dbft.(*Context).MakeHeader(...)
        github.com/nspcc-dev/dbft@v0.0.0-20210302103605-cc75991b7cfb/context.go:270
github.com/nspcc-dev/dbft.(*DBFT).onCommit(0xc000308000, 0x138c998, 0xc000115110)
        github.com/nspcc-dev/dbft@v0.0.0-20210302103605-cc75991b7cfb/dbft.go:487 +0x575
github.com/nspcc-dev/dbft.(*DBFT).OnReceive(0xc000308000, 0x138c998, 0xc000115110)
        github.com/nspcc-dev/dbft@v0.0.0-20210302103605-cc75991b7cfb/dbft.go:251 +0xef5
github.com/nspcc-dev/neo-go/pkg/consensus.(*service).eventLoop(0xc0001629a0)
        github.com/nspcc-dev/neo-go/pkg/consensus/consensus.go:312 +0x7d6
created by github.com/nspcc-dev/neo-go/pkg/consensus.(*service).Start
        github.com/nspcc-dev/neo-go/pkg/consensus/consensus.go:262 +0xdc

In fact, nonce is correctly provided by dbft library (since Legacy), we just
need to use it here.

Depends on nspcc-dev/dbft#54.