### PR TITLE
*: simplify some error messages

### DIFF
--- a/pkg/core/interop/contract/call.go
+++ b/pkg/core/interop/contract/call.go
@@ -120,7 +120,7 @@ func callExFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contra
 }
 
 // ErrNativeCall is returned for failed calls from native.
-var ErrNativeCall = errors.New("error during call from native")
+var ErrNativeCall = errors.New("failed native call")
 
 // CallFromNative performs synchronous call from native contract.
 func CallFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contract, method string, args []stackitem.Item, hasReturn bool) error {

--- a/pkg/core/oracle_test.go
+++ b/pkg/core/oracle_test.go
@@ -405,7 +405,7 @@ func (c *httpClient) Do(req *http.Request) (*http.Response, error) {
 			Body: newResponseBody(resp.body),
 		}, nil
 	}
-	return nil, errors.New("error during request")
+	return nil, errors.New("request failed")
 }
 
 func newDefaultHTTPClient() oracle.HTTPClient {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -33,7 +33,7 @@ type errorAtInstruct struct {
 }
 
 func (e *errorAtInstruct) Error() string {
-	return fmt.Sprintf("error encountered at instruction %d (%s): %s", e.ip, e.op, e.err)
+	return fmt.Sprintf("at instruction %d (%s): %s", e.ip, e.op, e.err)
 }
 
 func newError(ip int, op opcode.Opcode, err interface{}) *errorAtInstruct {


### PR DESCRIPTION
Log:
2021-07-23T09:59:18.948+0300    WARN    contract invocation failed      {"tx": "de3e3c1f1d37e4528990f894dea5583fd320485ad3862a95eb0e8823eecf4a5f", "block": 9643, "error": "error encountered at instruction 1 (SYSCALL): error during call from native: error encountered at instruction 745 (CAT): invalid conversion: Map/ByteString"}

The word "error" appears 4 times here.