### PR TITLE
wallet: truncate file after writing

### DIFF
--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -181,7 +181,7 @@ func (w *Wallet) writeRaw(data []byte) error {
 
 func (w *Wallet) rewind() error {
 	if s, ok := w.rw.(io.Seeker); ok {
-		if _, err := s.Seek(0, 0); err != nil {
+		if _, err := s.Seek(0, io.SeekStart); err != nil {
 			return err
 		}
 	}

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -167,7 +167,16 @@ func (w *Wallet) writeRaw(data []byte) error {
 	}
 
 	_, err := w.rw.Write(data)
-	return err
+	if err != nil {
+		return err
+	}
+
+	if f, ok := w.rw.(*os.File); ok {
+		if err := f.Truncate(int64(len(data))); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (w *Wallet) rewind() error {

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -143,20 +143,31 @@ func (w *Wallet) Path() string {
 // that is responsible for saving the data. This can
 // be a buffer, file, etc..
 func (w *Wallet) Save() error {
-	if err := w.rewind(); err != nil {
+	data, err := json.Marshal(w)
+	if err != nil {
 		return err
 	}
-	return json.NewEncoder(w.rw).Encode(w)
+
+	return w.writeRaw(data)
 }
 
 // savePretty saves wallet in a beautiful JSON.
 func (w *Wallet) savePretty() error {
+	data, err := json.MarshalIndent(w, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return w.writeRaw(data)
+}
+
+func (w *Wallet) writeRaw(data []byte) error {
 	if err := w.rewind(); err != nil {
 		return err
 	}
-	enc := json.NewEncoder(w.rw)
-	enc.SetIndent("", "  ")
-	return enc.Encode(w)
+
+	_, err := w.rw.Write(data)
+	return err
 }
 
 func (w *Wallet) rewind() error {


### PR DESCRIPTION
If wallet size decreases, we need to remove trailing garbage if it
exists. This can happen when removing account or reading pretty-printed
wallet. It doesn't affect our CLI (we decode only file prefix), but
it is nice to always have a valid JSON file.

Signed-off-by: Evgeniy Stratonikov <evgeniy@nspcc.ru>