### PR TITLE
cli/smartcontract: provide manifest groups on deploy

### DIFF
--- a/cli/executor_test.go
+++ b/cli/executor_test.go
@@ -34,6 +34,9 @@ const (
 	validatorAddr = "NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP"
 	multisigAddr  = "NVTiAjNgagDkTr5HTzDmQP9kPwPHN5BgVq"
 
+	testWalletPath    = "testdata/testwallet.json"
+	testWalletAccount = "Nfyz4KcsgYepRJw1W5C2uKCi6QWKf7v6gG"
+
 	validatorWallet = "testdata/wallet1_solo.json"
 )
 

--- a/cli/smartcontract/manifest.go
+++ b/cli/smartcontract/manifest.go
@@ -1,0 +1,122 @@
+package smartcontract
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/nspcc-dev/neo-go/cli/flags"
+	"github.com/nspcc-dev/neo-go/pkg/core/state"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/nef"
+	"github.com/nspcc-dev/neo-go/pkg/wallet"
+	"github.com/urfave/cli"
+)
+
+func manifestAddGroup(ctx *cli.Context) error {
+	walletPath := ctx.String("wallet")
+	if len(walletPath) == 0 {
+		return cli.NewExitError(errNoWallet, 1)
+	}
+
+	w, err := wallet.NewWalletFromFile(walletPath)
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+	defer w.Close()
+
+	addr, err := flags.ParseAddress(ctx.String("account"))
+	if err != nil {
+		return cli.NewExitError(errors.New("address is missing"), 1)
+	}
+
+	sender, err := flags.ParseAddress(ctx.String("sender"))
+	if err != nil {
+		return cli.NewExitError("invalid sender", 1)
+	}
+
+	nf, _, err := readNEFFile(ctx.String("nef"))
+	if err != nil {
+		return cli.NewExitError(fmt.Errorf("can't read NEF file: %w", err), 1)
+	}
+
+	mPath := ctx.String("manifest")
+	m, _, err := readManifest(mPath)
+	if err != nil {
+		return cli.NewExitError(fmt.Errorf("can't read contract manifest: %w", err), 1)
+	}
+
+	h := state.CreateContractHash(sender, nf.Checksum, m.Name)
+
+	gAcc, err := getUnlockedAccount(w, addr)
+	if err != nil {
+		return err
+	}
+
+	var found bool
+
+	sig := gAcc.PrivateKey().Sign(h.BytesBE())
+	pub := gAcc.PrivateKey().PublicKey()
+	for i := range m.Groups {
+		if m.Groups[i].PublicKey.Equal(pub) {
+			m.Groups[i].Signature = sig
+			found = true
+			break
+		}
+	}
+	if !found {
+		m.Groups = append(m.Groups, manifest.Group{
+			PublicKey: pub,
+			Signature: sig,
+		})
+	}
+
+	rawM, err := json.Marshal(m)
+	if err != nil {
+		return cli.NewExitError(fmt.Errorf("can't marshal manifest: %w", err), 1)
+	}
+
+	err = ioutil.WriteFile(mPath, rawM, os.ModePerm)
+	if err != nil {
+		return cli.NewExitError(fmt.Errorf("can't write manifest file: %w", err), 1)
+	}
+	return nil
+}
+
+func readNEFFile(filename string) (*nef.File, []byte, error) {
+	if len(filename) == 0 {
+		return nil, nil, errors.New("no nef file was provided")
+	}
+
+	f, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	nefFile, err := nef.FileFromBytes(f)
+	if err != nil {
+		return nil, nil, fmt.Errorf("can't parse NEF file: %w", err)
+	}
+
+	return &nefFile, f, nil
+}
+
+func readManifest(filename string) (*manifest.Manifest, []byte, error) {
+	if len(filename) == 0 {
+		return nil, nil, errNoManifestFile
+	}
+
+	manifestBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(manifest.Manifest)
+	err = json.Unmarshal(manifestBytes, m)
+	if err != nil {
+		return nil, nil, err
+	}
+	return m, manifestBytes, nil
+}

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -810,33 +810,14 @@ func getUnlockedAccount(wall *wallet.Wallet, addr util.Uint160) (*wallet.Account
 
 // contractDeploy deploys contract.
 func contractDeploy(ctx *cli.Context) error {
-	in := ctx.String("in")
-	if len(in) == 0 {
-		return cli.NewExitError(errNoInput, 1)
-	}
-	manifestFile := ctx.String("manifest")
-	if len(manifestFile) == 0 {
-		return cli.NewExitError(errNoManifestFile, 1)
-	}
-
-	f, err := ioutil.ReadFile(in)
+	nefFile, f, err := readNEFFile(ctx.String("in"))
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
-	// Check the file.
-	nefFile, err := nef.FileFromBytes(f)
-	if err != nil {
-		return cli.NewExitError(fmt.Errorf("failed to read .nef file: %w", err), 1)
-	}
 
-	manifestBytes, err := ioutil.ReadFile(manifestFile)
+	m, manifestBytes, err := readManifest(ctx.String("manifest"))
 	if err != nil {
 		return cli.NewExitError(fmt.Errorf("failed to read manifest file: %w", err), 1)
-	}
-	m := &manifest.Manifest{}
-	err = json.Unmarshal(manifestBytes, m)
-	if err != nil {
-		return cli.NewExitError(fmt.Errorf("failed to restore manifest file: %w", err), 1)
 	}
 
 	appCallParams := []smartcontract.Parameter{

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -276,6 +276,16 @@ Using either constant or literal for contract hash and method will allow compile
 to perform more extensive analysis.
 This check can be disabled with `--no-permissions` flag.
 
+#### Manifest file
+Any contract can be included in a group identified by a public key which is used in [permissions](#Permissions).
+This is achieved with `manifest add-group` command.
+```
+./bin/neo-go contract manifest add-group -n contract.nef -m contract.manifest.json --sender <sender> --wallet /path/to/wallet.json --account <account>
+```
+It accepts contract `.nef` and manifest files emitted by `compile` command as well as
+sender and signer accounts. `--sender` is the account who will send deploy transaction later (not necessarily in wallet).
+`--account` is the wallet account which signs contract hash using group private key.
+
 #### Neo Express support
 
 It's possible to deploy contracts written in Go using [Neo


### PR DESCRIPTION
Close #2098 .

There are possible problems, but I haven't found a way for them to occur:
1. Sent manifest will differ from the one we read. This is ok, because contract hash calculation uses only manifest name, so `calc-hash` will continue to work.
2. One might want to have multiple groups in different wallets (for some multisig transactions). This is not supported.