### PR TITLE
Some allocation optimizations

### DIFF
--- a/pkg/core/mpt/base.go
+++ b/pkg/core/mpt/base.go
@@ -23,7 +23,6 @@ type BaseNodeIface interface {
 	Hash() util.Uint256
 	Type() NodeType
 	Bytes() []byte
-	EncodeBinaryAsChild(w *io.BinWriter)
 }
 
 type flushedNode interface {
@@ -74,6 +73,15 @@ func (b *BaseNode) updateBytes(n Node) {
 func (b *BaseNode) invalidateCache() {
 	b.bytesValid = false
 	b.hashValid = false
+}
+
+func encodeBinaryAsChild(n Node, w *io.BinWriter) {
+	if isEmpty(n) {
+		w.WriteB(byte(EmptyT))
+		return
+	}
+	w.WriteB(byte(HashT))
+	w.WriteBytes(n.Hash().BytesBE())
 }
 
 // encodeNodeWithType encodes node together with it's type.

--- a/pkg/core/mpt/base.go
+++ b/pkg/core/mpt/base.go
@@ -1,6 +1,7 @@
 package mpt
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
@@ -63,8 +64,9 @@ func (b *BaseNode) updateHash(n Node) {
 
 // updateCache updates hash and bytes fields for this BaseNode.
 func (b *BaseNode) updateBytes(n Node) {
-	buf := io.NewBufBinWriter()
-	encodeNodeWithType(n, buf.BinWriter)
+	buf := bytes.NewBuffer(make([]byte, 0, 1+n.Size()))
+	bw := io.NewBinWriterFromIO(buf)
+	encodeNodeWithType(n, bw)
 	b.bytes = buf.Bytes()
 	b.bytesValid = true
 }

--- a/pkg/core/mpt/batch_test.go
+++ b/pkg/core/mpt/batch_test.go
@@ -68,8 +68,8 @@ func testPut(t *testing.T, ps pairs, tr1, tr2 *Trie) {
 
 func TestTrie_PutBatchLeaf(t *testing.T) {
 	prepareLeaf := func(t *testing.T) (*Trie, *Trie) {
-		tr1 := NewTrie(new(HashNode), false, newTestStore())
-		tr2 := NewTrie(new(HashNode), false, newTestStore())
+		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
 		require.NoError(t, tr1.Put([]byte{0}, []byte("value")))
 		require.NoError(t, tr2.Put([]byte{0}, []byte("value")))
 		return tr1, tr2
@@ -97,8 +97,8 @@ func TestTrie_PutBatchLeaf(t *testing.T) {
 
 func TestTrie_PutBatchExtension(t *testing.T) {
 	prepareExtension := func(t *testing.T) (*Trie, *Trie) {
-		tr1 := NewTrie(new(HashNode), false, newTestStore())
-		tr2 := NewTrie(new(HashNode), false, newTestStore())
+		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
 		require.NoError(t, tr1.Put([]byte{1, 2}, []byte("value1")))
 		require.NoError(t, tr2.Put([]byte{1, 2}, []byte("value1")))
 		return tr1, tr2
@@ -144,8 +144,8 @@ func TestTrie_PutBatchExtension(t *testing.T) {
 
 func TestTrie_PutBatchBranch(t *testing.T) {
 	prepareBranch := func(t *testing.T) (*Trie, *Trie) {
-		tr1 := NewTrie(new(HashNode), false, newTestStore())
-		tr2 := NewTrie(new(HashNode), false, newTestStore())
+		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
 		require.NoError(t, tr1.Put([]byte{0x00, 2}, []byte("value1")))
 		require.NoError(t, tr2.Put([]byte{0x00, 2}, []byte("value1")))
 		require.NoError(t, tr1.Put([]byte{0x10, 3}, []byte("value2")))
@@ -175,8 +175,8 @@ func TestTrie_PutBatchBranch(t *testing.T) {
 			require.IsType(t, (*ExtensionNode)(nil), tr1.root)
 		})
 		t.Run("non-empty child is last node", func(t *testing.T) {
-			tr1 := NewTrie(new(HashNode), false, newTestStore())
-			tr2 := NewTrie(new(HashNode), false, newTestStore())
+			tr1 := NewTrie(EmptyNode{}, false, newTestStore())
+			tr2 := NewTrie(EmptyNode{}, false, newTestStore())
 			require.NoError(t, tr1.Put([]byte{0x00, 2}, []byte("value1")))
 			require.NoError(t, tr2.Put([]byte{0x00, 2}, []byte("value1")))
 			require.NoError(t, tr1.Put([]byte{0x00}, []byte("value2")))
@@ -222,8 +222,8 @@ func TestTrie_PutBatchBranch(t *testing.T) {
 
 func TestTrie_PutBatchHash(t *testing.T) {
 	prepareHash := func(t *testing.T) (*Trie, *Trie) {
-		tr1 := NewTrie(new(HashNode), false, newTestStore())
-		tr2 := NewTrie(new(HashNode), false, newTestStore())
+		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
 		require.NoError(t, tr1.Put([]byte{0x10}, []byte("value1")))
 		require.NoError(t, tr2.Put([]byte{0x10}, []byte("value1")))
 		require.NoError(t, tr1.Put([]byte{0x20}, []byte("value2")))
@@ -257,8 +257,8 @@ func TestTrie_PutBatchHash(t *testing.T) {
 
 func TestTrie_PutBatchEmpty(t *testing.T) {
 	t.Run("good", func(t *testing.T) {
-		tr1 := NewTrie(new(HashNode), false, newTestStore())
-		tr2 := NewTrie(new(HashNode), false, newTestStore())
+		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
 		var ps = pairs{
 			{[]byte{0}, []byte("value0")},
 			{[]byte{1}, []byte("value1")},
@@ -273,15 +273,15 @@ func TestTrie_PutBatchEmpty(t *testing.T) {
 			{[]byte{2}, nil},
 			{[]byte{3}, []byte("replace3")},
 		}
-		tr1 := NewTrie(new(HashNode), false, newTestStore())
-		tr2 := NewTrie(new(HashNode), false, newTestStore())
+		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
 		testIncompletePut(t, ps, 4, tr1, tr2)
 	})
 }
 
 // For the sake of coverage.
 func TestTrie_InvalidNodeType(t *testing.T) {
-	tr := NewTrie(new(HashNode), false, newTestStore())
+	tr := NewTrie(EmptyNode{}, false, newTestStore())
 	var b Batch
 	b.Add([]byte{1}, []byte("value"))
 	tr.root = Node(nil)
@@ -289,8 +289,8 @@ func TestTrie_InvalidNodeType(t *testing.T) {
 }
 
 func TestTrie_PutBatch(t *testing.T) {
-	tr1 := NewTrie(new(HashNode), false, newTestStore())
-	tr2 := NewTrie(new(HashNode), false, newTestStore())
+	tr1 := NewTrie(EmptyNode{}, false, newTestStore())
+	tr2 := NewTrie(EmptyNode{}, false, newTestStore())
 	var ps = pairs{
 		{[]byte{1}, []byte{1}},
 		{[]byte{2}, []byte{3}},
@@ -312,11 +312,10 @@ var _ = printNode
 // `spew.Dump()`.
 func printNode(prefix string, n Node) {
 	switch tn := n.(type) {
+	case EmptyNode:
+		fmt.Printf("%s empty\n", prefix)
+		return
 	case *HashNode:
-		if tn.IsEmpty() {
-			fmt.Printf("%s empty\n", prefix)
-			return
-		}
 		fmt.Printf("%s %s\n", prefix, tn.Hash().StringLE())
 	case *BranchNode:
 		for i, c := range tn.Children {

--- a/pkg/core/mpt/branch.go
+++ b/pkg/core/mpt/branch.go
@@ -45,6 +45,17 @@ func (b *BranchNode) Bytes() []byte {
 	return b.getBytes(b)
 }
 
+// Size implements Node interface.
+func (b *BranchNode) Size() int {
+	sz := childrenCount
+	for i := range b.Children {
+		if !isEmpty(b.Children[i]) {
+			sz += util.Uint256Size
+		}
+	}
+	return sz
+}
+
 // EncodeBinary implements io.Serializable.
 func (b *BranchNode) EncodeBinary(w *io.BinWriter) {
 	for i := 0; i < childrenCount; i++ {

--- a/pkg/core/mpt/branch.go
+++ b/pkg/core/mpt/branch.go
@@ -27,7 +27,7 @@ var _ Node = (*BranchNode)(nil)
 func NewBranchNode() *BranchNode {
 	b := new(BranchNode)
 	for i := 0; i < childrenCount; i++ {
-		b.Children[i] = new(HashNode)
+		b.Children[i] = EmptyNode{}
 	}
 	return b
 }

--- a/pkg/core/mpt/branch.go
+++ b/pkg/core/mpt/branch.go
@@ -48,14 +48,8 @@ func (b *BranchNode) Bytes() []byte {
 // EncodeBinary implements io.Serializable.
 func (b *BranchNode) EncodeBinary(w *io.BinWriter) {
 	for i := 0; i < childrenCount; i++ {
-		b.Children[i].EncodeBinaryAsChild(w)
+		encodeBinaryAsChild(b.Children[i], w)
 	}
-}
-
-// EncodeBinaryAsChild implements BaseNode interface.
-func (b *BranchNode) EncodeBinaryAsChild(w *io.BinWriter) {
-	n := &NodeObject{Node: NewHashNode(b.Hash())} // with type
-	n.EncodeBinary(w)
 }
 
 // DecodeBinary implements io.Serializable.

--- a/pkg/core/mpt/empty.go
+++ b/pkg/core/mpt/empty.go
@@ -1,0 +1,53 @@
+package mpt
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+// EmptyNode represents empty node.
+type EmptyNode struct{}
+
+// DecodeBinary implements io.Serializable interface.
+func (e EmptyNode) DecodeBinary(*io.BinReader) {
+}
+
+// EncodeBinary implements io.Serializable interface.
+func (e EmptyNode) EncodeBinary(*io.BinWriter) {
+}
+
+// MarshalJSON implements Node interface.
+func (e EmptyNode) MarshalJSON() ([]byte, error) {
+	return []byte(`{}`), nil
+}
+
+// UnmarshalJSON implements Node interface.
+func (e EmptyNode) UnmarshalJSON(bytes []byte) error {
+	var m map[string]interface{}
+	err := json.Unmarshal(bytes, &m)
+	if err != nil {
+		return err
+	}
+	if len(m) != 0 {
+		return errors.New("expected empty node")
+	}
+	return nil
+}
+
+// Hash implements Node interface.
+func (e EmptyNode) Hash() util.Uint256 {
+	panic("can't get hash of an EmptyNode")
+}
+
+// Type implements Node interface.
+func (e EmptyNode) Type() NodeType {
+	return EmptyT
+}
+
+// Bytes implements Node interface.
+func (e EmptyNode) Bytes() []byte {
+	return nil
+}

--- a/pkg/core/mpt/empty.go
+++ b/pkg/core/mpt/empty.go
@@ -19,6 +19,9 @@ func (e EmptyNode) DecodeBinary(*io.BinReader) {
 func (e EmptyNode) EncodeBinary(*io.BinWriter) {
 }
 
+// Size implements Node interface.
+func (EmptyNode) Size() int { return 0 }
+
 // MarshalJSON implements Node interface.
 func (e EmptyNode) MarshalJSON() ([]byte, error) {
 	return []byte(`{}`), nil

--- a/pkg/core/mpt/extension.go
+++ b/pkg/core/mpt/extension.go
@@ -72,6 +72,12 @@ func (e ExtensionNode) EncodeBinary(w *io.BinWriter) {
 	encodeBinaryAsChild(e.next, w)
 }
 
+// Size implements Node interface.
+func (e *ExtensionNode) Size() int {
+	return io.GetVarSize(len(e.key)) + len(e.key) +
+		1 + util.Uint256Size // e.next is never empty
+}
+
 // MarshalJSON implements json.Marshaler.
 func (e *ExtensionNode) MarshalJSON() ([]byte, error) {
 	m := map[string]interface{}{

--- a/pkg/core/mpt/extension.go
+++ b/pkg/core/mpt/extension.go
@@ -69,13 +69,7 @@ func (e *ExtensionNode) DecodeBinary(r *io.BinReader) {
 // EncodeBinary implements io.Serializable.
 func (e ExtensionNode) EncodeBinary(w *io.BinWriter) {
 	w.WriteVarBytes(e.key)
-	e.next.EncodeBinaryAsChild(w)
-}
-
-// EncodeBinaryAsChild implements BaseNode interface.
-func (e *ExtensionNode) EncodeBinaryAsChild(w *io.BinWriter) {
-	n := &NodeObject{Node: NewHashNode(e.Hash())} // with type
-	n.EncodeBinary(w)
+	encodeBinaryAsChild(e.next, w)
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/pkg/core/mpt/hash.go
+++ b/pkg/core/mpt/hash.go
@@ -27,6 +27,11 @@ func NewHashNode(h util.Uint256) *HashNode {
 // Type implements Node interface.
 func (h *HashNode) Type() NodeType { return HashT }
 
+// Size implements Node interface.
+func (h *HashNode) Size() int {
+	return util.Uint256Size
+}
+
 // Hash implements Node interface.
 func (h *HashNode) Hash() util.Uint256 {
 	if !h.hashValid {

--- a/pkg/core/mpt/hash.go
+++ b/pkg/core/mpt/hash.go
@@ -35,9 +35,6 @@ func (h *HashNode) Hash() util.Uint256 {
 	return h.hash
 }
 
-// IsEmpty returns true if h is an empty node i.e. contains no hash.
-func (h *HashNode) IsEmpty() bool { return !h.hashValid }
-
 // Bytes returns serialized HashNode.
 func (h *HashNode) Bytes() []byte {
 	return h.getBytes(h)
@@ -60,9 +57,6 @@ func (h HashNode) EncodeBinary(w *io.BinWriter) {
 
 // MarshalJSON implements json.Marshaler.
 func (h *HashNode) MarshalJSON() ([]byte, error) {
-	if !h.hashValid {
-		return []byte(`{}`), nil
-	}
 	return []byte(`{"hash":"` + h.hash.StringLE() + `"}`), nil
 }
 

--- a/pkg/core/mpt/hash.go
+++ b/pkg/core/mpt/hash.go
@@ -58,12 +58,6 @@ func (h HashNode) EncodeBinary(w *io.BinWriter) {
 	w.WriteBytes(h.hash[:])
 }
 
-// EncodeBinaryAsChild implements BaseNode interface.
-func (h *HashNode) EncodeBinaryAsChild(w *io.BinWriter) {
-	no := &NodeObject{Node: h} // with type
-	no.EncodeBinary(w)
-}
-
 // MarshalJSON implements json.Marshaler.
 func (h *HashNode) MarshalJSON() ([]byte, error) {
 	if !h.hashValid {

--- a/pkg/core/mpt/leaf.go
+++ b/pkg/core/mpt/leaf.go
@@ -56,12 +56,6 @@ func (n LeafNode) EncodeBinary(w *io.BinWriter) {
 	w.WriteVarBytes(n.value)
 }
 
-// EncodeBinaryAsChild implements BaseNode interface.
-func (n *LeafNode) EncodeBinaryAsChild(w *io.BinWriter) {
-	no := &NodeObject{Node: NewHashNode(n.Hash())} // with type
-	no.EncodeBinary(w)
-}
-
 // MarshalJSON implements json.Marshaler.
 func (n *LeafNode) MarshalJSON() ([]byte, error) {
 	return []byte(`{"value":"` + hex.EncodeToString(n.value) + `"}`), nil

--- a/pkg/core/mpt/leaf.go
+++ b/pkg/core/mpt/leaf.go
@@ -56,6 +56,11 @@ func (n LeafNode) EncodeBinary(w *io.BinWriter) {
 	w.WriteVarBytes(n.value)
 }
 
+// Size implements Node interface.
+func (n *LeafNode) Size() int {
+	return io.GetVarSize(len(n.value)) + len(n.value)
+}
+
 // MarshalJSON implements json.Marshaler.
 func (n *LeafNode) MarshalJSON() ([]byte, error) {
 	return []byte(`{"value":"` + hex.EncodeToString(n.value) + `"}`), nil

--- a/pkg/core/mpt/node.go
+++ b/pkg/core/mpt/node.go
@@ -33,6 +33,7 @@ type Node interface {
 	io.Serializable
 	json.Marshaler
 	json.Unmarshaler
+	Size() int
 	BaseNodeIface
 }
 

--- a/pkg/core/mpt/node.go
+++ b/pkg/core/mpt/node.go
@@ -68,7 +68,7 @@ func (n *NodeObject) UnmarshalJSON(data []byte) error {
 
 	switch len(m) {
 	case 0:
-		n.Node = new(HashNode)
+		n.Node = EmptyNode{}
 	case 1:
 		if v, ok := m["hash"]; ok {
 			var h util.Uint256

--- a/pkg/core/mpt/node_test.go
+++ b/pkg/core/mpt/node_test.go
@@ -78,9 +78,6 @@ func TestNode_Serializable(t *testing.T) {
 			t.Run("Raw", getTestFuncEncode(true, h, new(HashNode)))
 			t.Run("WithType", getTestFuncEncode(true, &NodeObject{h}, new(NodeObject)))
 		})
-		t.Run("Empty", func(t *testing.T) { // compare nodes, not hashes
-			testserdes.EncodeDecodeBinary(t, new(HashNode), new(HashNode))
-		})
 		t.Run("InvalidSize", func(t *testing.T) {
 			buf := io.NewBufBinWriter()
 			buf.BinWriter.WriteBytes(make([]byte, 13))
@@ -111,7 +108,7 @@ func TestInvalidJSON(t *testing.T) {
 	t.Run("InvalidChildrenCount", func(t *testing.T) {
 		var cs [childrenCount + 1]Node
 		for i := range cs {
-			cs[i] = new(HashNode)
+			cs[i] = EmptyNode{}
 		}
 		data, err := json.Marshal(cs)
 		require.NoError(t, err)

--- a/pkg/core/mpt/node_test.go
+++ b/pkg/core/mpt/node_test.go
@@ -27,6 +27,7 @@ func getTestFuncEncode(ok bool, expected, actual Node) func(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, expected.Type(), actual.Type())
 			require.Equal(t, expected.Hash(), actual.Hash())
+			require.Equal(t, 1+expected.Size(), len(expected.Bytes()))
 		})
 		t.Run("JSON", func(t *testing.T) {
 			bs, err := json.Marshal(expected)

--- a/pkg/core/mpt/proof.go
+++ b/pkg/core/mpt/proof.go
@@ -49,13 +49,11 @@ func (t *Trie) getProof(curr Node, path []byte, proofs *[][]byte) (Node, error) 
 			return n, nil
 		}
 	case *HashNode:
-		if !n.IsEmpty() {
-			r, err := t.getFromStore(n.Hash())
-			if err != nil {
-				return nil, err
-			}
-			return t.getProof(r, path, proofs)
+		r, err := t.getFromStore(n.Hash())
+		if err != nil {
+			return nil, err
 		}
+		return t.getProof(r, path, proofs)
 	}
 	return nil, ErrNotFound
 }

--- a/pkg/core/mpt/trie_test.go
+++ b/pkg/core/mpt/trie_test.go
@@ -239,8 +239,7 @@ func isValid(curr Node) bool {
 			if !isValid(n.Children[i]) {
 				return false
 			}
-			hn, ok := n.Children[i].(*HashNode)
-			if !ok || !hn.IsEmpty() {
+			if !isEmpty(n.Children[i]) {
 				count++
 			}
 		}
@@ -342,7 +341,7 @@ func testTrieDelete(t *testing.T, enableGC bool) {
 			})
 
 			require.NoError(t, tr.Delete([]byte{0xAB}))
-			require.True(t, tr.root.(*HashNode).IsEmpty())
+			require.IsType(t, EmptyNode{}, tr.root)
 		})
 
 		t.Run("MultipleKeys", func(t *testing.T) {
@@ -505,12 +504,11 @@ func TestTrie_Collapse(t *testing.T) {
 		require.Equal(t, NewLeafNode([]byte("value")), tr.root)
 	})
 	t.Run("Hash", func(t *testing.T) {
-		t.Run("Empty", func(t *testing.T) {
-			tr := NewTrie(new(HashNode), false, newTestStore())
+		t.Run("EmptyNode", func(t *testing.T) {
+			tr := NewTrie(EmptyNode{}, false, newTestStore())
 			require.NotPanics(t, func() { tr.Collapse(1) })
-			hn, ok := tr.root.(*HashNode)
+			_, ok := tr.root.(EmptyNode)
 			require.True(t, ok)
-			require.True(t, hn.IsEmpty())
 		})
 
 		h := random.Uint256()

--- a/pkg/core/state/notification_event.go
+++ b/pkg/core/state/notification_event.go
@@ -61,7 +61,10 @@ func (aer *AppExecResult) EncodeBinary(w *io.BinWriter) {
 	for _, it := range aer.Stack {
 		stackitem.EncodeBinaryProtected(it, w)
 	}
-	w.WriteArray(aer.Events)
+	w.WriteVarUint(uint64(len(aer.Events)))
+	for i := range aer.Events {
+		aer.Events[i].EncodeBinary(w)
+	}
 	w.WriteVarBytes([]byte(aer.FaultException))
 }
 

--- a/pkg/core/state/notification_event_test.go
+++ b/pkg/core/state/notification_event_test.go
@@ -13,6 +13,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func BenchmarkAppExecResult_EncodeBinary(b *testing.B) {
+	aer := &AppExecResult{
+		Container: random.Uint256(),
+		Execution: Execution{
+			Trigger:     trigger.Application,
+			VMState:     vm.HaltState,
+			GasConsumed: 12345,
+			Stack:       []stackitem.Item{},
+			Events: []NotificationEvent{{
+				ScriptHash: random.Uint160(),
+				Name:       "Event",
+				Item:       stackitem.NewArray([]stackitem.Item{stackitem.NewBool(true)}),
+			}},
+		},
+	}
+
+	w := io.NewBufBinWriter()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w.Reset()
+		aer.EncodeBinary(w.BinWriter)
+	}
+}
+
 func TestEncodeDecodeNotificationEvent(t *testing.T) {
 	event := &NotificationEvent{
 		ScriptHash: random.Uint160(),

--- a/pkg/core/transaction/bench_test.go
+++ b/pkg/core/transaction/bench_test.go
@@ -53,3 +53,14 @@ func BenchmarkDecodeFromBytes(t *testing.B) {
 		require.NoError(t, err)
 	}
 }
+
+func BenchmarkTransaction_Bytes(b *testing.B) {
+	tx, err := NewTransactionFromBytes(benchTx)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tx.Bytes()
+	}
+}

--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -203,7 +203,10 @@ func (t *Transaction) DecodeBinary(br *io.BinReader) {
 // EncodeBinary implements Serializable interface.
 func (t *Transaction) EncodeBinary(bw *io.BinWriter) {
 	t.encodeHashableFields(bw)
-	bw.WriteArray(t.Scripts)
+	bw.WriteVarUint(uint64(len(t.Scripts)))
+	for i := range t.Scripts {
+		t.Scripts[i].EncodeBinary(bw)
+	}
 }
 
 // encodeHashableFields encodes the fields that are not used for
@@ -218,8 +221,14 @@ func (t *Transaction) encodeHashableFields(bw *io.BinWriter) {
 	bw.WriteU64LE(uint64(t.SystemFee))
 	bw.WriteU64LE(uint64(t.NetworkFee))
 	bw.WriteU32LE(t.ValidUntilBlock)
-	bw.WriteArray(t.Signers)
-	bw.WriteArray(t.Attributes)
+	bw.WriteVarUint(uint64(len(t.Signers)))
+	for i := range t.Signers {
+		t.Signers[i].EncodeBinary(bw)
+	}
+	bw.WriteVarUint(uint64(len(t.Attributes)))
+	for i := range t.Attributes {
+		t.Attributes[i].EncodeBinary(bw)
+	}
 	bw.WriteVarBytes(t.Script)
 }
 

--- a/pkg/vm/stackitem/serialization.go
+++ b/pkg/vm/stackitem/serialization.go
@@ -112,8 +112,11 @@ func (w *serContext) serialize(item Item) error {
 		}
 	case *BigInteger:
 		w.data = append(w.data, byte(IntegerT))
-		data := bigint.ToBytes(t.Value().(*big.Int))
-		w.appendVarUint(uint64(len(data)))
+		v := t.Value().(*big.Int)
+		ln := len(w.data)
+		w.data = append(w.data, 0)
+		data := bigint.ToPreallocatedBytes(v, w.data[len(w.data):])
+		w.data[ln] = byte(len(data))
 		w.data = append(w.data, data...)
 	case *Interop:
 		if w.allowInvalid {


### PR DESCRIPTION
1. Don't allocate `NodeObject` just for serialization.
2. Use `EmptyNode = struct{}` instead of `HashNode`.
3. Don't allocate new slice for big integers during stackitem serialization.
There is some quirk here: `ToPreallocatedBytes` will perform a rough estimation of size, which differs from the real size. This will be fixed later.
4. Inline frequently called  `BinWriter.WriteArray` invocations.

Will update this with 1 more MPT optimization.