### PR TITLE
Optimize tx decoding

### DIFF
--- a/pkg/core/transaction/bench_test.go
+++ b/pkg/core/transaction/bench_test.go
@@ -1,0 +1,55 @@
+package transaction
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/stretchr/testify/require"
+)
+
+// Some typical transfer tx from mainnet.
+var (
+	benchTx     []byte
+	benchTxB64  = "AK9KzFu0P5gAAAAAAIjOEgAAAAAA7jAAAAGIDdjSt7aj2J+dktSobkC9j0/CJwEAWwsCAMLrCwwUtXfkIuockX9HAVMNeEuQMxMlYkMMFIgN2NK3tqPYn52S1KhuQL2PT8InFMAfDAh0cmFuc2ZlcgwUz3bii9AGLEpHjuNVYQETGfPPpNJBYn1bUjkBQgxAUiZNae4OTSu2EOGW+6fwslLIpVsczOAR9o6R796tFf2KG+nLzs709tCQ7NELZOQ7zUzfF19ADLvH/efNT4v9LygMIQNT96/wFdPSBO7NUI9Kpn9EffTRXsS6ZJ9PqRvbenijVEFW57Mn"
+	benchTxJSON []byte
+)
+
+func init() {
+	var err error
+	benchTx, err = base64.StdEncoding.DecodeString(benchTxB64)
+	if err != nil {
+		panic(err)
+	}
+	t, err := NewTransactionFromBytes(benchTx)
+	if err != nil {
+		panic(err)
+	}
+	benchTxJSON, err = t.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func BenchmarkDecodeBinary(t *testing.B) {
+	for n := 0; n < t.N; n++ {
+		r := io.NewBinReaderFromBuf(benchTx)
+		tx := &Transaction{}
+		tx.DecodeBinary(r)
+		require.NoError(t, r.Err)
+	}
+}
+
+func BenchmarkDecodeJSON(t *testing.B) {
+	for n := 0; n < t.N; n++ {
+		tx := &Transaction{}
+		require.NoError(t, tx.UnmarshalJSON(benchTxJSON))
+	}
+}
+
+func BenchmarkDecodeFromBytes(t *testing.B) {
+	for n := 0; n < t.N; n++ {
+		_, err := NewTransactionFromBytes(benchTx)
+		require.NoError(t, err)
+	}
+}

--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -234,13 +235,14 @@ func (t *Transaction) EncodeHashableFields() ([]byte, error) {
 
 // createHash creates the hash of the transaction.
 func (t *Transaction) createHash() error {
-	buf := io.NewBufBinWriter()
-	t.encodeHashableFields(buf.BinWriter)
-	if buf.Err != nil {
-		return buf.Err
+	shaHash := sha256.New()
+	bw := io.NewBinWriterFromIO(shaHash)
+	t.encodeHashableFields(bw)
+	if bw.Err != nil {
+		return bw.Err
 	}
 
-	t.hash = hash.Sha256(buf.Bytes())
+	shaHash.Sum(t.hash[:0])
 	return nil
 }
 

--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -143,8 +143,7 @@ func (t *Transaction) decodeHashableFields(br *io.BinReader) {
 	}
 }
 
-// DecodeBinary implements Serializable interface.
-func (t *Transaction) DecodeBinary(br *io.BinReader) {
+func (t *Transaction) decodeBinaryNoSize(br *io.BinReader) {
 	t.decodeHashableFields(br)
 	if br.Err != nil {
 		return
@@ -159,6 +158,14 @@ func (t *Transaction) DecodeBinary(br *io.BinReader) {
 	// to do it anymore.
 	if br.Err == nil {
 		br.Err = t.createHash()
+	}
+}
+
+// DecodeBinary implements Serializable interface.
+func (t *Transaction) DecodeBinary(br *io.BinReader) {
+	t.decodeBinaryNoSize(br)
+
+	if br.Err == nil {
 		_ = t.Size()
 	}
 }
@@ -240,7 +247,7 @@ func (t *Transaction) Bytes() []byte {
 func NewTransactionFromBytes(b []byte) (*Transaction, error) {
 	tx := &Transaction{}
 	r := io.NewBinReaderFromBuf(b)
-	tx.DecodeBinary(r)
+	tx.decodeBinaryNoSize(r)
 	if r.Err != nil {
 		return nil, r.Err
 	}

--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -148,8 +148,8 @@ func (t *Transaction) decodeBinaryNoSize(br *io.BinReader) {
 	if br.Err != nil {
 		return
 	}
-	br.ReadArray(&t.Scripts, len(t.Signers))
-	if len(t.Signers) != len(t.Scripts) {
+	br.ReadArray(&t.Scripts, MaxAttributes)
+	if br.Err == nil && len(t.Signers) != len(t.Scripts) {
 		br.Err = fmt.Errorf("%w: %d vs %d", ErrInvalidWitnessNum, len(t.Signers), len(t.Scripts))
 		return
 	}


### PR DESCRIPTION
### Problem

Transaction decoding is used a lot, but it's far from being optimal.

### Solution

On a micro-level this improves decoding a lot. But in neo-bench it doesn't change anything. The only thing I'm not sure about here probably is `ReadArray` change, it adds some substantial amount of code, yet at the same time our blockchain is all about transactions, so decoding them should be as fast as it can be.