### PR TITLE
core: don't recalculate witness script hash

### DIFF
--- a/pkg/core/bench_test.go
+++ b/pkg/core/bench_test.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/config/netmode"
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/nspcc-dev/neo-go/pkg/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkVerifyWitness(t *testing.B) {
+	bc := newTestChain(t)
+	acc, err := wallet.NewAccount()
+	require.NoError(t, err)
+
+	tx := bc.newTestTx(acc.Contract.ScriptHash(), []byte{byte(opcode.PUSH1)})
+	require.NoError(t, acc.SignTx(netmode.UnitTestNet, tx))
+
+	t.ResetTimer()
+	for n := 0; n < t.N; n++ {
+		_ = bc.VerifyWitness(tx.Signers[0].Account, tx, &tx.Scripts[0], 100000000)
+	}
+}

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1837,7 +1837,7 @@ func (bc *Blockchain) InitVerificationVM(v *vm.VM, getContract func(util.Uint160
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrInvalidVerification, err)
 		}
-		v.LoadScriptWithFlags(witness.VerificationScript, callflag.ReadOnly)
+		v.LoadScriptWithHash(witness.VerificationScript, hash, callflag.ReadOnly)
 	} else {
 		cs, err := getContract(hash)
 		if err != nil {


### PR DESCRIPTION
We know it already, but with current loading code VM will hash it once more. I
have not measured consequences of this change, but it just can't be bad.