### PR TITLE
rpc/request: delay parameter unmarshaling

### DIFF
--- a/pkg/rpc/client/wsclient_test.go
+++ b/pkg/rpc/client/wsclient_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -186,10 +187,10 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			},
 			func(t *testing.T, p *request.Params) {
 				param := p.Value(1)
-				require.NotNil(t, param)
-				require.Equal(t, request.BlockFilterT, param.Type)
-				filt, ok := param.Value.(request.BlockFilter)
-				require.Equal(t, true, ok)
+				raw, ok := param.Value.(json.RawMessage)
+				require.True(t, ok)
+				filt := new(request.BlockFilter)
+				require.NoError(t, json.Unmarshal(raw, filt))
 				require.Equal(t, 3, filt.Primary)
 			},
 		},
@@ -201,10 +202,10 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			},
 			func(t *testing.T, p *request.Params) {
 				param := p.Value(1)
-				require.NotNil(t, param)
-				require.Equal(t, request.TxFilterT, param.Type)
-				filt, ok := param.Value.(request.TxFilter)
-				require.Equal(t, true, ok)
+				raw, ok := param.Value.(json.RawMessage)
+				require.True(t, ok)
+				filt := new(request.TxFilter)
+				require.NoError(t, json.Unmarshal(raw, filt))
 				require.Equal(t, util.Uint160{1, 2, 3, 4, 5}, *filt.Sender)
 				require.Nil(t, filt.Signer)
 			},
@@ -217,10 +218,10 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			},
 			func(t *testing.T, p *request.Params) {
 				param := p.Value(1)
-				require.NotNil(t, param)
-				require.Equal(t, request.TxFilterT, param.Type)
-				filt, ok := param.Value.(request.TxFilter)
-				require.Equal(t, true, ok)
+				raw, ok := param.Value.(json.RawMessage)
+				require.True(t, ok)
+				filt := new(request.TxFilter)
+				require.NoError(t, json.Unmarshal(raw, filt))
 				require.Nil(t, filt.Sender)
 				require.Equal(t, util.Uint160{0, 42}, *filt.Signer)
 			},
@@ -234,10 +235,10 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			},
 			func(t *testing.T, p *request.Params) {
 				param := p.Value(1)
-				require.NotNil(t, param)
-				require.Equal(t, request.TxFilterT, param.Type)
-				filt, ok := param.Value.(request.TxFilter)
-				require.Equal(t, true, ok)
+				raw, ok := param.Value.(json.RawMessage)
+				require.True(t, ok)
+				filt := new(request.TxFilter)
+				require.NoError(t, json.Unmarshal(raw, filt))
 				require.Equal(t, util.Uint160{1, 2, 3, 4, 5}, *filt.Sender)
 				require.Equal(t, util.Uint160{0, 42}, *filt.Signer)
 			},
@@ -250,10 +251,10 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			},
 			func(t *testing.T, p *request.Params) {
 				param := p.Value(1)
-				require.NotNil(t, param)
-				require.Equal(t, request.NotificationFilterT, param.Type)
-				filt, ok := param.Value.(request.NotificationFilter)
-				require.Equal(t, true, ok)
+				raw, ok := param.Value.(json.RawMessage)
+				require.True(t, ok)
+				filt := new(request.NotificationFilter)
+				require.NoError(t, json.Unmarshal(raw, filt))
 				require.Equal(t, util.Uint160{1, 2, 3, 4, 5}, *filt.Contract)
 				require.Nil(t, filt.Name)
 			},
@@ -266,10 +267,10 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			},
 			func(t *testing.T, p *request.Params) {
 				param := p.Value(1)
-				require.NotNil(t, param)
-				require.Equal(t, request.NotificationFilterT, param.Type)
-				filt, ok := param.Value.(request.NotificationFilter)
-				require.Equal(t, true, ok)
+				raw, ok := param.Value.(json.RawMessage)
+				require.True(t, ok)
+				filt := new(request.NotificationFilter)
+				require.NoError(t, json.Unmarshal(raw, filt))
 				require.Equal(t, "my_pretty_notification", *filt.Name)
 				require.Nil(t, filt.Contract)
 			},
@@ -283,10 +284,10 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			},
 			func(t *testing.T, p *request.Params) {
 				param := p.Value(1)
-				require.NotNil(t, param)
-				require.Equal(t, request.NotificationFilterT, param.Type)
-				filt, ok := param.Value.(request.NotificationFilter)
-				require.Equal(t, true, ok)
+				raw, ok := param.Value.(json.RawMessage)
+				require.True(t, ok)
+				filt := new(request.NotificationFilter)
+				require.NoError(t, json.Unmarshal(raw, filt))
 				require.Equal(t, util.Uint160{1, 2, 3, 4, 5}, *filt.Contract)
 				require.Equal(t, "my_pretty_notification", *filt.Name)
 			},
@@ -299,10 +300,10 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			},
 			func(t *testing.T, p *request.Params) {
 				param := p.Value(1)
-				require.NotNil(t, param)
-				require.Equal(t, request.ExecutionFilterT, param.Type)
-				filt, ok := param.Value.(request.ExecutionFilter)
-				require.Equal(t, true, ok)
+				raw, ok := param.Value.(json.RawMessage)
+				require.True(t, ok)
+				filt := new(request.ExecutionFilter)
+				require.NoError(t, json.Unmarshal(raw, filt))
 				require.Equal(t, "FAULT", filt.State)
 			},
 		},


### PR DESCRIPTION
It is rather costly to try to unmarshal many structs in order.

Signed-off-by: Evgeniy Stratonikov <evgeniy@nspcc.ru>