### PR TITLE
core: take an addblock lock on exit

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -410,6 +410,7 @@ func (bc *Blockchain) Run() {
 	persistTimer := time.NewTimer(persistInterval)
 	defer func() {
 		persistTimer.Stop()
+		bc.addLock.Lock() // Prevent changing state, but do not release the lock, we're about to exit.
 		if _, err := bc.persist(); err != nil {
 			bc.log.Warn("failed to persist", zap.Error(err))
 		}


### PR DESCRIPTION
Prevent this (2.x, but relevant here also):

2021-08-12T15:24:00.750+0300    INFO    shutting down service   {"service": "Prometheus", "endpoint": ":2112"}
2021-08-12T15:24:00.752+0300    INFO    shutting down service   {"service": "Pprof", "endpoint": ":2113"}
2021-08-12T15:24:00.868+0300    INFO    blockchain persist completed    {"persistedBlocks": 14, "persistedKeys": 3145, "headerHeight": 7806078, "blockHeight": 7794173, "took": "652.243264ms"}
2021-08-12T15:24:00.974+0300    INFO    blockchain persist completed    {"persistedBlocks": 1, "persistedKeys": 259, "headerHeight": 7806078, "blockHeight": 7794174, "took": "221.955904ms"}
panic: assignment to entry in nil map

goroutine 132 [running]:
github.com/nspcc-dev/neo-go/pkg/core/storage.(*MemoryStore).drop(...)
        github.com/nspcc-dev/neo-go/pkg/core/storage/memory_store.go:71
github.com/nspcc-dev/neo-go/pkg/core/storage.(*MemoryStore).Delete(0xc0002889c0, 0xc022642060, 0x21, 0x30, 0x21, 0xc022642060)
        github.com/nspcc-dev/neo-go/pkg/core/storage/memory_store.go:79 +0x9c
github.com/nspcc-dev/neo-go/pkg/core/mpt.(*Trie).updateRefCount(0xc00029cd50, 0x70945b6e05b4ce98, 0xb058a7450d307de5, 0x660ef5aff9146084, 0x1293434e970256e5, 0xc000000001)
        github.com/nspcc-dev/neo-go/pkg/core/mpt/trie.go:410 +0x257
github.com/nspcc-dev/neo-go/pkg/core/mpt.(*Trie).Flush(0xc00029cd50)
        github.com/nspcc-dev/neo-go/pkg/core/mpt/trie.go:370 +0x23a
github.com/nspcc-dev/neo-go/pkg/core.(*Blockchain).storeBlock(0xc0002c6000, 0xc022476500, 0x0, 0xd6b100)
        github.com/nspcc-dev/neo-go/pkg/core/blockchain.go:869 +0x3ac5
github.com/nspcc-dev/neo-go/pkg/core.(*Blockchain).AddBlock(0xc0002c6000, 0xc022476500, 0x0, 0x0)
        github.com/nspcc-dev/neo-go/pkg/core/blockchain.go:446 +0xeb
github.com/nspcc-dev/neo-go/pkg/network.(*blockQueue).run(0xc0001e1ad0)
        github.com/nspcc-dev/neo-go/pkg/network/blockqueue.go:48 +0x168
created by github.com/nspcc-dev/neo-go/pkg/network.(*Server).Start
        github.com/nspcc-dev/neo-go/pkg/network/server.go:183 +0x25d

Which then leads to broken DB.
