### PR TITLE
cli: fix tests for go1.17

### DIFF
--- a/cli/server/dump_test.go
+++ b/cli/server/dump_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,15 +16,15 @@ func TestGetPath(t *testing.T) {
 		err := os.RemoveAll(testPath)
 		require.NoError(t, err)
 	})
-	path, err := getPath(testPath, 123)
+	actual, err := getPath(testPath, 123)
 	require.NoError(t, err)
-	require.Equal(t, testPath+"/BlockStorage_100000/dump-block-1000.json", path)
+	require.Equal(t, path.Join(testPath, "/BlockStorage_100000/dump-block-1000.json"), actual)
 
-	path, err = getPath(testPath, 1230)
+	actual, err = getPath(testPath, 1230)
 	require.NoError(t, err)
-	require.Equal(t, testPath+"/BlockStorage_100000/dump-block-2000.json", path)
+	require.Equal(t, path.Join(testPath, "/BlockStorage_100000/dump-block-2000.json"), actual)
 
-	path, err = getPath(testPath, 123000)
+	actual, err = getPath(testPath, 123000)
 	require.NoError(t, err)
-	require.Equal(t, testPath+"/BlockStorage_200000/dump-block-123000.json", path)
+	require.Equal(t, path.Join(testPath, "/BlockStorage_200000/dump-block-123000.json"), actual)
 }


### PR DESCRIPTION
`getPath` returns paths without leading dot.

Signed-off-by: Evgeniy Stratonikov <evgeniy@nspcc.ru>

```
=== RUN   TestGetPath
    dump_test.go:20: 
        	Error Trace:	dump_test.go:20
        	Error:      	Not equal: 
        	            	expected: "./746297090/BlockStorage_100000/dump-block-1000.json"
        	            	actual  : "746297090/BlockStorage_100000/dump-block-1000.json"
```

This is most likely related to changes in `io.TempDir` package rather than `filepath.Join` (`filepath.Clean` was already there in go1.16).