### PR TITLE
Drop some useless allocations

### DIFF
--- a/pkg/core/block/block.go
+++ b/pkg/core/block/block.go
@@ -107,9 +107,11 @@ func New(stateRootEnabled bool) *Block {
 // Notice that only the hashes of the transactions are stored.
 func (b *Block) Trim() ([]byte, error) {
 	buf := io.NewBufBinWriter()
+	numTx := len(b.Transactions)
+	buf.Grow(b.GetExpectedBlockSizeWithoutTransactions(numTx) + util.Uint256Size*numTx)
 	b.Header.EncodeBinary(buf.BinWriter)
 
-	buf.WriteVarUint(uint64(len(b.Transactions)))
+	buf.WriteVarUint(uint64(numTx))
 	for _, tx := range b.Transactions {
 		h := tx.Hash()
 		h.EncodeBinary(buf.BinWriter)

--- a/pkg/core/interop/context.go
+++ b/pkg/core/interop/context.go
@@ -57,23 +57,19 @@ func NewContext(trigger trigger.Type, bc blockchainer.Blockchainer, d dao.DAO,
 	block *block.Block, tx *transaction.Transaction, log *zap.Logger) *Context {
 	baseExecFee := int64(DefaultBaseExecFee)
 	dao := d.GetWrapped()
-	nes := make([]state.NotificationEvent, 0)
 
 	if bc != nil && (block == nil || block.Index != 0) {
 		baseExecFee = bc.GetPolicer().GetBaseExecFee()
 	}
 	return &Context{
-		Chain:         bc,
-		Network:       uint32(bc.GetConfig().Magic),
-		Natives:       natives,
-		Trigger:       trigger,
-		Block:         block,
-		Tx:            tx,
-		DAO:           dao,
-		Notifications: nes,
-		Log:           log,
-		// Functions is a slice of interops sorted by ID.
-		Functions:   []Function{},
+		Chain:       bc,
+		Network:     uint32(bc.GetConfig().Magic),
+		Natives:     natives,
+		Trigger:     trigger,
+		Block:       block,
+		Tx:          tx,
+		DAO:         dao,
+		Log:         log,
 		getContract: getContract,
 		baseExecFee: baseExecFee,
 	}

--- a/pkg/io/binaryBufWriter.go
+++ b/pkg/io/binaryBufWriter.go
@@ -13,13 +13,14 @@ var ErrDrained = errors.New("buffer already drained")
 // writes via Bytes().
 type BufBinWriter struct {
 	*BinWriter
-	buf *bytes.Buffer
+	buf bytes.Buffer
 }
 
 // NewBufBinWriter makes a BufBinWriter with an empty byte buffer.
 func NewBufBinWriter() *BufBinWriter {
-	b := new(bytes.Buffer)
-	return &BufBinWriter{BinWriter: NewBinWriterFromIO(b), buf: b}
+	b := new(BufBinWriter)
+	b.BinWriter = NewBinWriterFromIO(&b.buf)
+	return b
 }
 
 // Len returns the number of bytes of the unread portion of the buffer.

--- a/pkg/io/binaryBufWriter.go
+++ b/pkg/io/binaryBufWriter.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 )
 
+// ErrDrained is returned on an attempt to use already drained write buffer.
+var ErrDrained = errors.New("buffer already drained")
+
 // BufBinWriter is an additional layer on top of BinWriter that
 // automatically creates buffer to write into that you can get after all
 // writes via Bytes().
@@ -29,7 +32,7 @@ func (bw *BufBinWriter) Bytes() []byte {
 	if bw.Err != nil {
 		return nil
 	}
-	bw.Err = errors.New("buffer already drained")
+	bw.Err = ErrDrained
 	return bw.buf.Bytes()
 }
 


### PR DESCRIPTION
TXs ≈ 1000000
RPS ≈ 31678.809
RPC Errors  ≈ 0 / 0.000%
TPS ≈ 31219.756
DefaultMSPerBlock = 1000

CPU ≈ 34.589%
Mem ≈ 528.872MB

:wink: 

The key to single-node performance is allocations now (and a bit of locking of course).