### PR TITLE
mpt: remove unrtraceable roots

### DIFF
--- a/pkg/core/mpt/batch_test.go
+++ b/pkg/core/mpt/batch_test.go
@@ -57,7 +57,7 @@ func testIncompletePut(t *testing.T, ps pairs, n int, tr1, tr2 *Trie) {
 
 	t.Run("test restore", func(t *testing.T) {
 		tr2.Flush()
-		tr3 := NewTrie(NewHashNode(tr2.StateRoot()), false, storage.NewMemCachedStore(tr2.Store))
+		tr3 := NewTrie(NewHashNode(tr2.StateRoot()), Config{Store: storage.NewMemCachedStore(tr2.Store)})
 		for _, p := range ps[:n] {
 			val, err := tr3.Get(p[0])
 			if p[1] == nil {
@@ -74,10 +74,14 @@ func testPut(t *testing.T, ps pairs, tr1, tr2 *Trie) {
 	testIncompletePut(t, ps, len(ps), tr1, tr2)
 }
 
+func newEmptyTrie() *Trie {
+	return NewTrie(EmptyNode{}, Config{Store: newTestStore()})
+}
+
 func TestTrie_PutBatchLeaf(t *testing.T) {
 	prepareLeaf := func(t *testing.T) (*Trie, *Trie) {
-		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
-		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr1 := newEmptyTrie()
+		tr2 := newEmptyTrie()
 		require.NoError(t, tr1.Put([]byte{0}, []byte("value")))
 		require.NoError(t, tr2.Put([]byte{0}, []byte("value")))
 		return tr1, tr2
@@ -118,8 +122,8 @@ func TestTrie_PutBatchLeaf(t *testing.T) {
 
 func TestTrie_PutBatchExtension(t *testing.T) {
 	prepareExtension := func(t *testing.T) (*Trie, *Trie) {
-		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
-		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr1 := newEmptyTrie()
+		tr2 := newEmptyTrie()
 		require.NoError(t, tr1.Put([]byte{1, 2}, []byte("value1")))
 		require.NoError(t, tr2.Put([]byte{1, 2}, []byte("value1")))
 		return tr1, tr2
@@ -170,8 +174,8 @@ func TestTrie_PutBatchExtension(t *testing.T) {
 
 func TestTrie_PutBatchBranch(t *testing.T) {
 	prepareBranch := func(t *testing.T) (*Trie, *Trie) {
-		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
-		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr1 := newEmptyTrie()
+		tr2 := newEmptyTrie()
 		require.NoError(t, tr1.Put([]byte{0x00, 2}, []byte("value1")))
 		require.NoError(t, tr2.Put([]byte{0x00, 2}, []byte("value1")))
 		require.NoError(t, tr1.Put([]byte{0x10, 3}, []byte("value2")))
@@ -201,8 +205,8 @@ func TestTrie_PutBatchBranch(t *testing.T) {
 			require.IsType(t, (*ExtensionNode)(nil), tr1.root)
 		})
 		t.Run("non-empty child is last node", func(t *testing.T) {
-			tr1 := NewTrie(EmptyNode{}, false, newTestStore())
-			tr2 := NewTrie(EmptyNode{}, false, newTestStore())
+			tr1 := newEmptyTrie()
+			tr2 := newEmptyTrie()
 			require.NoError(t, tr1.Put([]byte{0x00, 2}, []byte("value1")))
 			require.NoError(t, tr2.Put([]byte{0x00, 2}, []byte("value1")))
 			require.NoError(t, tr1.Put([]byte{0x00}, []byte("value2")))
@@ -248,8 +252,8 @@ func TestTrie_PutBatchBranch(t *testing.T) {
 
 func TestTrie_PutBatchHash(t *testing.T) {
 	prepareHash := func(t *testing.T) (*Trie, *Trie) {
-		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
-		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr1 := newEmptyTrie()
+		tr2 := newEmptyTrie()
 		require.NoError(t, tr1.Put([]byte{0x10}, []byte("value1")))
 		require.NoError(t, tr2.Put([]byte{0x10}, []byte("value1")))
 		require.NoError(t, tr1.Put([]byte{0x20}, []byte("value2")))
@@ -283,8 +287,8 @@ func TestTrie_PutBatchHash(t *testing.T) {
 
 func TestTrie_PutBatchEmpty(t *testing.T) {
 	t.Run("good", func(t *testing.T) {
-		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
-		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr1 := newEmptyTrie()
+		tr2 := newEmptyTrie()
 		var ps = pairs{
 			{[]byte{0}, []byte("value0")},
 			{[]byte{1}, []byte("value1")},
@@ -299,15 +303,15 @@ func TestTrie_PutBatchEmpty(t *testing.T) {
 			{[]byte{2}, nil},
 			{[]byte{3}, []byte("replace3")},
 		}
-		tr1 := NewTrie(EmptyNode{}, false, newTestStore())
-		tr2 := NewTrie(EmptyNode{}, false, newTestStore())
+		tr1 := newEmptyTrie()
+		tr2 := newEmptyTrie()
 		testIncompletePut(t, ps, 4, tr1, tr2)
 	})
 }
 
 // For the sake of coverage.
 func TestTrie_InvalidNodeType(t *testing.T) {
-	tr := NewTrie(EmptyNode{}, false, newTestStore())
+	tr := newEmptyTrie()
 	var b Batch
 	b.Add([]byte{1}, []byte("value"))
 	tr.root = Node(nil)
@@ -315,8 +319,8 @@ func TestTrie_InvalidNodeType(t *testing.T) {
 }
 
 func TestTrie_PutBatch(t *testing.T) {
-	tr1 := NewTrie(EmptyNode{}, false, newTestStore())
-	tr2 := NewTrie(EmptyNode{}, false, newTestStore())
+	tr1 := newEmptyTrie()
+	tr2 := newEmptyTrie()
 	var ps = pairs{
 		{[]byte{1}, []byte{1}},
 		{[]byte{2}, []byte{3}},

--- a/pkg/core/mpt/billet.go
+++ b/pkg/core/mpt/billet.go
@@ -182,13 +182,14 @@ func (b *Billet) incrementRefAndStore(h util.Uint256, bs []byte) {
 		// An item may already be in store.
 		data, err = b.Store.Get(key)
 		if err == nil {
-			cnt = int32(binary.LittleEndian.Uint32(data[len(data)-4:]))
+			cnt = int32(binary.LittleEndian.Uint32(data[len(data)-12:]))
 		}
 		cnt++
 		if len(data) == 0 {
-			data = append(bs, 0, 0, 0, 0)
+			// FIXME think about current generation
+			data = append(bs, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 		}
-		binary.LittleEndian.PutUint32(data[len(data)-4:], uint32(cnt))
+		binary.LittleEndian.PutUint32(data[len(data)-12:], uint32(cnt))
 		_ = b.Store.Put(key, data)
 	} else {
 		_ = b.Store.Put(key, bs)

--- a/pkg/core/mpt/billet_test.go
+++ b/pkg/core/mpt/billet_test.go
@@ -19,7 +19,7 @@ func TestBillet_RestoreHashNode(t *testing.T) {
 		expectedBytes, err := tr.Store.Get(makeStorageKey(expectedNode.Hash().BytesBE()))
 		if expectedRefCount != 0 {
 			require.NoError(t, err)
-			require.Equal(t, expectedRefCount, binary.LittleEndian.Uint32(expectedBytes[len(expectedBytes)-4:]))
+			require.Equal(t, expectedRefCount, binary.LittleEndian.Uint32(expectedBytes[len(expectedBytes)-12:]))
 		} else {
 			require.True(t, errors.Is(err, storage.ErrKeyNotFound))
 		}

--- a/pkg/core/mpt/compat_test.go
+++ b/pkg/core/mpt/compat_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/core/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -277,12 +278,12 @@ func TestCompatibility(t *testing.T) {
 		tr1 := copyTrie(tr)
 		require.NoError(t, tr1.Delete([]byte{0xa1}))
 		tr1.Flush()
-		require.Equal(t, 2, len(tr1.Store.GetBatch().Put))
+		require.Equal(t, 2, len(tr1.Store.(*storage.MemCachedStore).GetBatch().Put))
 
 		tr2 := copyTrie(tr1)
 		require.NoError(t, tr2.Delete([]byte{0xa2}))
 		tr2.Flush()
-		require.Equal(t, 0, len(tr2.Store.GetBatch().Put))
+		require.Equal(t, 0, len(tr2.Store.(*storage.MemCachedStore).GetBatch().Put))
 	})
 
 	t.Run("BranchDeleteDirty", func(t *testing.T) {
@@ -300,12 +301,12 @@ func TestCompatibility(t *testing.T) {
 		tr2 := copyTrie(tr1)
 		require.NoError(t, tr2.Delete([]byte{0x20}))
 		tr2.Flush()
-		require.Equal(t, 2, len(tr2.Store.GetBatch().Put))
+		require.Equal(t, 2, len(tr2.Store.(*storage.MemCachedStore).GetBatch().Put))
 
 		tr3 := copyTrie(tr2)
 		require.NoError(t, tr3.Delete([]byte{0x30}))
 		tr3.Flush()
-		require.Equal(t, 0, len(tr3.Store.GetBatch().Put))
+		require.Equal(t, 0, len(tr3.Store.(*storage.MemCachedStore).GetBatch().Put))
 	})
 
 	t.Run("ExtensionPutDirty", func(t *testing.T) {
@@ -318,7 +319,7 @@ func TestCompatibility(t *testing.T) {
 		tr1 := copyTrie(tr)
 		require.NoError(t, tr1.Put([]byte{0xa3}, []byte{0x03}))
 		tr1.Flush()
-		require.Equal(t, 5, len(tr1.Store.GetBatch().Put))
+		require.Equal(t, 5, len(tr1.Store.(*storage.MemCachedStore).GetBatch().Put))
 	})
 
 	t.Run("BranchPutDirty", func(t *testing.T) {
@@ -352,7 +353,7 @@ func copyTrie(t *Trie) *Trie {
 }
 
 func checkBatchSize(t *testing.T, tr *Trie, n int) {
-	require.Equal(t, n, len(tr.Store.GetBatch().Put))
+	require.Equal(t, n, len(tr.Store.(*storage.MemCachedStore).GetBatch().Put))
 }
 
 func testGetProof(t *testing.T, tr *Trie, key []byte, size int) [][]byte {

--- a/pkg/core/mpt/compat_test.go
+++ b/pkg/core/mpt/compat_test.go
@@ -23,7 +23,7 @@ func prepareMPTCompat() *Trie {
 	b.Children[16] = v2
 	b.Children[15] = NewHashNode(e4.Hash())
 
-	tr := NewTrie(r, true, newTestStore())
+	tr := NewTrie(r, Config{Store: newTestStore(), RefCountEnabled: true})
 	tr.putToStore(r)
 	tr.putToStore(b)
 	tr.putToStore(e1)
@@ -129,7 +129,7 @@ func TestCompatibility(t *testing.T) {
 		b.Children[0] = e1
 		b.Children[15] = NewHashNode(e4.Hash())
 
-		tr := NewTrie(NewHashNode(r.Hash()), false, newTestStore())
+		tr := NewTrie(NewHashNode(r.Hash()), Config{Store: newTestStore()})
 		tr.putToStore(r)
 		tr.putToStore(b)
 		tr.putToStore(e1)
@@ -149,7 +149,7 @@ func TestCompatibility(t *testing.T) {
 		tr.testHas(t, []byte{0xac, 0x02}, []byte{0xab, 0xcd})
 		tr.Flush()
 
-		tr2 := NewTrie(NewHashNode(tr.root.Hash()), false, tr.Store)
+		tr2 := NewTrie(NewHashNode(tr.root.Hash()), Config{Store: tr.Store})
 		tr2.testHas(t, []byte{0xac, 0x02}, []byte{0xab, 0xcd})
 	})
 
@@ -186,7 +186,7 @@ func TestCompatibility(t *testing.T) {
 		b.Children[16] = v2
 		b.Children[15] = NewHashNode(e4.Hash())
 
-		tr := NewTrie(NewHashNode(r.Hash()), true, mainTrie.Store)
+		tr := NewTrie(NewHashNode(r.Hash()), Config{Store: mainTrie.Store, RefCountEnabled: true})
 		require.Equal(t, r.Hash(), tr.root.Hash())
 
 		// Tail bytes contain reference counter thus check for prefix.
@@ -348,7 +348,7 @@ func TestCompatibility(t *testing.T) {
 }
 
 func copyTrie(t *Trie) *Trie {
-	return NewTrie(NewHashNode(t.root.Hash()), t.refcountEnabled, t.Store)
+	return NewTrie(NewHashNode(t.root.Hash()), t.Config)
 }
 
 func checkBatchSize(t *testing.T, tr *Trie, n int) {
@@ -368,7 +368,7 @@ func testGetProof(t *testing.T, tr *Trie, key []byte, size int) [][]byte {
 }
 
 func newFilledTrie(t *testing.T, args ...[]byte) *Trie {
-	tr := NewTrie(nil, true, newTestStore())
+	tr := NewTrie(nil, Config{Store: newTestStore(), RefCountEnabled: true})
 	for i := 0; i < len(args); i += 2 {
 		require.NoError(t, tr.Put(args[i], args[i+1]))
 	}

--- a/pkg/core/mpt/gc.go
+++ b/pkg/core/mpt/gc.go
@@ -1,0 +1,188 @@
+package mpt
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"runtime"
+
+	"github.com/nspcc-dev/neo-go/pkg/core/storage"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+// flushNodeGC puts node to the storage and adds generation mark to it.
+// It panics if GC is disabled.
+func (t *Trie) flushNodeGC(h util.Uint256) {
+	if !t.GCEnabled {
+		panic("`flushNodeGC` is called, but GC is disabled")
+	}
+
+	key := makeStorageKey(h.BytesBE())
+	node := t.refcount[h]
+	data := node.bytes
+	if node.refcount > 0 {
+		data = append(data, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint32(data[len(data)-4:], t.Generation)
+		_ = t.Store.Put(key, data)
+	}
+}
+
+func init() {
+	runtime.SetBlockProfileRate(1)
+}
+
+func (t *Trie) traverseAndUpdateGeneration(h util.Uint256, gen uint32, st storage.Store) error {
+	select {
+	case <-t.gcClosed:
+		return ErrInterrupted
+	default:
+	}
+
+	key := makeStorageKey(h.BytesBE())
+	data, err := st.Get(key)
+	if err != nil {
+		return err
+	}
+
+	var n NodeObject
+	r := io.NewBinReaderFromBuf(data)
+	n.DecodeBinary(r)
+	if r.Err != nil {
+		return r.Err
+	}
+
+	// Children of node retrieved from store are always hash nodes.
+	switch nd := n.Node.(type) {
+	case *BranchNode:
+		for i := range nd.Children {
+			if !isEmpty(nd.Children[i]) {
+				if err := t.traverseAndUpdateGeneration(nd.Children[i].Hash(), gen, st); err != nil {
+					return err
+				}
+			}
+		}
+	case *ExtensionNode:
+		if !isEmpty(nd.next) {
+			if err := t.traverseAndUpdateGeneration(nd.next.Hash(), gen, st); err != nil {
+				return err
+			}
+		}
+	case EmptyNode:
+		panic("empty node")
+	case *HashNode:
+		panic(fmt.Sprintf("hash node in store: %s", nd.Hash()))
+	}
+
+	old := binary.LittleEndian.Uint32(data[len(data)-4:])
+	if old <= gen-2 {
+		binary.LittleEndian.PutUint32(data[len(data)-4:], gen)
+		_ = st.Put(key, data)
+	}
+	return nil
+}
+
+const (
+	gcLogBatchSize = 8
+	gcBatchSize    = 1 << gcLogBatchSize
+)
+
+// ErrInterrupted is returned when GC is shutting down.
+var ErrInterrupted = errors.New("GC is shutting down")
+
+// ShutdownGC shutdowns GC if it is in process.
+func (t *Trie) ShutdownGC() {
+	if t.gcRunning.Load() {
+		close(t.gcClosed)
+		<-t.gcFinished
+	}
+}
+
+const maxDepth = 10
+
+func (t *Trie) PrepareGC() []util.Uint256 {
+	return t.traverse(maxDepth, nil, t.root)
+}
+
+func (t *Trie) traverse(d int, hs []util.Uint256, node Node) []util.Uint256 {
+	if d == 0 {
+		return hs
+	}
+	switch n := node.(type) {
+	case *BranchNode:
+		hs = append(hs, n.Hash())
+		for _, c := range n.Children {
+			hs = t.traverse(d-1, hs, c)
+		}
+	case *ExtensionNode:
+		hs = append(hs, n.Hash())
+		hs = t.traverse(d-1, hs, n.next)
+	case *LeafNode:
+		hs = append(hs, n.Hash())
+	}
+	return hs
+}
+
+// PerformGC compacts storage by removing items which are no longer
+func (t *Trie) PerformGC(root util.Uint256, st storage.Store) (int, error) {
+	if !t.GCEnabled {
+		return 0, nil
+	}
+	if t.gcRunning.Load() {
+		return 0, errors.New("GC is already running")
+	}
+	if root.Equals(util.Uint256{}) {
+		return 0, nil
+	}
+	//
+	//t.gcMtx.Lock()
+	//defer t.gcMtx.Unlock()
+
+	t.gcRunning.Store(true)
+	defer func() {
+		t.gcRunning.Store(false)
+		select {
+		case <-t.gcClosed:
+			close(t.gcFinished)
+		default:
+		}
+	}()
+
+	if mc, ok := t.Store.(*storage.MemCachedStore); ok {
+		_, err := mc.Persist()
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	gen := t.Generation
+	if err := t.traverseAndUpdateGeneration(root, gen, st); err != nil {
+		return 0, fmt.Errorf("can't update generation: %w", err)
+	}
+
+	var n int
+loop:
+	for i := 0; i <= 0xFF; i += gcBatchSize {
+		b := st.Batch()
+		for j := 0; j < gcBatchSize; j++ {
+			select {
+			case <-t.gcClosed:
+				break loop
+			default:
+			}
+			st.Seek([]byte{byte(storage.DataMPT), byte(i + j)}, func(k, v []byte) {
+				if len(k) == 33 && binary.LittleEndian.Uint32(v[len(v)-4:]) <= gen-2 {
+					n++
+					b.Delete(k)
+				}
+			})
+		}
+
+		err := st.PutBatch(b)
+		if err != nil {
+			return n, err
+		}
+		fmt.Println("REMOVE BATCH", i, n)
+	}
+	return n, nil
+}

--- a/pkg/core/mpt/node_test.go
+++ b/pkg/core/mpt/node_test.go
@@ -93,7 +93,7 @@ func TestNode_Serializable(t *testing.T) {
 
 // https://github.com/neo-project/neo/blob/neox-2.x/neo.UnitTests/UT_MPTTrie.cs#L198
 func TestJSONSharp(t *testing.T) {
-	tr := NewTrie(nil, false, newTestStore())
+	tr := newEmptyTrie()
 	require.NoError(t, tr.Put([]byte{0xac, 0x11}, []byte{0xac, 0x11}))
 	require.NoError(t, tr.Put([]byte{0xac, 0x22}, []byte{0xac, 0x22}))
 	require.NoError(t, tr.Put([]byte{0xac}, []byte{0xac}))

--- a/pkg/core/mpt/proof.go
+++ b/pkg/core/mpt/proof.go
@@ -62,7 +62,7 @@ func (t *Trie) getProof(curr Node, path []byte, proofs *[][]byte) (Node, error) 
 // It also returns value for the key.
 func VerifyProof(rh util.Uint256, key []byte, proofs [][]byte) ([]byte, bool) {
 	path := toNibbles(key)
-	tr := NewTrie(NewHashNode(rh), false, storage.NewMemCachedStore(storage.NewMemoryStore()))
+	tr := NewTrie(NewHashNode(rh), Config{Store: storage.NewMemCachedStore(storage.NewMemoryStore())})
 	for i := range proofs {
 		h := hash.DoubleSha256(proofs[i])
 		// no errors in Put to memory store

--- a/pkg/core/mpt/proof_test.go
+++ b/pkg/core/mpt/proof_test.go
@@ -15,7 +15,7 @@ func newProofTrie(t *testing.T, missingHashNode bool) *Trie {
 	b.Children[4] = NewHashNode(e.Hash())
 	b.Children[5] = e2
 
-	tr := NewTrie(b, false, newTestStore())
+	tr := NewTrie(b, Config{Store: newTestStore()})
 	require.NoError(t, tr.Put([]byte{0x12, 0x31}, []byte("value1")))
 	require.NoError(t, tr.Put([]byte{0x12, 0x32}, []byte("value2")))
 	tr.putToStore(l)

--- a/pkg/core/mpt/trie.go
+++ b/pkg/core/mpt/trie.go
@@ -22,7 +22,7 @@ type Trie struct {
 
 // Config represents MPT configuration.
 type Config struct {
-	Store           *storage.MemCachedStore
+	Store           storage.Store
 	RefCountEnabled bool
 }
 

--- a/pkg/core/mpt/untraceable_test.go
+++ b/pkg/core/mpt/untraceable_test.go
@@ -1,0 +1,64 @@
+package mpt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrieRemoveUntraceable(t *testing.T) {
+	cfg := Config{
+		Store:             newTestStore(),
+		RefCountEnabled:   true,
+		RemoveUntraceable: true,
+	}
+	tr := NewTrie(EmptyNode{}, cfg)
+
+	var b Batch
+
+	b.Add([]byte{1, 2}, []byte{3, 4})
+	b.Add([]byte{1, 3}, []byte{3, 4})
+	tr.Generation++
+	_, err := tr.PutBatch(b)
+	require.NoError(t, err)
+	tr.Flush()
+	r1 := tr.StateRoot()
+
+	b.kv = b.kv[:0]
+	b.Add([]byte{1, 2}, []byte{5, 6})
+	tr.Generation++
+	_, err = tr.PutBatch(b)
+	require.NoError(t, err)
+	tr.Flush()
+	r2 := tr.StateRoot()
+
+	b.kv = b.kv[:0]
+	b.Add([]byte{1, 3}, []byte{7, 8})
+	tr.Generation++
+	_, err = tr.PutBatch(b)
+	require.NoError(t, err)
+	tr.Flush()
+	r3 := tr.StateRoot()
+
+	cfg.Generation = 1
+	require.NoError(t, RemoveRoot(r1, cfg))
+	_, err = tr.getFromStore(r1)
+	require.Error(t, err)
+
+	tr2 := NewTrie(NewHashNode(r2), cfg)
+	tr2.testHas(t, []byte{1, 2}, []byte{5, 6})
+	tr2.testHas(t, []byte{1, 3}, []byte{3, 4})
+
+	tr3 := NewTrie(NewHashNode(r3), cfg)
+	tr3.testHas(t, []byte{1, 2}, []byte{5, 6})
+	tr3.testHas(t, []byte{1, 3}, []byte{7, 8})
+
+	cfg.Generation = 2
+	require.NoError(t, RemoveRoot(r2, cfg))
+	_, err = tr.getFromStore(r2)
+	require.Error(t, err)
+
+	tr3 = NewTrie(NewHashNode(r3), cfg)
+	tr3.testHas(t, []byte{1, 2}, []byte{5, 6})
+	tr3.testHas(t, []byte{1, 3}, []byte{7, 8})
+}

--- a/pkg/core/stateroot/module.go
+++ b/pkg/core/stateroot/module.go
@@ -57,7 +57,7 @@ func NewModule(bc blockchainer.Blockchainer, log *zap.Logger, s *storage.MemCach
 
 // GetStateProof returns proof of having key in the MPT with the specified root.
 func (s *Module) GetStateProof(root util.Uint256, key []byte) ([][]byte, error) {
-	tr := mpt.NewTrie(mpt.NewHashNode(root), false, storage.NewMemCachedStore(s.Store))
+	tr := mpt.NewTrie(mpt.NewHashNode(root), mpt.Config{Store: storage.NewMemCachedStore(s.Store)})
 	return tr.GetProof(key)
 }
 
@@ -90,7 +90,7 @@ func (s *Module) Init(height uint32, enableRefCount bool) error {
 
 	var gcKey = []byte{byte(storage.DataMPT), prefixGC}
 	if height == 0 {
-		s.mpt = mpt.NewTrie(nil, enableRefCount, s.Store)
+		s.mpt = mpt.NewTrie(nil, mpt.Config{Store: s.Store})
 		var val byte
 		if enableRefCount {
 			val = 1
@@ -111,7 +111,10 @@ func (s *Module) Init(height uint32, enableRefCount bool) error {
 	}
 	s.currentLocal.Store(r.Root)
 	s.localHeight.Store(r.Index)
-	s.mpt = mpt.NewTrie(mpt.NewHashNode(r.Root), enableRefCount, s.Store)
+	s.mpt = mpt.NewTrie(mpt.NewHashNode(r.Root), mpt.Config{
+		RefCountEnabled: enableRefCount,
+		Store:           s.Store,
+	})
 	return nil
 }
 
@@ -171,7 +174,10 @@ func (s *Module) JumpToState(sr *state.MPTRoot, enableRefCount bool) error {
 
 	s.currentLocal.Store(sr.Root)
 	s.localHeight.Store(sr.Index)
-	s.mpt = mpt.NewTrie(mpt.NewHashNode(sr.Root), enableRefCount, s.Store)
+	s.mpt = mpt.NewTrie(mpt.NewHashNode(sr.Root), mpt.Config{
+		Store:           s.Store,
+		RefCountEnabled: enableRefCount,
+	})
 	return nil
 }
 

--- a/pkg/core/statesync/module_test.go
+++ b/pkg/core/statesync/module_test.go
@@ -15,7 +15,10 @@ import (
 
 func TestModule_PR2019_discussion_r689629704(t *testing.T) {
 	expectedStorage := storage.NewMemCachedStore(storage.NewMemoryStore())
-	tr := mpt.NewTrie(nil, true, expectedStorage)
+	tr := mpt.NewTrie(nil, mpt.Config{
+		Store:           expectedStorage,
+		RefCountEnabled: true,
+	})
 	require.NoError(t, tr.Put([]byte{0x03}, []byte("leaf1")))
 	require.NoError(t, tr.Put([]byte{0x01, 0xab, 0x02}, []byte("leaf2")))
 	require.NoError(t, tr.Put([]byte{0x01, 0xab, 0x04}, []byte("leaf3")))


### PR DESCRIPTION
Close #2095 .

It is ready to review but needs more opimization and testing.
Current implementation adds about 40% overhead on n3 dump restore.