### PR TITLE
rpc: return protocol parameters in `getversion`, fix #2160

### DIFF
--- a/pkg/rpc/client/client.go
+++ b/pkg/rpc/client/client.go
@@ -119,8 +119,12 @@ func (c *Client) Init() error {
 	if err != nil {
 		return fmt.Errorf("failed to get network magic: %w", err)
 	}
-	c.network = version.Magic
-	c.stateRootInHeader = version.StateRootInHeader
+	c.network = version.Protocol.Network
+	c.stateRootInHeader = version.Protocol.StateRootInHeader
+	if version.Protocol.MillisecondsPerBlock == 0 {
+		c.network = version.Magic
+		c.stateRootInHeader = version.StateRootInHeader
+	}
 	neoContractHash, err := c.GetContractStateByAddressOrName(nativenames.Neo)
 	if err != nil {
 		return fmt.Errorf("failed to get NEO contract scripthash: %w", err)

--- a/pkg/rpc/response/result/version.go
+++ b/pkg/rpc/response/result/version.go
@@ -1,16 +1,37 @@
 package result
 
-import "github.com/nspcc-dev/neo-go/pkg/config/netmode"
+import (
+	"github.com/nspcc-dev/neo-go/pkg/config/netmode"
+	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
+)
 
 type (
 	// Version model used for reporting server version
 	// info.
 	Version struct {
+		// Magic contains network magic.
+		// Deprecated: use Protocol.StateRootInHeader instead
 		Magic     netmode.Magic `json:"network"`
 		TCPPort   uint16        `json:"tcpport"`
 		WSPort    uint16        `json:"wsport,omitempty"`
 		Nonce     uint32        `json:"nonce"`
 		UserAgent string        `json:"useragent"`
+		Protocol  Protocol      `json:"protocol"`
+		// StateRootInHeader is true if state root is contained in block header.
+		// Deprecated: use Protocol.StateRootInHeader instead
+		StateRootInHeader bool `json:"staterootinheader,omitempty"`
+	}
+
+	// Protocol represents network-dependent parameters.
+	Protocol struct {
+		AddressVersion              byte          `json:"addressversion"`
+		Network                     netmode.Magic `json:"network"`
+		MillisecondsPerBlock        int           `json:"msperblock"`
+		MaxTraceableBlocks          uint32        `json:"maxtraceableblocks"`
+		MaxValidUntilBlockIncrement uint32        `json:"maxvaliduntilblockincrement"`
+		MaxTransactionsPerBlock     uint16        `json:"maxtransactionsperblock"`
+		MemoryPoolMaxTransactions   int           `json:"memorypoolmaxtransactions"`
+		InitialGasDistribution      fixedn.Fixed8 `json:"initialgasdistribution"`
 		// StateRootInHeader is true if state root is contained in block header.
 		StateRootInHeader bool `json:"staterootinheader,omitempty"`
 	}

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -520,12 +520,25 @@ func (s *Server) getVersion(_ request.Params) (interface{}, *response.Error) {
 	if err != nil {
 		return nil, response.NewInternalServerError("Cannot fetch tcp port", err)
 	}
+
+	cfg := s.chain.GetConfig()
 	return result.Version{
 		Magic:             s.network,
 		TCPPort:           port,
 		Nonce:             s.coreServer.ID(),
 		UserAgent:         s.coreServer.UserAgent,
-		StateRootInHeader: s.chain.GetConfig().StateRootInHeader,
+		StateRootInHeader: cfg.StateRootInHeader,
+		Protocol: result.Protocol{
+			AddressVersion:              address.NEO3Prefix,
+			Network:                     cfg.Magic,
+			MillisecondsPerBlock:        cfg.SecondsPerBlock * 1000,
+			MaxTraceableBlocks:          cfg.MaxTraceableBlocks,
+			MaxValidUntilBlockIncrement: cfg.MaxValidUntilBlockIncrement,
+			MaxTransactionsPerBlock:     cfg.MaxTransactionsPerBlock,
+			MemoryPoolMaxTransactions:   cfg.MemPoolSize,
+			InitialGasDistribution:      cfg.InitialGASSupply,
+			StateRootInHeader:           cfg.StateRootInHeader,
+		},
 	}, nil
 }
 

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -690,6 +690,17 @@ var rpcTestCases = map[string][]rpcTestCase{
 				resp, ok := ver.(*result.Version)
 				require.True(t, ok)
 				require.Equal(t, "/NEO-GO:/", resp.UserAgent)
+
+				cfg := e.chain.GetConfig()
+				require.EqualValues(t, address.NEO3Prefix, resp.Protocol.AddressVersion)
+				require.EqualValues(t, cfg.Magic, resp.Protocol.Network)
+				require.EqualValues(t, cfg.SecondsPerBlock*1000, resp.Protocol.MillisecondsPerBlock)
+				require.EqualValues(t, cfg.MaxTraceableBlocks, resp.Protocol.MaxTraceableBlocks)
+				require.EqualValues(t, cfg.MaxValidUntilBlockIncrement, resp.Protocol.MaxValidUntilBlockIncrement)
+				require.EqualValues(t, cfg.MaxTransactionsPerBlock, resp.Protocol.MaxTransactionsPerBlock)
+				require.EqualValues(t, cfg.MemPoolSize, resp.Protocol.MemoryPoolMaxTransactions)
+				require.EqualValues(t, cfg.InitialGASSupply, resp.Protocol.InitialGasDistribution)
+				require.EqualValues(t, false, resp.Protocol.StateRootInHeader)
 			},
 		},
 	},


### PR DESCRIPTION
`StateRootInHeader` is duplicated similarly to `Network`.
It will be removed in future as it is surely a protocol parameter.

Signed-off-by: Evgeniy Stratonikov <evgeniy@nspcc.ru>
