### PR TITLE
network: fix race in StateSync module tests

### DIFF
--- a/internal/fakechain/fakechain.go
+++ b/internal/fakechain/fakechain.go
@@ -55,6 +55,15 @@ type FakeStateSync struct {
 
 // NewFakeChain returns new FakeChain structure.
 func NewFakeChain() *FakeChain {
+	return NewFakeChainWithCustomCfg(nil)
+}
+
+// NewFakeChainWithCustomCfg returns new FakeChain structure with specified protocol configuration.
+func NewFakeChainWithCustomCfg(protocolCfg func(c *config.ProtocolConfiguration)) *FakeChain {
+	cfg := config.ProtocolConfiguration{Magic: netmode.UnitTestNet, P2PNotaryRequestPayloadPoolSize: 10}
+	if protocolCfg != nil {
+		protocolCfg(&cfg)
+	}
 	return &FakeChain{
 		Pool:                  mempool.New(10, 0, false),
 		PoolTxF:               func(*transaction.Transaction) error { return nil },
@@ -62,7 +71,7 @@ func NewFakeChain() *FakeChain {
 		blocks:                make(map[util.Uint256]*block.Block),
 		hdrHashes:             make(map[uint32]util.Uint256),
 		txs:                   make(map[util.Uint256]*transaction.Transaction),
-		ProtocolConfiguration: config.ProtocolConfiguration{Magic: netmode.UnitTestNet, P2PNotaryRequestPayloadPoolSize: 10},
+		ProtocolConfiguration: cfg,
 	}
 }
 

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/nspcc-dev/neo-go/internal/fakechain"
+	"github.com/nspcc-dev/neo-go/pkg/config"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/network/capability"
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
@@ -187,7 +188,11 @@ func (p *localPeer) CanProcessAddr() bool {
 }
 
 func newTestServer(t *testing.T, serverConfig ServerConfig) *Server {
-	s, err := newServerFromConstructors(serverConfig, fakechain.NewFakeChain(), zaptest.NewLogger(t),
+	return newTestServerWithCustomCfg(t, serverConfig, nil)
+}
+
+func newTestServerWithCustomCfg(t *testing.T, serverConfig ServerConfig, protocolCfg func(*config.ProtocolConfiguration)) *Server {
+	s, err := newServerFromConstructors(serverConfig, fakechain.NewFakeChainWithCustomCfg(protocolCfg), zaptest.NewLogger(t),
 		newFakeTransp, newFakeConsensus, newTestDiscovery)
 	require.NoError(t, err)
 	t.Cleanup(s.discovery.Close)

--- a/pkg/network/server_test.go
+++ b/pkg/network/server_test.go
@@ -1059,14 +1059,15 @@ func TestTryInitStateSync(t *testing.T) {
 			p := newLocalPeer(t, s)
 			p.handshaked = true
 			p.lastBlockIndex = h
-			s.peers[p] = true
+			s.register <- p
 		}
 		p := newLocalPeer(t, s)
 		p.handshaked = false // one disconnected peer to check it won't be taken into attention
 		p.lastBlockIndex = 5
-		s.peers[p] = true
-		var expectedH uint32 = 8 // median peer
+		s.register <- p
+		require.Eventually(t, func() bool { return 7 == s.PeerCount() }, time.Second, time.Millisecond*10)
 
+		var expectedH uint32 = 8 // median peer
 		ss := &fakechain.FakeStateSync{InitFunc: func(h uint32) error {
 			if h != expectedH {
 				return fmt.Errorf("invalid height: expected %d, got %d", expectedH, h)


### PR DESCRIPTION
Register peers properly and set protocol configuration values before server start.
