### PR TITLE
rpc: do not return error if account is not found for `getunclaimed` call

### DIFF
--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -1397,7 +1397,7 @@ func (s *Server) getUnclaimed(ps request.Params) (interface{}, *response.Error) 
 
 	acc := s.chain.GetAccountState(u)
 	if acc == nil {
-		return nil, response.NewInternalServerError("unknown account", nil)
+		return &result.Unclaimed{}, nil
 	}
 	res, errRes := result.NewUnclaimed(acc, s.chain)
 	if errRes != nil {


### PR DESCRIPTION
Follow the reference behaviour, see https://github.com/neo-project/neo-modules/blob/master-2.x/RpcWallet/RpcWallet.cs#L251.