### PR TITLE
examples: rename Migrate methods to Update

### DIFF
--- a/examples/timer/timer.go
+++ b/examples/timer/timer.go
@@ -39,8 +39,8 @@ func _deploy(_ interface{}, isUpdate bool) {
 	runtime.Log("Timer set to " + i + " ticks.")
 }
 
-// Migrate migrates the contract.
-func Migrate(script []byte, manifest []byte) bool {
+// Update updates the contract.
+func Update(script []byte, manifest []byte) bool {
 	if !runtime.CheckWitness(owner) {
 		runtime.Log("Only owner is allowed to update the contract.")
 		return false


### PR DESCRIPTION
### Problem

See https://github.com/nspcc-dev/neofs-contract/issues/128.

### Solution

It's a remnant from N2, so this PR unifies style of all
update-related methods.
