### PR TITLE
compiler: check that safe methods exist

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -270,6 +270,11 @@ func CreateManifest(di *DebugInfo, o *Options) (*manifest.Manifest, error) {
 	if err != nil {
 		return m, fmt.Errorf("failed to convert debug info to manifest: %w", err)
 	}
+	for _, name := range o.SafeMethods {
+		if m.ABI.GetMethod(name, -1) == nil {
+			return m, fmt.Errorf("method %s is marked as safe but missing from manifest", name)
+		}
+	}
 	if !o.NoStandardCheck {
 		if err := standard.CheckABI(m, o.ContractSupportedStandards...); err != nil {
 			return m, err

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -125,6 +125,20 @@ func TestOnPayableChecks(t *testing.T) {
 	})
 }
 
+func TestSafeMethodWarnings(t *testing.T) {
+	src := `package payable
+		func Main() int { return 1 }`
+
+	_, di, err := compiler.CompileWithDebugInfo("eventTest", strings.NewReader(src))
+	require.NoError(t, err)
+
+	_, err = compiler.CreateManifest(di, &compiler.Options{SafeMethods: []string{"main"}})
+	require.NoError(t, err)
+
+	_, err = compiler.CreateManifest(di, &compiler.Options{SafeMethods: []string{"main", "mississippi"}})
+	require.Error(t, err)
+}
+
 func TestEventWarnings(t *testing.T) {
 	src := `package payable
 		import "github.com/nspcc-dev/neo-go/pkg/interop/runtime"


### PR DESCRIPTION
If a method is missing from the manifest, it is most likely a typo
or regression after refactoring. There is no "turn-off" flag
for this check because we can do this precisely.

Signed-off-by: Evgeniy Stratonikov <evgeniy@nspcc.ru>

There was a bug in https://github.com/nspcc-dev/neofs-contract/pull/135/commits/56d064710f1f12b03ce7523c52703834d25e1e94, I think we can prevent this in future.