### PR TITLE
rpc: use uint64 for timestamp boundaries in GetNEP17Transfers

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -165,18 +165,18 @@ additional parameter and then use paging to request the next batch of
 transfers.
 
 Example requesting 10 events for address NbTiM6h8r99kpRtb428XcsUk1TzKed2gTc
-within 0-1600094189 timestamps:
+within 0-1600094189000 timestamps:
 
 ```json
 { "jsonrpc": "2.0", "id": 5, "method": "getnep17transfers", "params":
-["NbTiM6h8r99kpRtb428XcsUk1TzKed2gTc", 0, 1600094189, 10] }
+["NbTiM6h8r99kpRtb428XcsUk1TzKed2gTc", 0, 1600094189000, 10] }
 ```
 
 Get the next 10 transfers for the same account within the same time frame:
 
 ```json
 { "jsonrpc": "2.0", "id": 5, "method": "getnep17transfers", "params":
-["NbTiM6h8r99kpRtb428XcsUk1TzKed2gTc", 0, 1600094189, 10, 1] }
+["NbTiM6h8r99kpRtb428XcsUk1TzKed2gTc", 0, 1600094189000, 10, 1] }
 ```
 
 #### Websocket server

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -283,7 +283,7 @@ func (c *Client) GetNEP17Balances(address util.Uint160) (*result.NEP17Balances, 
 // are supported since neo-go 0.77.0 and limit and page since neo-go 0.78.0.
 // These parameters are positional in the JSON-RPC call, you can't specify limit
 // and not specify start/stop for example.
-func (c *Client) GetNEP17Transfers(address string, start, stop *uint32, limit, page *int) (*result.NEP17Transfers, error) {
+func (c *Client) GetNEP17Transfers(address string, start, stop *uint64, limit, page *int) (*result.NEP17Transfers, error) {
 	params := request.NewRawParams(address)
 	if start != nil {
 		params.Values = append(params.Values, *start)

--- a/pkg/rpc/client/rpc_test.go
+++ b/pkg/rpc/client/rpc_test.go
@@ -1206,14 +1206,14 @@ var rpcClientErrorCases = map[string][]rpcClientErrorCase{
 		{
 			name: "getnep17transfers_invalid_params_error 2",
 			invoke: func(c *Client) (interface{}, error) {
-				var stop uint32
+				var stop uint64
 				return c.GetNEP17Transfers("Nhfg3TbpwogLvDGVvAvqyThbsHgoSUKwtn", nil, &stop, nil, nil)
 			},
 		},
 		{
 			name: "getnep17transfers_invalid_params_error 3",
 			invoke: func(c *Client) (interface{}, error) {
-				var start uint32
+				var start uint64
 				var limit int
 				return c.GetNEP17Transfers("Nhfg3TbpwogLvDGVvAvqyThbsHgoSUKwtn", &start, nil, &limit, nil)
 			},
@@ -1221,7 +1221,7 @@ var rpcClientErrorCases = map[string][]rpcClientErrorCase{
 		{
 			name: "getnep17transfers_invalid_params_error 4",
 			invoke: func(c *Client) (interface{}, error) {
-				var start, stop uint32
+				var start, stop uint64
 				var page int
 				return c.GetNEP17Transfers("Nhfg3TbpwogLvDGVvAvqyThbsHgoSUKwtn", &start, &stop, nil, &page)
 			},


### PR DESCRIPTION
Block's timestamp is in milliseconds, so it overflows uint32.

Thanks to @carpawell.