### PR TITLE
rpc: correctly handle RPC invocations with no arguments, fix #2219

### DIFF
--- a/pkg/rpc/request/txBuilder.go
+++ b/pkg/rpc/request/txBuilder.go
@@ -127,6 +127,9 @@ func CreateFunctionInvocationScript(contract util.Uint160, method string, params
 			emit.Opcodes(script.BinWriter, opcode.PACK)
 		}
 	}
+	if len(params) == 0 {
+		emit.Opcodes(script.BinWriter, opcode.NEWARRAY0)
+	}
 
 	emit.AppCallNoArgs(script.BinWriter, contract, method, callflag.All)
 	return script.Bytes(), nil

--- a/pkg/rpc/request/tx_builder_test.go
+++ b/pkg/rpc/request/tx_builder_test.go
@@ -22,10 +22,10 @@ func TestInvocationScriptCreationGood(t *testing.T) {
 		script string
 	}{{
 		ps:     Params{{Type: StringT, Value: "transfer"}},
-		script: "1f0c087472616e736665720c146f459162ceeb248b071ec157d9e4f6fd26fdbe5041627d5b52",
+		script: "c21f0c087472616e736665720c146f459162ceeb248b071ec157d9e4f6fd26fdbe5041627d5b52",
 	}, {
 		ps:     Params{{Type: NumberT, Value: 42}},
-		script: "1f0c0234320c146f459162ceeb248b071ec157d9e4f6fd26fdbe5041627d5b52",
+		script: "c21f0c0234320c146f459162ceeb248b071ec157d9e4f6fd26fdbe5041627d5b52",
 	}, {
 		ps:     Params{{Type: StringT, Value: "m"}, {Type: BooleanT, Value: true}},
 		script: "11db201f0c016d0c146f459162ceeb248b071ec157d9e4f6fd26fdbe5041627d5b52",


### PR DESCRIPTION
In N3 no arguments passed should be treated as empty arguments array not as
missing array of arguments, because the array must be present even for
functions that accept no parameters.

