### PR TITLE
vm: wait more for a test prog execution ending

### DIFF
--- a/pkg/vm/cli/cli_test.go
+++ b/pkg/vm/cli/cli_test.go
@@ -88,7 +88,7 @@ func (e *executor) runProg(t *testing.T, commands ...string) {
 	}()
 	select {
 	case <-e.ch:
-	case <-time.After(2 * time.Second):
+	case <-time.After(4 * time.Second):
 		require.Fail(t, "command took too long time")
 	}
 }


### PR DESCRIPTION
### Problem

Tests failure with the following error:
```
=== RUN   TestLoad/loadgo,_check_calling_flags
    cli_test.go:92: 
        	Error Trace:	cli_test.go:92
        	            				cli_test.go:229
        	Error:      	command took too long time
        	Test:       	TestLoad/loadgo,_check_calling_flags
```

### Solution

Wait more for the test ending.
