### PR TITLE
core: handle empty MPT batch properly

### DIFF
--- a/pkg/core/mpt/batch.go
+++ b/pkg/core/mpt/batch.go
@@ -43,6 +43,9 @@ func (b *Batch) Add(key []byte, value []byte) {
 // and won't strip the resulting branch node.
 // However it is used mostly after the block processing to update MPT and error is not expected.
 func (t *Trie) PutBatch(b Batch) (int, error) {
+	if len(b.kv) == 0 {
+		return 0, nil
+	}
 	r, n, err := t.putBatch(b.kv)
 	t.root = r
 	return n, err

--- a/pkg/core/mpt/batch_test.go
+++ b/pkg/core/mpt/batch_test.go
@@ -329,6 +329,8 @@ func TestTrie_PutBatch(t *testing.T) {
 
 	ps = pairs{[2][]byte{{4}, nil}}
 	testPut(t, ps, tr1, tr2)
+
+	testPut(t, pairs{}, tr1, tr2)
 }
 
 var _ = printNode


### PR DESCRIPTION
It's OK to have it.
