### PR TITLE
*: allow to build NeoGo binaries on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 BRANCH = "master"
 REPONAME = "neo-go"
 NETMODE ?= "privnet"
-BINARY = "./bin/neo-go"
+GOOS ?= $(shell go env GOOS)
+EXTENSION=
+ifeq ($(GOOS),windows)
+  EXTENSION=".exe"
+endif
+BINARY=./bin/neo-go$(EXTENSION)
 DESTDIR = ""
 SYSCONFIGDIR = "/etc"
 BINDIR = "/usr/bin"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ make build
 
 The resulting binary is `bin/neo-go`.
 
+#### Building on Windows
+
+To build NeoGo on Windows platform we recommend you to install `make` from [MinGW
+package](https://osdn.net/projects/mingw/). Then you can build NeoGo with:
+
+```
+make build
+```
+
+The resulting binary is `bin/neo-go.exe`.
+
+We also recommend you to switch the Windows Firewall off for further NeoGo node run.
+
 ## Running a node
 
 A node needs to connect to some network, either local one (usually referred to

--- a/cli/input/input.go
+++ b/cli/input/input.go
@@ -25,11 +25,11 @@ type ReadWriter struct {
 func ReadLine(prompt string) (string, error) {
 	trm := Terminal
 	if trm == nil {
-		s, err := term.MakeRaw(syscall.Stdin)
+		s, err := term.MakeRaw(int(syscall.Stdin))
 		if err != nil {
 			panic(err)
 		}
-		defer func() { _ = term.Restore(syscall.Stdin, s) }()
+		defer func() { _ = term.Restore(int(syscall.Stdin), s) }()
 		trm = term.NewTerminal(ReadWriter{
 			Reader: os.Stdin,
 			Writer: os.Stdout,
@@ -50,11 +50,11 @@ func readLine(trm *term.Terminal, prompt string) (string, error) {
 func ReadPassword(prompt string) (string, error) {
 	trm := Terminal
 	if trm == nil {
-		s, err := term.MakeRaw(syscall.Stdin)
+		s, err := term.MakeRaw(int(syscall.Stdin))
 		if err != nil {
 			panic(err)
 		}
-		defer func() { _ = term.Restore(syscall.Stdin, s) }()
+		defer func() { _ = term.Restore(int(syscall.Stdin), s) }()
 		trm = term.NewTerminal(ReadWriter{os.Stdin, os.Stdout}, prompt)
 	}
 	return trm.ReadPassword(prompt)


### PR DESCRIPTION
Related to #2008.

This PR fixes compilation errors and allows to build NeoGo node with `GOOS=windows` and `GOARCH=amd64` envs. The resulting binary is runnable (tested `node` command on the current testnet/mainnet), but the most of the tests are failing, the issue needs additional investigation.

At least, we're able to build/run the node, and it works somehow.