### PR TITLE
Dont panic on stdin ioctl issues

### DIFF
--- a/cli/input/input.go
+++ b/cli/input/input.go
@@ -27,7 +27,7 @@ func ReadLine(prompt string) (string, error) {
 	if trm == nil {
 		s, err := term.MakeRaw(syscall.Stdin)
 		if err != nil {
-			panic(err)
+			return "", err
 		}
 		defer func() { _ = term.Restore(syscall.Stdin, s) }()
 		trm = term.NewTerminal(ReadWriter{
@@ -52,7 +52,7 @@ func ReadPassword(prompt string) (string, error) {
 	if trm == nil {
 		s, err := term.MakeRaw(syscall.Stdin)
 		if err != nil {
-			panic(err)
+			return "", err
 		}
 		defer func() { _ = term.Restore(syscall.Stdin, s) }()
 		trm = term.NewTerminal(ReadWriter{os.Stdin, os.Stdout}, prompt)

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -811,7 +811,7 @@ func getUnlockedAccount(wall *wallet.Wallet, addr util.Uint160) (*wallet.Account
 	rawPass, err := input.ReadPassword(
 		fmt.Sprintf("Enter account %s password > ", address.Uint160ToString(addr)))
 	if err != nil {
-		return nil, cli.NewExitError(err, 1)
+		return nil, cli.NewExitError(fmt.Errorf("Error reading password: %w", err), 1)
 	}
 	pass := strings.TrimRight(string(rawPass), "\n")
 	err = acc.Decrypt(pass, wall.Scrypt)

--- a/cli/wallet/validator.go
+++ b/cli/wallet/validator.go
@@ -205,7 +205,7 @@ func getDecryptedAccount(ctx *cli.Context, wall *wallet.Wallet, addr util.Uint16
 	}
 
 	if pass, err := input.ReadPassword("Password > "); err != nil {
-		fmt.Println("ERROR", pass, err)
+		fmt.Println("Error reading password", err)
 		return nil, err
 	} else if err := acc.Decrypt(pass, wall.Scrypt); err != nil {
 		return nil, err

--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -302,7 +302,7 @@ func convertWallet(ctx *cli.Context) error {
 	for _, acc := range wall.Accounts {
 		pass, err := input.ReadPassword(fmt.Sprintf("Enter passphrase for account %s (label '%s') > ", acc.Address, acc.Label))
 		if err != nil {
-			return cli.NewExitError(err, 1)
+			return cli.NewExitError(fmt.Errorf("Error reading password: %w", err), 1)
 		}
 		newAcc, err := acc.convert(pass, wall.Scrypt)
 		if err != nil {
@@ -372,7 +372,7 @@ loop:
 		if decrypt {
 			pass, err := input.ReadPassword("Enter password > ")
 			if err != nil {
-				return cli.NewExitError(err, 1)
+				return cli.NewExitError(fmt.Errorf("Error reading password: %w", err), 1)
 			}
 
 			pk, err := keys.NEP2Decrypt(wif, pass, wall.Scrypt)
@@ -567,7 +567,7 @@ func dumpWallet(ctx *cli.Context) error {
 	if ctx.Bool("decrypt") {
 		pass, err := input.ReadPassword("Enter wallet password > ")
 		if err != nil {
-			return cli.NewExitError(err, 1)
+			return cli.NewExitError(fmt.Errorf("Error reading password: %w", err), 1)
 		}
 		for i := range wall.Accounts {
 			// Just testing the decryption here.
@@ -656,11 +656,11 @@ func readAccountInfo() (string, string, error) {
 	rawName, _ := input.ReadLine("Enter the name of the account > ")
 	phrase, err := input.ReadPassword("Enter passphrase > ")
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("Error reading password: %w", err)
 	}
 	phraseCheck, err := input.ReadPassword("Confirm passphrase > ")
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("Error reading password: %w", err)
 	}
 
 	if phrase != phraseCheck {
@@ -692,7 +692,7 @@ func newAccountFromWIF(w io.Writer, wif string, scrypt keys.ScryptParams) (*wall
 	if len(wif) == 58 {
 		pass, err := input.ReadPassword("Enter password > ")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Error reading password: %w", err)
 		}
 
 		return wallet.NewAccountFromEncryptedWIF(wif, pass, scrypt)


### PR DESCRIPTION
Before:
```
$ echo qwe | ./bin/neo-go wallet export --wallet test.json --decrypt NNcXZaE2H2YCizC8FfDMvekMT8Ynirdvqg
panic: inappropriate ioctl for device

goroutine 1 [running]:
github.com/nspcc-dev/neo-go/cli/input.ReadPassword(0x1075746, 0x11, 0x0, 0x0, 0x0, 0x0)
        github.com/nspcc-dev/neo-go/cli/input/input.go:55 +0x2be
github.com/nspcc-dev/neo-go/cli/wallet.exportKeys(0xc0002e2420, 0xc0002a2b00, 0xc0002a2b60)
        github.com/nspcc-dev/neo-go/cli/wallet/wallet.go:373 +0x54a
github.com/urfave/cli.HandleAction(0xed2a20, 0x11d59b8, 0xc0002e2420, 0xc0002e2420, 0x0)
        github.com/urfave/cli@v1.22.5/app.go:524 +0x105
github.com/urfave/cli.Command.Run(0x106b35f, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0x107c985, 0x17, 0x1096870, ...)
        github.com/urfave/cli@v1.22.5/command.go:173 +0x579
github.com/urfave/cli.(*App).RunAsSubcommand(0xc0002b2380, 0xc0002e2160, 0x0, 0x0)
        github.com/urfave/cli@v1.22.5/app.go:405 +0x914
github.com/urfave/cli.Command.startApp(0x106bc41, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0x108ccdd, 0x24, 0x0, ...)
        github.com/urfave/cli@v1.22.5/command.go:372 +0x7ff
github.com/urfave/cli.Command.Run(0x106bc41, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0x108ccdd, 0x24, 0x0, ...)
        github.com/urfave/cli@v1.22.5/command.go:102 +0x9d4
github.com/urfave/cli.(*App).Run(0xc0002b21c0, 0xc00003a070, 0x7, 0x7, 0x0, 0x0)
        github.com/urfave/cli@v1.22.5/app.go:277 +0x808
main.main()
        command-line-arguments/main.go:19 +0x4e
```
After:
```
$ echo qwe | ./bin/neo-go wallet export --wallet test.json --decrypt NNcXZaE2H2YCizC8FfDMvekMT8Ynirdvqg
Error reading password: inappropriate ioctl for device
```