### PR TITLE
examples: adjust NEP17 and token-sale examples

### DIFF
--- a/examples/token-sale/token_sale.go
+++ b/examples/token-sale/token_sale.go
@@ -186,7 +186,9 @@ func Transfer(from, to interop.Hash160, amount int, _ interface{}) bool {
 	}
 	amountTo := getIntFromDB(ctx, to)
 	totalAmountTo := amountTo + amount
-	storage.Put(ctx, to, totalAmountTo)
+	if totalAmountTo != 0 {
+		storage.Put(ctx, to, totalAmountTo)
+	}
 	return true
 }
 

--- a/examples/token/nep17/nep17.go
+++ b/examples/token/nep17/nep17.go
@@ -64,7 +64,10 @@ func (t Token) Transfer(ctx storage.Context, from, to interop.Hash160, amount in
 
 	amountTo := getIntFromDB(ctx, to)
 	totalAmountTo := amountTo + amount
-	storage.Put(ctx, to, totalAmountTo)
+	if totalAmountTo != 0 {
+		storage.Put(ctx, to, totalAmountTo)
+	}
+
 	runtime.Notify("Transfer", from, to, amount)
 	if to != nil && management.GetContract(to) != nil {
 		contract.Call(to, "onNEP17Payment", contract.All, from, amount, data)


### PR DESCRIPTION
Do not store zero receiver balance in the contract storage.

Refs. https://github.com/nspcc-dev/nex-contracts/pull/4#discussion_r742114449.
