### PR TITLE
neotest: minor usability improvements

### DIFF
--- a/examples/nft-nd-nns/tests/nonnative_name_service_test.go
+++ b/examples/nft-nd-nns/tests/nonnative_name_service_test.go
@@ -20,10 +20,7 @@ func newNSClient(t *testing.T) *neotest.ContractInvoker {
 	c := neotest.CompileFile(t, e.CommitteeHash, "..", "../nns.yml")
 	e.DeployContract(t, c, nil)
 
-	h, err := e.Chain.GetContractScriptHash(1)
-	require.NoError(t, err)
-	require.Equal(t, c.Hash, h)
-	return e.CommitteeInvoker(h)
+	return e.CommitteeInvoker(c.Hash)
 }
 
 func TestNameService_Price(t *testing.T) {

--- a/pkg/neotest/account.go
+++ b/pkg/neotest/account.go
@@ -2,7 +2,8 @@ package neotest
 
 var _nonce uint32
 
-func nonce() uint32 {
+// Nonce returns unique number that can be used as nonce for new transactions.
+func Nonce() uint32 {
 	_nonce++
 	return _nonce
 }

--- a/pkg/neotest/basic.go
+++ b/pkg/neotest/basic.go
@@ -2,6 +2,7 @@ package neotest
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -142,6 +143,19 @@ func (e *Executor) CheckFault(t *testing.T, h util.Uint256, s string) {
 	require.Equal(t, vm.FaultState, aer[0].VMState)
 	require.True(t, strings.Contains(aer[0].FaultException, s),
 		"expected: %s, got: %s", s, aer[0].FaultException)
+}
+
+// CheckTxNotificationEvent checks that specified event was emitted at the specified position
+// during transaction script execution. Negative index corresponds to backwards enumeration.
+func (e *Executor) CheckTxNotificationEvent(t *testing.T, h util.Uint256, index int, expected state.NotificationEvent) {
+	aer, err := e.Chain.GetAppExecResults(h, trigger.Application)
+	require.NoError(t, err)
+	l := len(aer[0].Events)
+	if index < 0 {
+		index = l + index
+	}
+	require.True(t, 0 <= index && index < l, fmt.Errorf("notification index is out of range: want %d, len is %d", index, l))
+	require.Equal(t, expected, aer[0].Events[index])
 }
 
 // NewDeployTx returns new deployment tx for contract signed by committee.

--- a/pkg/neotest/basic.go
+++ b/pkg/neotest/basic.go
@@ -69,7 +69,7 @@ func (e *Executor) NewUnsignedTx(t *testing.T, hash util.Uint160, method string,
 
 	script := w.Bytes()
 	tx := transaction.New(script, 0)
-	tx.Nonce = nonce()
+	tx.Nonce = Nonce()
 	tx.ValidUntilBlock = e.Chain.BlockHeight() + 1
 	return tx
 }
@@ -157,7 +157,7 @@ func (e *Executor) NewDeployTx(t *testing.T, bc blockchainer.Blockchainer, c *Co
 	require.NoError(t, buf.Err)
 
 	tx := transaction.New(buf.Bytes(), 100*native.GASFactor)
-	tx.Nonce = nonce()
+	tx.Nonce = Nonce()
 	tx.ValidUntilBlock = bc.BlockHeight() + 1
 	tx.Signers = []transaction.Signer{{
 		Account: e.Committee.ScriptHash(),


### PR DESCRIPTION
* Export `nonce()` method for external usage.
* Check deployed contract hash against precalculated one.
* Add the ability to check notification events.