### PR TITLE
Makefile: use GOEXE to build on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,7 @@
 BRANCH = "master"
 REPONAME = "neo-go"
 NETMODE ?= "privnet"
-GOOS ?= $(shell go env GOOS)
-EXTENSION=
-ifeq ($(GOOS),windows)
-  EXTENSION=".exe"
-endif
-BINARY=./bin/neo-go$(EXTENSION)
+BINARY=./bin/neo-go$(shell go env GOEXE)
 DESTDIR = ""
 SYSCONFIGDIR = "/etc"
 BINDIR = "/usr/bin"


### PR DESCRIPTION
Turns out that there's already special goenv variable to build with proper extension.

It seems to be cleaner than https://github.com/nspcc-dev/neo-go/pull/2239.