### PR TITLE
Fix custom sender scopes in CreateTxFromScript

### DIFF
--- a/cli/contract_test.go
+++ b/cli/contract_test.go
@@ -466,9 +466,17 @@ func TestComlileAndInvokeFunction(t *testing.T) {
 		})
 
 		t.Run("with cosigner", func(t *testing.T) {
-			t.Run("cosigner is sender", func(t *testing.T) {
+			t.Run("cosigner is sender (none)", func(t *testing.T) {
 				e.In.WriteString("one\r")
-				e.Run(t, append(cmd, hVerify.StringLE(), "verify", "--", validatorAddr+":Global")...)
+				e.RunWithError(t, append(cmd, h.StringLE(), "checkSenderWitness", "--", validatorAddr+":None")...)
+			})
+			t.Run("cosigner is sender (customcontract)", func(t *testing.T) {
+				e.In.WriteString("one\r")
+				e.Run(t, append(cmd, h.StringLE(), "checkSenderWitness", "--", validatorAddr+":CustomContracts:"+h.StringLE())...)
+			})
+			t.Run("cosigner is sender (global)", func(t *testing.T) {
+				e.In.WriteString("one\r")
+				e.Run(t, append(cmd, h.StringLE(), "checkSenderWitness", "--", validatorAddr+":Global")...)
 			})
 
 			acc, err := wallet.NewAccount()

--- a/cli/testdata/deploy/main.go
+++ b/cli/testdata/deploy/main.go
@@ -40,6 +40,14 @@ func Fail() {
 	panic("as expected")
 }
 
+// CheckSenderWitness checks sender's witness.
+func CheckSenderWitness() {
+	tx := runtime.GetScriptContainer()
+	if !runtime.CheckWitness(tx.Sender) {
+		panic("not witnessed")
+	}
+}
+
 // Update updates contract with the new one.
 func Update(script, manifest []byte) {
 	ctx := storage.GetReadOnlyContext()

--- a/pkg/rpc/client/rpc.go
+++ b/pkg/rpc/client/rpc.go
@@ -714,7 +714,7 @@ func getSigners(sender *wallet.Account, cosigners []SignerAccount) ([]transactio
 	}
 	for _, c := range cosigners {
 		if c.Signer.Account == from {
-			s.Scopes = c.Signer.Scopes
+			s = c.Signer
 			continue
 		}
 		signers = append(signers, c.Signer)


### PR DESCRIPTION
Passing CustromContracts to CreateTxFromScript leads to witness failure.