### PR TITLE
services: fix Oracle response creation algorithm

### DIFF
--- a/cli/wallet/multisig.go
+++ b/cli/wallet/multisig.go
@@ -58,14 +58,14 @@ func signStoredTransaction(ctx *cli.Context) error {
 	}
 	if out := ctx.String("out"); out != "" {
 		if err := paramcontext.Save(c, out); err != nil {
-			return cli.NewExitError(err, 1)
+			return cli.NewExitError(fmt.Errorf("failed to dump resulting transaction: %w", err), 1)
 		}
 	}
 	if len(ctx.String(options.RPCEndpointFlag)) != 0 {
 		for i := range tx.Signers {
 			w, err := c.GetWitness(tx.Signers[i].Account)
 			if err != nil {
-				return cli.NewExitError(err, 1)
+				return cli.NewExitError(fmt.Errorf("failed to construct witness for signer #%d: %w", i, err), 1)
 			}
 			tx.Scripts = append(tx.Scripts, *w)
 		}
@@ -76,11 +76,11 @@ func signStoredTransaction(ctx *cli.Context) error {
 		var err error // `GetRPCClient` returns specialized type.
 		c, err := options.GetRPCClient(gctx, ctx)
 		if err != nil {
-			return cli.NewExitError(err, 1)
+			return cli.NewExitError(fmt.Errorf("failed to create RPC client: %w", err), 1)
 		}
 		res, err := c.SendRawTransaction(tx)
 		if err != nil {
-			return cli.NewExitError(err, 1)
+			return cli.NewExitError(fmt.Errorf("failed to submit transaction to RPC node: %w", err), 1)
 		}
 		fmt.Fprintln(ctx.App.Writer, res.StringLE())
 		return nil

--- a/pkg/core/oracle_test.go
+++ b/pkg/core/oracle_test.go
@@ -168,6 +168,25 @@ func TestOracle(t *testing.T) {
 	checkEmitTx := func(t *testing.T, ch chan *transaction.Transaction) {
 		require.Len(t, ch, 1)
 		tx := <-ch
+
+		// Response transaction has its hash being precalculated. Check that this hash
+		// matches the actual one.
+		cachedHash := tx.Hash()
+		cp := transaction.Transaction{
+			Version:         tx.Version,
+			Nonce:           tx.Nonce,
+			SystemFee:       tx.SystemFee,
+			NetworkFee:      tx.NetworkFee,
+			ValidUntilBlock: tx.ValidUntilBlock,
+			Script:          tx.Script,
+			Attributes:      tx.Attributes,
+			Signers:         tx.Signers,
+			Scripts:         tx.Scripts,
+			Trimmed:         tx.Trimmed,
+		}
+		actualHash := cp.Hash()
+		require.Equal(t, actualHash, cachedHash, "transaction hash was changed during ")
+
 		require.NoError(t, bc.verifyAndPoolTx(tx, bc.GetMemPool(), bc))
 	}
 


### PR DESCRIPTION
We shouldn't cache transaction hash if the transaction is incomplete.