### PR TITLE
compiler: allow to slice struct field

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -641,12 +641,12 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 		return nil
 
 	case *ast.SliceExpr:
-		if isCompoundSlice(c.typeOf(n.X.(*ast.Ident)).Underlying()) {
+		if isCompoundSlice(c.typeOf(n.X).Underlying()) {
 			c.prog.Err = errors.New("subslices are supported only for []byte")
 			return nil
 		}
-		name := n.X.(*ast.Ident).Name
-		c.emitLoadVar("", name)
+
+		ast.Walk(c, n.X)
 
 		if n.Low != nil {
 			ast.Walk(c, n.Low)

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -432,6 +432,16 @@ func TestSubsliceCompound(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestSubsliceFromStructField(t *testing.T) {
+	src := `package foo
+	type pair struct { key, value []byte }
+	func Main() []byte {
+		p := pair{ []byte{1}, []byte{4, 8, 15, 16, 23, 42} }
+		return p.value[2:4]
+	}`
+	eval(t, src, []byte{15, 16})
+}
+
 func TestRemove(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		src := `package foo


### PR DESCRIPTION
It makes no sense to restrict to identifiers.

From https://github.com/nspcc-dev/neofs-contract/issues/169#issuecomment-981832196 (the problem was not really in cast itself).

Signed-off-by: Evgeniy Stratonikov <evgeniy@nspcc.ru>