### PR TITLE
vm: put child invocation tree nodes into `call` element

### DIFF
--- a/pkg/vm/invocation_tree.go
+++ b/pkg/vm/invocation_tree.go
@@ -8,5 +8,5 @@ import (
 // you can see how contracts called each other.
 type InvocationTree struct {
 	Current util.Uint160      `json:"hash"`
-	Calls   []*InvocationTree `json:"calls,omitempty"`
+	Calls   []*InvocationTree `json:"call,omitempty"`
 }


### PR DESCRIPTION
As neo-project/neo-modules#657 currently does.
