### PR TITLE
interop/storage: fix outdated RemovePrefix comment

### DIFF
--- a/pkg/interop/storage/storage.go
+++ b/pkg/interop/storage/storage.go
@@ -25,7 +25,7 @@ const (
 	None FindFlags = 0
 	// KeysOnly is used for iterating over keys.
 	KeysOnly FindFlags = 1 << 0
-	// RemovePrefix is used for stripping 1-byte prefix from keys.
+	// RemovePrefix is used for stripping prefix (passed to Find) from keys.
 	RemovePrefix FindFlags = 1 << 1
 	// ValuesOnly is used for iterating over values.
 	ValuesOnly FindFlags = 1 << 2


### PR DESCRIPTION
ffaae0f7736119d9c7a60436c983b2566869c887 changed the behavior long time ago,
we're actually stripping whole requested prefix.