### PR TITLE
core: don't sort witnesses prior to check, fix #2301

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2510,7 +2510,6 @@ func (bc *Blockchain) verifyTxWitnesses(t *transaction.Transaction, block *block
 		return errors.Errorf("expected len(hashes) == len(witnesses). got: %d != %d", len(hashes), len(witnesses))
 	}
 	sort.Slice(hashes, func(i, j int) bool { return hashes[i].Less(hashes[j]) })
-	sort.Slice(witnesses, func(i, j int) bool { return witnesses[i].ScriptHash().Less(witnesses[j].ScriptHash()) })
 	interopCtx := bc.newInteropContext(trigger.Verification, bc.dao, block, t)
 	for i := 0; i < len(hashes); i++ {
 		err := bc.verifyHashAgainstScript(hashes[i], &witnesses[i], t.VerificationHash(), interopCtx, false)


### PR DESCRIPTION
8537700b7b006ee317ce3a25c4ce4831d18eee48 was a bit wrong in its witness
treatment, contract-based verification scripts have zero length and this
script has a hash different from the target script hash to check, so sorting
can break witnesses in some cases.
