### PR TITLE
util: reverse the order of uint160 comparsion

### DIFF
--- a/pkg/util/uint160.go
+++ b/pkg/util/uint160.go
@@ -107,7 +107,7 @@ func (u Uint160) Equals(other Uint160) bool {
 // Less returns true if this value is less than given Uint160 value. It's
 // primarily intended to be used for sorting purposes.
 func (u Uint160) Less(other Uint160) bool {
-	for k := range u {
+	for k := Uint160Size - 1; k >= 0; k-- {
 		if u[k] == other[k] {
 			continue
 		}


### PR DESCRIPTION
A follow-up to #2302, sort hashes using reverse order. Fixes
f9c68613f41ca85ddb01ec757153c0d86018d2324f6ff85a4afc708bb598b722 validation.

Hi, neo-project/neo#938.