### PR TITLE
Store applog with tx

### DIFF
--- a/pkg/core/block/block.go
+++ b/pkg/core/block/block.go
@@ -62,11 +62,11 @@ func (b *Block) RebuildMerkleRoot() {
 	b.MerkleRoot = b.ComputeMerkleRoot()
 }
 
-// NewBlockFromTrimmedBytes returns a new block from trimmed data.
+// NewTrimmedFromReader returns a new block from trimmed data.
 // This is commonly used to create a block from stored data.
 // Blocks created from trimmed data will have their Trimmed field
 // set to true.
-func NewBlockFromTrimmedBytes(stateRootEnabled bool, b []byte) (*Block, error) {
+func NewTrimmedFromReader(stateRootEnabled bool, br *io.BinReader) (*Block, error) {
 	block := &Block{
 		Header: Header{
 			StateRootEnabled: stateRootEnabled,
@@ -74,7 +74,6 @@ func NewBlockFromTrimmedBytes(stateRootEnabled bool, b []byte) (*Block, error) {
 		Trimmed: true,
 	}
 
-	br := io.NewBinReaderFromBuf(b)
 	block.Header.DecodeBinary(br)
 	lenHashes := br.ReadVarUint()
 	if lenHashes > MaxTransactionsPerBlock {

--- a/pkg/core/block/block_test.go
+++ b/pkg/core/block/block_test.go
@@ -58,7 +58,8 @@ func TestTrimmedBlock(t *testing.T) {
 	b, err := block.Trim()
 	require.NoError(t, err)
 
-	trimmedBlock, err := NewBlockFromTrimmedBytes(false, b)
+	r := io.NewBinReaderFromBuf(b)
+	trimmedBlock, err := NewTrimmedFromReader(false, r)
 	require.NoError(t, err)
 
 	assert.True(t, trimmedBlock.Trimmed)

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -126,7 +126,7 @@ func TestAddBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, block := range blocks {
-		key := storage.AppendPrefix(storage.DataBlock, block.Hash().BytesBE())
+		key := storage.AppendPrefix(storage.DataExecutable, block.Hash().BytesBE())
 		_, err := bc.dao.Store.Get(key)
 		require.NoErrorf(t, err, "block %s not persisted", block.Hash())
 	}
@@ -805,7 +805,7 @@ func TestVerifyTx(t *testing.T) {
 							},
 						},
 					}
-					require.NoError(t, bc.dao.StoreAsTransaction(conflicting, bc.blockHeight, nil))
+					require.NoError(t, bc.dao.StoreAsTransaction(conflicting, bc.blockHeight, nil, nil))
 					require.True(t, errors.Is(bc.VerifyTx(tx), ErrHasConflicts))
 				})
 				t.Run("attribute on-chain conflict", func(t *testing.T) {

--- a/pkg/core/native_ledger_test.go
+++ b/pkg/core/native_ledger_test.go
@@ -18,7 +18,7 @@ func TestLedgerGetTransactionHeight(t *testing.T) {
 	for i := 0; i < 13; i++ {
 		require.NoError(t, chain.AddBlock(chain.newBlock()))
 	}
-	require.NoError(t, chain.dao.StoreAsTransaction(tx, 13, nil))
+	require.NoError(t, chain.dao.StoreAsTransaction(tx, 13, nil, nil))
 	t.Run("good", func(t *testing.T) {
 		res, err := invokeContractMethod(chain, 100000000, ledger, "getTransactionHeight", tx.Hash().BytesBE())
 		require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestLedgerGetTransaction(t *testing.T) {
 	ledger := chain.contracts.ByName(nativenames.Ledger).Metadata().Hash
 
 	t.Run("success", func(t *testing.T) {
-		require.NoError(t, chain.dao.StoreAsTransaction(tx, 0, nil))
+		require.NoError(t, chain.dao.StoreAsTransaction(tx, 0, nil, nil))
 
 		res, err := invokeContractMethod(chain, 100000000, ledger, "getTransaction", tx.Hash().BytesBE())
 		require.NoError(t, err)
@@ -63,13 +63,13 @@ func TestLedgerGetTransaction(t *testing.T) {
 	})
 
 	t.Run("isn't traceable", func(t *testing.T) {
-		require.NoError(t, chain.dao.StoreAsTransaction(tx, 2, nil)) // block 1 is added above
+		require.NoError(t, chain.dao.StoreAsTransaction(tx, 2, nil, nil)) // block 1 is added above
 		res, err := invokeContractMethod(chain, 100000000, ledger, "getTransaction", tx.Hash().BytesBE())
 		require.NoError(t, err)
 		checkResult(t, res, stackitem.Null{})
 	})
 	t.Run("bad hash", func(t *testing.T) {
-		require.NoError(t, chain.dao.StoreAsTransaction(tx, 0, nil))
+		require.NoError(t, chain.dao.StoreAsTransaction(tx, 0, nil, nil))
 		res, err := invokeContractMethod(chain, 100000000, ledger, "getTransaction", tx.Hash().BytesLE())
 		require.NoError(t, err)
 		checkResult(t, res, stackitem.Null{})
@@ -120,7 +120,7 @@ func TestLedgerGetTransactionFromBlock(t *testing.T) {
 	})
 	t.Run("isn't traceable", func(t *testing.T) {
 		b.Index = chain.BlockHeight() + 1
-		require.NoError(t, chain.dao.StoreAsBlock(b, nil))
+		require.NoError(t, chain.dao.StoreAsBlock(b, nil, nil, nil))
 		res, err := invokeContractMethod(chain, 100000000, ledger, "getTransactionFromBlock", bhash.BytesBE(), int64(0))
 		require.NoError(t, err)
 		checkResult(t, res, stackitem.Null{})
@@ -166,7 +166,7 @@ func TestLedgerGetBlock(t *testing.T) {
 	})
 	t.Run("isn't traceable", func(t *testing.T) {
 		b.Index = chain.BlockHeight() + 1
-		require.NoError(t, chain.dao.StoreAsBlock(b, nil))
+		require.NoError(t, chain.dao.StoreAsBlock(b, nil, nil, nil))
 		res, err := invokeContractMethod(chain, 100000000, ledger, "getBlock", bhash.BytesBE())
 		require.NoError(t, err)
 		checkResult(t, res, stackitem.Null{})

--- a/pkg/core/statesync/module.go
+++ b/pkg/core/statesync/module.go
@@ -315,7 +315,7 @@ func (s *Module) AddBlock(block *block.Block) error {
 	}
 	cache := s.dao.GetWrapped()
 	writeBuf := io.NewBufBinWriter()
-	if err := cache.StoreAsBlock(block, writeBuf); err != nil {
+	if err := cache.StoreAsBlock(block, nil, nil, writeBuf); err != nil {
 		return err
 	}
 	writeBuf.Reset()
@@ -326,7 +326,7 @@ func (s *Module) AddBlock(block *block.Block) error {
 	}
 
 	for _, tx := range block.Transactions {
-		if err := cache.StoreAsTransaction(tx, block.Index, writeBuf); err != nil {
+		if err := cache.StoreAsTransaction(tx, block.Index, nil, writeBuf); err != nil {
 			return err
 		}
 		writeBuf.Reset()

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -8,13 +8,11 @@ import (
 
 // KeyPrefix constants.
 const (
-	DataBlock       KeyPrefix = 0x01
-	DataTransaction KeyPrefix = 0x02
-	DataMPT         KeyPrefix = 0x03
-	STAccount       KeyPrefix = 0x40
-	STNotification  KeyPrefix = 0x4d
-	STContractID    KeyPrefix = 0x51
-	STStorage       KeyPrefix = 0x70
+	DataExecutable KeyPrefix = 0x01
+	DataMPT        KeyPrefix = 0x03
+	STAccount      KeyPrefix = 0x40
+	STContractID   KeyPrefix = 0x51
+	STStorage      KeyPrefix = 0x70
 	// STTempStorage is used to store contract storage items during state sync process
 	// in order not to mess up the previous state which has its own items stored by
 	// STStorage prefix. Once state exchange process is completed, all items with
@@ -31,6 +29,12 @@ const (
 	SYSStateJumpStage              KeyPrefix = 0xc4
 	SYSCleanStorage                KeyPrefix = 0xc5
 	SYSVersion                     KeyPrefix = 0xf0
+)
+
+// Executable subtypes.
+const (
+	ExecBlock       byte = 1
+	ExecTransaction byte = 2
 )
 
 const (

--- a/pkg/core/storage/store_test.go
+++ b/pkg/core/storage/store_test.go
@@ -8,8 +8,7 @@ import (
 
 var (
 	prefixes = []KeyPrefix{
-		DataBlock,
-		DataTransaction,
+		DataExecutable,
 		STAccount,
 		STStorage,
 		IXHeaderHashList,
@@ -20,7 +19,6 @@ var (
 
 	expected = []uint8{
 		0x01,
-		0x02,
 		0x40,
 		0x70,
 		0x80,


### PR DESCRIPTION
### Problem

We're a bit slow.

### Solution

Increase da TPS.

It will interfere with #2299, so we can wait for a while before merging it, maybe improve some naming or things along the way (for example, RPC server can now technically get both tx and aer for `getrawtransaction` request in a single query, but I'm not sure it's worth doing this, there are no other similar simultaneous uses).