### PR TITLE
vm: cut trailing spaces in `PrintOps`

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -145,7 +145,7 @@ func (v *VM) PrintOps(out io.Writer) {
 		out = os.Stdout
 	}
 	w := tabwriter.NewWriter(out, 0, 0, 4, ' ', 0)
-	fmt.Fprintln(w, "INDEX\tOPCODE\tPARAMETER\t")
+	fmt.Fprintln(w, "INDEX\tOPCODE\tPARAMETER")
 	realctx := v.Context()
 	ctx := realctx.Copy()
 	ctx.ip = 0
@@ -154,10 +154,10 @@ func (v *VM) PrintOps(out io.Writer) {
 		cursor := ""
 		instr, parameter, err := ctx.Next()
 		if ctx.ip == realctx.ip {
-			cursor = "<<"
+			cursor = "\t<<"
 		}
 		if err != nil {
-			fmt.Fprintf(w, "%d\t%s\tERROR: %s\t%s\n", ctx.ip, instr, err, cursor)
+			fmt.Fprintf(w, "%d\t%s\tERROR: %s%s\n", ctx.ip, instr, err, cursor)
 			break
 		}
 		var desc = ""
@@ -203,7 +203,7 @@ func (v *VM) PrintOps(out io.Writer) {
 			}
 		}
 
-		fmt.Fprintf(w, "%d\t%s\t%s\t%s\n", ctx.ip, instr, desc, cursor)
+		fmt.Fprintf(w, "%d\t%s\t%s%s\n", ctx.ip, instr, desc, cursor)
 		if ctx.nextip >= len(ctx.prog) {
 			break
 		}

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"math/big"
 	"math/rand"
+	"strings"
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/internal/random"
@@ -1179,6 +1180,25 @@ func TestPICKITEM(t *testing.T) {
 		m := stackitem.NewMap()
 		t.Run("Map, missing key", getTestFuncForVM(tryProg, "Key not found in Map", m, 1))
 	})
+}
+
+func TestVMPrintOps(t *testing.T) {
+	w := io.NewBufBinWriter()
+	emit.Bytes(w.BinWriter, make([]byte, 1000))
+	emit.Opcodes(w.BinWriter, opcode.PUSH0)
+	emit.Bytes(w.BinWriter, make([]byte, 8))
+
+	buf := bytes.NewBuffer(nil)
+	v := New()
+	v.Load(w.Bytes())
+	v.PrintOps(buf)
+
+	ss := strings.Split(buf.String(), "\n")
+	require.Equal(t, 5, len(ss)) // header + 3 opcodes + trailing newline
+	require.True(t, len(ss[0]) < 1000)
+	require.True(t, len(ss[1]) > 1000)
+	require.True(t, len(ss[2]) < 1000)
+	require.True(t, len(ss[3]) < 1000)
 }
 
 func TestPICKITEMDupArray(t *testing.T) {


### PR DESCRIPTION
When there is a single big instruction (like PUSHDATA4) in script,
all other instructions are padded to the right with spaces.
This makes it hard to view script in terminal, because long lines
are usually wrapped at the screen boundary and printed as multiple lines.

The culprit is our `cursor` field which is printed in the last column
and causes all previous fields to have the same length for every
instruction. One way to fix this is to omit cursor field if it is empty.

Signed-off-by: Evgeniy Stratonikov <evgeniy@nspcc.ru>