### PR TITLE
storage: allow to Seek from some point and backwards

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2106,7 +2106,7 @@ func (bc *Blockchain) PoolTxWithData(t *transaction.Transaction, data interface{
 	return bc.verifyAndPoolTx(t, mp, feer, data)
 }
 
-//GetStandByValidators returns validators from the configuration.
+// GetStandByValidators returns validators from the configuration.
 func (bc *Blockchain) GetStandByValidators() keys.PublicKeys {
 	return bc.sbCommittee[:bc.config.ValidatorsCount].Copy()
 }

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -486,7 +486,7 @@ func (bc *Blockchain) removeOldStorageItems() {
 
 	b := bc.dao.Store.Batch()
 	prefix := statesync.TemporaryPrefix(bc.dao.Version.StoragePrefix)
-	bc.dao.Store.Seek([]byte{byte(prefix)}, func(k, _ []byte) {
+	bc.dao.Store.Seek(storage.SeekRange{Prefix: []byte{byte(prefix)}}, func(k, _ []byte) {
 		// #1468, but don't need to copy here, because it is done by Store.
 		b.Delete(k)
 	})

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -1051,7 +1051,7 @@ func TestVerifyTx(t *testing.T) {
 			netFee, sizeDelta := fee.Calculate(bc.GetBaseExecFee(), testchain.MultisigVerificationScript())
 			tx.NetworkFee = netFee + // multisig witness verification price
 				int64(size)*bc.FeePerByte() + // fee for unsigned size
-				int64(sizeDelta)*bc.FeePerByte() + //fee for multisig size
+				int64(sizeDelta)*bc.FeePerByte() + // fee for multisig size
 				66*bc.FeePerByte() + // fee for Notary signature size (66 bytes for Invocation script and 0 bytes for Verification script)
 				2*bc.FeePerByte() + // fee for the length of each script in Notary witness (they are nil, so we did not take them into account during `size` calculation)
 				transaction.NotaryServiceFeePerKey + // fee for Notary attribute

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -1769,7 +1769,7 @@ func TestBlockchain_InitWithIncompleteStateJump(t *testing.T) {
 	if bcSpout.dao.Version.StoragePrefix == tempPrefix {
 		tempPrefix = storage.STStorage
 	}
-	bcSpout.dao.Store.Seek(bcSpout.dao.Version.StoragePrefix.Bytes(), func(k, v []byte) {
+	bcSpout.dao.Store.Seek(storage.SeekRange{Prefix: bcSpout.dao.Version.StoragePrefix.Bytes()}, func(k, v []byte) {
 		key := slice.Copy(k)
 		key[0] = byte(tempPrefix)
 		value := slice.Copy(v)

--- a/pkg/core/helper_test.go
+++ b/pkg/core/helper_test.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -66,6 +67,27 @@ func newTestChainWithCustomCfgAndStore(t testing.TB, st storage.Store, f func(*c
 	go chain.Run()
 	t.Cleanup(chain.Close)
 	return chain
+}
+
+func newLevelDBForTesting(t testing.TB) storage.Store {
+	ldbDir := t.TempDir()
+	dbConfig := storage.DBConfiguration{
+		Type: "leveldb",
+		LevelDBOptions: storage.LevelDBOptions{
+			DataDirectoryPath: ldbDir,
+		},
+	}
+	newLevelStore, err := storage.NewLevelDBStore(dbConfig.LevelDBOptions)
+	require.Nil(t, err, "NewLevelDBStore error")
+	return newLevelStore
+}
+
+func newBoltStoreForTesting(t testing.TB) storage.Store {
+	d := t.TempDir()
+	testFileName := filepath.Join(d, "test_bolt_db")
+	boltDBStore, err := storage.NewBoltDBStore(storage.BoltDBOptions{FilePath: testFileName})
+	require.NoError(t, err)
+	return boltDBStore
 }
 
 func initTestChain(t testing.TB, st storage.Store, f func(*config.Config)) *Blockchain {

--- a/pkg/core/interop_system.go
+++ b/pkg/core/interop_system.go
@@ -190,7 +190,7 @@ func storageFind(ic *interop.Context) error {
 	// Items in seekres should be sorted by key, but GetStorageItemsWithPrefix returns
 	// sorted items, so no need to sort them one more time.
 	ctx, cancel := context.WithCancel(context.Background())
-	seekres := ic.DAO.SeekAsync(ctx, stc.ID, prefix)
+	seekres := ic.DAO.SeekAsync(ctx, stc.ID, storage.SeekRange{Prefix: prefix})
 	item := istorage.NewIterator(seekres, prefix, opts)
 	ic.VM.Estack().PushItem(stackitem.NewInterop(item))
 	ic.RegisterCancelFunc(cancel)

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -503,7 +503,7 @@ func (m *Management) InitializeCache(d dao.DAO) error {
 	defer m.mtx.Unlock()
 
 	var initErr error
-	d.Seek(m.ID, []byte{prefixContract}, func(_, v []byte) {
+	d.Seek(m.ID, storage.SeekRange{Prefix: []byte{prefixContract}}, func(_, v []byte) {
 		var cs = new(state.Contract)
 		initErr = stackitem.DeserializeConvertible(v, cs)
 		if initErr != nil {

--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -386,7 +386,7 @@ func (n *NEO) PostPersist(ic *interop.Context) error {
 func (n *NEO) getGASPerVote(d dao.DAO, key []byte, index ...uint32) []big.Int {
 	var max = make([]uint32, len(index))
 	var reward = make([]big.Int, len(index))
-	d.Seek(n.ID, key, func(k, v []byte) {
+	d.Seek(n.ID, storage.SeekRange{Prefix: key}, func(k, v []byte) {
 		if len(k) == 4 {
 			num := binary.BigEndian.Uint32(k)
 			for i, ind := range index {
@@ -591,7 +591,7 @@ func (n *NEO) dropCandidateIfZero(d dao.DAO, pub *keys.PublicKey, c *candidate) 
 
 	var toRemove []string
 	voterKey := makeVoterKey(pub.Bytes())
-	d.Seek(n.ID, voterKey, func(k, v []byte) {
+	d.Seek(n.ID, storage.SeekRange{Prefix: voterKey}, func(k, v []byte) {
 		toRemove = append(toRemove, string(k))
 	})
 	for i := range toRemove {

--- a/pkg/core/native_neo_test.go
+++ b/pkg/core/native_neo_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 	"sort"
@@ -10,6 +11,7 @@ import (
 	"github.com/nspcc-dev/neo-go/internal/testchain"
 	"github.com/nspcc-dev/neo-go/pkg/config/netmode"
 	"github.com/nspcc-dev/neo-go/pkg/core/native"
+	"github.com/nspcc-dev/neo-go/pkg/core/storage"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/io"
@@ -31,7 +33,7 @@ func setSigner(tx *transaction.Transaction, h util.Uint160) {
 	}}
 }
 
-func checkTxHalt(t *testing.T, bc *Blockchain, h util.Uint256) {
+func checkTxHalt(t testing.TB, bc *Blockchain, h util.Uint256) {
 	aer, err := bc.GetAppExecResults(h, trigger.Application)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(aer))
@@ -475,4 +477,120 @@ func newAccountWithGAS(t *testing.T, bc *Blockchain) *wallet.Account {
 	require.NoError(t, err)
 	transferTokenFromMultisigAccount(t, bc, acc.PrivateKey().GetScriptHash(), bc.contracts.GAS.Hash, 1000_00000000)
 	return acc
+}
+
+func BenchmarkNEO_GetGASPerVote(t *testing.B) {
+	var stores = map[string]func(testing.TB) storage.Store{
+		"MemPS": func(t testing.TB) storage.Store {
+			return storage.NewMemoryStore()
+		},
+		"BoltPS":  newBoltStoreForTesting,
+		"LevelPS": newLevelDBForTesting,
+	}
+	for psName, newPS := range stores {
+		for nRewardRecords := 10; nRewardRecords <= 1000; nRewardRecords *= 10 {
+			for rewardDistance := 1; rewardDistance <= 1000; rewardDistance *= 10 {
+				t.Run(fmt.Sprintf("%s_%dRewardRecords_%dRewardDistance", psName, nRewardRecords, rewardDistance), func(t *testing.B) {
+					ps := newPS(t)
+					t.Cleanup(func() { ps.Close() })
+					benchmarkGasPerVote(t, ps, nRewardRecords, rewardDistance)
+				})
+			}
+		}
+	}
+}
+
+func benchmarkGasPerVote(t *testing.B, ps storage.Store, nRewardRecords int, rewardDistance int) {
+	bc := newTestChainWithCustomCfgAndStore(t, ps, nil)
+
+	neo := bc.contracts.NEO
+	tx := transaction.New([]byte{byte(opcode.PUSH1)}, 0)
+	ic := bc.newInteropContext(trigger.Application, bc.dao, nil, tx)
+	ic.SpawnVM()
+	ic.Block = bc.newBlock(tx)
+
+	advanceChain := func(t *testing.B, count int) {
+		for i := 0; i < count; i++ {
+			require.NoError(t, bc.AddBlock(bc.newBlock()))
+			ic.Block.Index++
+		}
+	}
+
+	// Vote for new committee.
+	sz := testchain.CommitteeSize()
+	accs := make([]*wallet.Account, sz)
+	candidates := make(keys.PublicKeys, sz)
+	txs := make([]*transaction.Transaction, 0, len(accs))
+	for i := 0; i < sz; i++ {
+		priv, err := keys.NewPrivateKey()
+		require.NoError(t, err)
+		candidates[i] = priv.PublicKey()
+		accs[i], err = wallet.NewAccount()
+		require.NoError(t, err)
+		require.NoError(t, neo.RegisterCandidateInternal(ic, candidates[i]))
+
+		to := accs[i].Contract.ScriptHash()
+		w := io.NewBufBinWriter()
+		emit.AppCall(w.BinWriter, bc.contracts.NEO.Hash, "transfer", callflag.All,
+			neoOwner.BytesBE(), to.BytesBE(),
+			big.NewInt(int64(sz-i)*1000000).Int64(), nil)
+		emit.Opcodes(w.BinWriter, opcode.ASSERT)
+		emit.AppCall(w.BinWriter, bc.contracts.GAS.Hash, "transfer", callflag.All,
+			neoOwner.BytesBE(), to.BytesBE(),
+			int64(1_000_000_000), nil)
+		emit.Opcodes(w.BinWriter, opcode.ASSERT)
+		require.NoError(t, w.Err)
+		tx := transaction.New(w.Bytes(), 1000_000_000)
+		tx.ValidUntilBlock = bc.BlockHeight() + 1
+		setSigner(tx, testchain.MultisigScriptHash())
+		require.NoError(t, testchain.SignTx(bc, tx))
+		txs = append(txs, tx)
+	}
+	require.NoError(t, bc.AddBlock(bc.newBlock(txs...)))
+	for _, tx := range txs {
+		checkTxHalt(t, bc, tx.Hash())
+	}
+	for i := 0; i < sz; i++ {
+		priv := accs[i].PrivateKey()
+		h := priv.GetScriptHash()
+		setSigner(tx, h)
+		ic.VM.Load(priv.PublicKey().GetVerificationScript())
+		require.NoError(t, neo.VoteInternal(ic, h, candidates[i]))
+	}
+	_, err := ic.DAO.Persist()
+	require.NoError(t, err)
+
+	// Collect set of nRewardRecords reward records for each voter.
+	advanceChain(t, nRewardRecords*testchain.CommitteeSize())
+
+	// Transfer some more NEO to first voter to update his balance height.
+	to := accs[0].Contract.ScriptHash()
+	w := io.NewBufBinWriter()
+	emit.AppCall(w.BinWriter, bc.contracts.NEO.Hash, "transfer", callflag.All,
+		neoOwner.BytesBE(), to.BytesBE(), int64(1), nil)
+	emit.Opcodes(w.BinWriter, opcode.ASSERT)
+	require.NoError(t, w.Err)
+	tx = transaction.New(w.Bytes(), 1000_000_000)
+	tx.ValidUntilBlock = bc.BlockHeight() + 1
+	setSigner(tx, testchain.MultisigScriptHash())
+	require.NoError(t, testchain.SignTx(bc, tx))
+	require.NoError(t, bc.AddBlock(bc.newBlock(tx)))
+
+	aer, err := bc.GetAppExecResults(tx.Hash(), trigger.Application)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(aer))
+	require.Equal(t, vm.HaltState, aer[0].VMState, aer[0].FaultException)
+
+	// Advance chain one more time to avoid same start/end rewarding bounds.
+	advanceChain(t, rewardDistance)
+	end := bc.BlockHeight()
+
+	t.ResetTimer()
+	t.ReportAllocs()
+	t.StartTimer()
+	for i := 0; i < t.N; i++ {
+		_, err := neo.CalculateBonus(ic.DAO, to, end)
+		require.NoError(t, err)
+	}
+	t.StopTimer()
 }

--- a/pkg/core/stateroot/module.go
+++ b/pkg/core/stateroot/module.go
@@ -127,7 +127,7 @@ func (s *Module) CleanStorage() error {
 		return fmt.Errorf("can't clean MPT data for non-genesis block: expected local stateroot height 0, got %d", s.localHeight.Load())
 	}
 	b := s.Store.Batch()
-	s.Store.Seek([]byte{byte(storage.DataMPT)}, func(k, _ []byte) {
+	s.Store.Seek(storage.SeekRange{Prefix: []byte{byte(storage.DataMPT)}}, func(k, _ []byte) {
 		// #1468, but don't need to copy here, because it is done by Store.
 		b.Delete(k)
 	})

--- a/pkg/core/statesync/module_test.go
+++ b/pkg/core/statesync/module_test.go
@@ -32,7 +32,7 @@ func TestModule_PR2019_discussion_r689629704(t *testing.T) {
 		nodes         = make(map[util.Uint256][]byte)
 		expectedItems []storage.KeyValue
 	)
-	expectedStorage.Seek(storage.DataMPT.Bytes(), func(k, v []byte) {
+	expectedStorage.Seek(storage.SeekRange{Prefix: storage.DataMPT.Bytes()}, func(k, v []byte) {
 		key := slice.Copy(k)
 		value := slice.Copy(v)
 		expectedItems = append(expectedItems, storage.KeyValue{
@@ -95,7 +95,7 @@ func TestModule_PR2019_discussion_r689629704(t *testing.T) {
 
 	// Compare resulting storage items and refcounts.
 	var actualItems []storage.KeyValue
-	expectedStorage.Seek(storage.DataMPT.Bytes(), func(k, v []byte) {
+	expectedStorage.Seek(storage.SeekRange{Prefix: storage.DataMPT.Bytes()}, func(k, v []byte) {
 		key := slice.Copy(k)
 		value := slice.Copy(v)
 		actualItems = append(actualItems, storage.KeyValue{

--- a/pkg/core/statesync_test.go
+++ b/pkg/core/statesync_test.go
@@ -424,7 +424,7 @@ func TestStateSyncModule_RestoreBasicChain(t *testing.T) {
 	// compare storage states
 	fetchStorage := func(bc *Blockchain) []storage.KeyValue {
 		var kv []storage.KeyValue
-		bc.dao.Store.Seek(bc.dao.Version.StoragePrefix.Bytes(), func(k, v []byte) {
+		bc.dao.Store.Seek(storage.SeekRange{Prefix: bc.dao.Version.StoragePrefix.Bytes()}, func(k, v []byte) {
 			key := slice.Copy(k)
 			value := slice.Copy(v)
 			if key[0] == byte(storage.STTempStorage) {
@@ -444,7 +444,7 @@ func TestStateSyncModule_RestoreBasicChain(t *testing.T) {
 	// no temp items should be left
 	require.Eventually(t, func() bool {
 		var haveItems bool
-		bcBolt.dao.Store.Seek(storage.STStorage.Bytes(), func(_, _ []byte) {
+		bcBolt.dao.Store.Seek(storage.SeekRange{Prefix: storage.STStorage.Bytes()}, func(_, _ []byte) {
 			haveItems = true
 		})
 		return !haveItems

--- a/pkg/core/storage/leveldb_store.go
+++ b/pkg/core/storage/leveldb_store.go
@@ -85,8 +85,13 @@ func (s *LevelDBStore) PutChangeSet(puts map[string][]byte, dels map[string]bool
 }
 
 // Seek implements the Store interface.
-func (s *LevelDBStore) Seek(key []byte, f func(k, v []byte)) {
-	iter := s.db.NewIterator(util.BytesPrefix(key), nil)
+func (s *LevelDBStore) Seek(rng SeekRange, f func(k, v []byte)) {
+	start := make([]byte, len(rng.Prefix)+len(rng.Start))
+	copy(start, rng.Prefix)
+	copy(start[len(rng.Prefix):], rng.Start)
+	prefix := util.BytesPrefix(rng.Prefix)
+	prefix.Start = start
+	iter := s.db.NewIterator(prefix, nil)
 	for iter.Next() {
 		f(iter.Key(), iter.Value())
 	}

--- a/pkg/core/storage/memcached_store_test.go
+++ b/pkg/core/storage/memcached_store_test.go
@@ -138,33 +138,33 @@ func TestCachedSeek(t *testing.T) {
 		// Given this prefix...
 		goodPrefix = []byte{'f'}
 		// these pairs should be found...
-		lowerKVs = []kvSeen{
-			{[]byte("foo"), []byte("bar"), false},
-			{[]byte("faa"), []byte("bra"), false},
+		lowerKVs = []KeyValue{
+			{[]byte("foo"), []byte("bar")},
+			{[]byte("faa"), []byte("bra")},
 		}
 		// and these should be not.
-		deletedKVs = []kvSeen{
-			{[]byte("fee"), []byte("pow"), false},
-			{[]byte("fii"), []byte("qaz"), false},
+		deletedKVs = []KeyValue{
+			{[]byte("fee"), []byte("pow")},
+			{[]byte("fii"), []byte("qaz")},
 		}
 		// and these should be not.
-		updatedKVs = []kvSeen{
-			{[]byte("fuu"), []byte("wop"), false},
-			{[]byte("fyy"), []byte("zaq"), false},
+		updatedKVs = []KeyValue{
+			{[]byte("fuu"), []byte("wop")},
+			{[]byte("fyy"), []byte("zaq")},
 		}
 		ps = NewMemoryStore()
 		ts = NewMemCachedStore(ps)
 	)
 	for _, v := range lowerKVs {
-		require.NoError(t, ps.Put(v.key, v.val))
+		require.NoError(t, ps.Put(v.Key, v.Value))
 	}
 	for _, v := range deletedKVs {
-		require.NoError(t, ps.Put(v.key, v.val))
-		require.NoError(t, ts.Delete(v.key))
+		require.NoError(t, ps.Put(v.Key, v.Value))
+		require.NoError(t, ts.Delete(v.Key))
 	}
 	for _, v := range updatedKVs {
-		require.NoError(t, ps.Put(v.key, []byte("stub")))
-		require.NoError(t, ts.Put(v.key, v.val))
+		require.NoError(t, ps.Put(v.Key, []byte("stub")))
+		require.NoError(t, ts.Put(v.Key, v.Value))
 	}
 	foundKVs := make(map[string][]byte)
 	ts.Seek(goodPrefix, func(k, v []byte) {
@@ -172,14 +172,14 @@ func TestCachedSeek(t *testing.T) {
 	})
 	assert.Equal(t, len(foundKVs), len(lowerKVs)+len(updatedKVs))
 	for _, kv := range lowerKVs {
-		assert.Equal(t, kv.val, foundKVs[string(kv.key)])
+		assert.Equal(t, kv.Value, foundKVs[string(kv.Key)])
 	}
 	for _, kv := range deletedKVs {
-		_, ok := foundKVs[string(kv.key)]
+		_, ok := foundKVs[string(kv.Key)]
 		assert.Equal(t, false, ok)
 	}
 	for _, kv := range updatedKVs {
-		assert.Equal(t, kv.val, foundKVs[string(kv.key)])
+		assert.Equal(t, kv.Value, foundKVs[string(kv.Key)])
 	}
 }
 
@@ -332,46 +332,46 @@ func TestCachedSeekSorting(t *testing.T) {
 		// Given this prefix...
 		goodPrefix = []byte{1}
 		// these pairs should be found...
-		lowerKVs = []kvSeen{
-			{[]byte{1, 2, 3}, []byte("bra"), false},
-			{[]byte{1, 2, 5}, []byte("bar"), false},
-			{[]byte{1, 3, 3}, []byte("bra"), false},
-			{[]byte{1, 3, 5}, []byte("bra"), false},
+		lowerKVs = []KeyValue{
+			{[]byte{1, 2, 3}, []byte("bra")},
+			{[]byte{1, 2, 5}, []byte("bar")},
+			{[]byte{1, 3, 3}, []byte("bra")},
+			{[]byte{1, 3, 5}, []byte("bra")},
 		}
 		// and these should be not.
-		deletedKVs = []kvSeen{
-			{[]byte{1, 7, 3}, []byte("pow"), false},
-			{[]byte{1, 7, 4}, []byte("qaz"), false},
+		deletedKVs = []KeyValue{
+			{[]byte{1, 7, 3}, []byte("pow")},
+			{[]byte{1, 7, 4}, []byte("qaz")},
 		}
 		// and these should be not.
-		updatedKVs = []kvSeen{
-			{[]byte{1, 2, 4}, []byte("zaq"), false},
-			{[]byte{1, 2, 6}, []byte("zaq"), false},
-			{[]byte{1, 3, 2}, []byte("wop"), false},
-			{[]byte{1, 3, 4}, []byte("zaq"), false},
+		updatedKVs = []KeyValue{
+			{[]byte{1, 2, 4}, []byte("zaq")},
+			{[]byte{1, 2, 6}, []byte("zaq")},
+			{[]byte{1, 3, 2}, []byte("wop")},
+			{[]byte{1, 3, 4}, []byte("zaq")},
 		}
 		ps = NewMemoryStore()
 		ts = NewMemCachedStore(ps)
 	)
 	for _, v := range lowerKVs {
-		require.NoError(t, ps.Put(v.key, v.val))
+		require.NoError(t, ps.Put(v.Key, v.Value))
 	}
 	for _, v := range deletedKVs {
-		require.NoError(t, ps.Put(v.key, v.val))
-		require.NoError(t, ts.Delete(v.key))
+		require.NoError(t, ps.Put(v.Key, v.Value))
+		require.NoError(t, ts.Delete(v.Key))
 	}
 	for _, v := range updatedKVs {
-		require.NoError(t, ps.Put(v.key, []byte("stub")))
-		require.NoError(t, ts.Put(v.key, v.val))
+		require.NoError(t, ps.Put(v.Key, []byte("stub")))
+		require.NoError(t, ts.Put(v.Key, v.Value))
 	}
-	var foundKVs []kvSeen
+	var foundKVs []KeyValue
 	ts.Seek(goodPrefix, func(k, v []byte) {
-		foundKVs = append(foundKVs, kvSeen{key: slice.Copy(k), val: slice.Copy(v)})
+		foundKVs = append(foundKVs, KeyValue{Key: slice.Copy(k), Value: slice.Copy(v)})
 	})
 	assert.Equal(t, len(foundKVs), len(lowerKVs)+len(updatedKVs))
 	expected := append(lowerKVs, updatedKVs...)
 	sort.Slice(expected, func(i, j int) bool {
-		return bytes.Compare(expected[i].key, expected[j].key) < 0
+		return bytes.Compare(expected[i].Key, expected[j].Key) < 0
 	})
 	require.Equal(t, expected, foundKVs)
 }

--- a/pkg/core/storage/memcached_store_test.go
+++ b/pkg/core/storage/memcached_store_test.go
@@ -167,7 +167,7 @@ func TestCachedSeek(t *testing.T) {
 		require.NoError(t, ts.Put(v.Key, v.Value))
 	}
 	foundKVs := make(map[string][]byte)
-	ts.Seek(goodPrefix, func(k, v []byte) {
+	ts.Seek(SeekRange{Prefix: goodPrefix}, func(k, v []byte) {
 		foundKVs[string(k)] = v
 	})
 	assert.Equal(t, len(foundKVs), len(lowerKVs)+len(updatedKVs))
@@ -232,7 +232,7 @@ func benchmarkCachedSeek(t *testing.B, ps Store, psElementsCount, tsElementsCoun
 	t.ReportAllocs()
 	t.ResetTimer()
 	for n := 0; n < t.N; n++ {
-		ts.Seek(searchPrefix, func(k, v []byte) {})
+		ts.Seek(SeekRange{Prefix: searchPrefix}, func(k, v []byte) {})
 	}
 	t.StopTimer()
 }
@@ -290,7 +290,7 @@ func (b *BadStore) PutChangeSet(_ map[string][]byte, _ map[string]bool) error {
 	b.onPutBatch()
 	return ErrKeyNotFound
 }
-func (b *BadStore) Seek(k []byte, f func(k, v []byte)) {
+func (b *BadStore) Seek(rng SeekRange, f func(k, v []byte)) {
 }
 func (b *BadStore) Close() error {
 	return nil
@@ -365,7 +365,7 @@ func TestCachedSeekSorting(t *testing.T) {
 		require.NoError(t, ts.Put(v.Key, v.Value))
 	}
 	var foundKVs []KeyValue
-	ts.Seek(goodPrefix, func(k, v []byte) {
+	ts.Seek(SeekRange{Prefix: goodPrefix}, func(k, v []byte) {
 		foundKVs = append(foundKVs, KeyValue{Key: slice.Copy(k), Value: slice.Copy(v)})
 	})
 	assert.Equal(t, len(foundKVs), len(lowerKVs)+len(updatedKVs))

--- a/pkg/core/storage/memory_store_test.go
+++ b/pkg/core/storage/memory_store_test.go
@@ -28,7 +28,7 @@ func BenchmarkMemorySeek(t *testing.B) {
 			t.ReportAllocs()
 			t.ResetTimer()
 			for n := 0; n < t.N; n++ {
-				ms.Seek(searchPrefix, func(k, v []byte) {})
+				ms.Seek(SeekRange{Prefix: searchPrefix}, func(k, v []byte) {})
 			}
 		})
 	}

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -59,6 +59,10 @@ type SeekRange struct {
 	// Empty Prefix and empty Start can be combined, which means seeking
 	// through all keys in the DB.
 	Start []byte
+	// Backwards denotes whether Seek direction should be reversed, i.e.
+	// whether seeking should be performed in a descending way.
+	// Backwards can be safely combined with Prefix and Start.
+	Backwards bool
 }
 
 // ErrKeyNotFound is an error returned by Store implementations

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -45,6 +45,22 @@ const (
 	MaxStorageValueLen = 65535
 )
 
+// SeekRange represents options for Store.Seek operation.
+type SeekRange struct {
+	// Prefix denotes the Seek's lookup key.
+	// Empty Prefix means seeking through all keys in the DB starting from
+	// the Start if specified.
+	Prefix []byte
+	// Start denotes value upended to the Prefix to start Seek from.
+	// Seeking starting from some key includes this key to the result;
+	// if no matching key was found then next suitable key is picked up.
+	// Start may be empty. Empty Start means seeking through all keys in
+	// the DB with matching Prefix.
+	// Empty Prefix and empty Start can be combined, which means seeking
+	// through all keys in the DB.
+	Start []byte
+}
+
 // ErrKeyNotFound is an error returned by Store implementations
 // when a certain key is not found.
 var ErrKeyNotFound = errors.New("key not found")
@@ -63,7 +79,7 @@ type (
 		// Seek can guarantee that provided key (k) and value (v) are the only valid until the next call to f.
 		// Key and value slices should not be modified. Seek can guarantee that key-value items are sorted by
 		// key in ascending way.
-		Seek(k []byte, f func(k, v []byte))
+		Seek(rng SeekRange, f func(k, v []byte))
 		Close() error
 	}
 


### PR DESCRIPTION
Close #2187.

TODO:

- [x] Allow to seek backwards from some point (do we need it?).
- [x] Use `SeekFrom` and `SeekBackwards` where appropriate.
- [x] Benchmarks.
- [x] Fix commets.
- [x] Optimize time of `getGasPerVote` (something is wrong with it, execution time after optimisation is larger than before).