### PR TITLE
cli: use pretty-print wallet dump to save into file

### DIFF
--- a/cli/wallet/nep17.go
+++ b/cli/wallet/nep17.go
@@ -324,7 +324,7 @@ func importNEPToken(ctx *cli.Context, standard string) error {
 	}
 
 	wall.AddToken(tok)
-	if err := wall.Save(); err != nil {
+	if err := wall.SavePretty(); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 	printTokenInfo(ctx, tok)
@@ -396,7 +396,7 @@ func removeNEPToken(ctx *cli.Context, standard string) error {
 	}
 	if err := wall.RemoveToken(token.Hash); err != nil {
 		return cli.NewExitError(fmt.Errorf("can't remove token: %w", err), 1)
-	} else if err := wall.Save(); err != nil {
+	} else if err := wall.SavePretty(); err != nil {
 		return cli.NewExitError(fmt.Errorf("error while saving wallet: %w", err), 1)
 	}
 	return nil

--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -313,7 +313,7 @@ func convertWallet(ctx *cli.Context) error {
 		}
 		newWallet.AddAccount(newAcc)
 	}
-	if err := newWallet.Save(); err != nil {
+	if err := newWallet.SavePretty(); err != nil {
 		return cli.NewExitError(err, -1)
 	}
 	return nil
@@ -544,7 +544,7 @@ func removeAccount(ctx *cli.Context) error {
 
 	if err := wall.RemoveAccount(acc.Address); err != nil {
 		return cli.NewExitError(fmt.Errorf("error on remove: %w", err), 1)
-	} else if err := wall.Save(); err != nil {
+	} else if err := wall.SavePretty(); err != nil {
 		return cli.NewExitError(fmt.Errorf("error while saving wallet: %w", err), 1)
 	}
 	return nil
@@ -640,7 +640,7 @@ func createWallet(ctx *cli.Context) error {
 	if err != nil {
 		return cli.NewExitError(err, 1)
 	}
-	if err := wall.Save(); err != nil {
+	if err := wall.SavePretty(); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 
@@ -745,7 +745,7 @@ func addAccountAndSave(w *wallet.Wallet, acc *wallet.Account) error {
 	}
 
 	w.AddAccount(acc)
-	return w.Save()
+	return w.SavePretty()
 }
 
 func fmtPrintWallet(w io.Writer, wall *wallet.Wallet) {

--- a/pkg/core/stateroot_test.go
+++ b/pkg/core/stateroot_test.go
@@ -169,7 +169,7 @@ func createAndWriteWallet(t *testing.T, acc *wallet.Account, path, password stri
 	require.NoError(t, err)
 	require.NoError(t, acc.Encrypt(password, w.Scrypt))
 	w.AddAccount(acc)
-	require.NoError(t, w.Save())
+	require.NoError(t, w.SavePretty())
 	w.Close()
 	return w
 }

--- a/pkg/wallet/regenerate_test.go
+++ b/pkg/wallet/regenerate_test.go
@@ -201,7 +201,7 @@ func createWallet(t *testing.T, path string, accs ...*Account) {
 	for _, acc := range accs {
 		w.AddAccount(acc)
 	}
-	require.NoError(t, w.savePretty())
+	require.NoError(t, w.SavePretty())
 	w.Close()
 }
 

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -95,7 +95,7 @@ func (w *Wallet) CreateAccount(name, passphrase string) error {
 		return err
 	}
 	w.AddAccount(acc)
-	return w.Save()
+	return w.SavePretty()
 }
 
 // AddAccount adds an existing Account to the wallet.
@@ -138,20 +138,10 @@ func (w *Wallet) Path() string {
 	return w.path
 }
 
-// Save saves the wallet data. It's the internal io.ReadWriter
+// SavePretty saves wallet in a beautiful JSON. It's the internal io.ReadWriter
 // that is responsible for saving the data. This can
-// be a buffer, file, etc..
-func (w *Wallet) Save() error {
-	data, err := json.Marshal(w)
-	if err != nil {
-		return err
-	}
-
-	return w.writeRaw(data)
-}
-
-// savePretty saves wallet in a beautiful JSON.
-func (w *Wallet) savePretty() error {
+// be a buffer, file, etc.
+func (w *Wallet) SavePretty() error {
 	data, err := json.MarshalIndent(w, "", "  ")
 	if err != nil {
 		return err

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -88,7 +88,7 @@ func TestSave(t *testing.T) {
 		Default:      false,
 	})
 
-	errForSave := wallet.Save()
+	errForSave := wallet.SavePretty()
 	require.NoError(t, errForSave)
 
 	openedWallet, err := NewWalletFromFile(wallet.path)


### PR DESCRIPTION
Close #2317.

I've firstly thought about adding a separate `--pretty` flag, but it seems to be overhead to make the user specify this flag each time he overwrites wallet (we have a lot of such places).