### PR TITLE
core: lock block addition on state jump

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -502,8 +502,10 @@ func (bc *Blockchain) removeOldStorageItems() {
 // specified by the state sync point p. All the data needed for the jump must be
 // collected by the state sync module.
 func (bc *Blockchain) jumpToState(p uint32) error {
+	bc.addLock.Lock()
 	bc.lock.Lock()
 	defer bc.lock.Unlock()
+	defer bc.addLock.Unlock()
 
 	return bc.jumpToStateInternal(p, none)
 }


### PR DESCRIPTION
It should be performed before we're able to process blocks or before we
shutdown (which uses addition lock), fix

panic: assignment to entry in nil map

goroutine 5755 [running]:
github.com/nspcc-dev/neo-go/pkg/core/storage.(*MemoryStore).drop(...)
        /home/rik/dev/neo-go/pkg/core/storage/memory_store.go:74
github.com/nspcc-dev/neo-go/pkg/core/storage.(*MemoryStore).PutChangeSet(0xc00093e700, 0xc0002051a0, 0xc000205200, 0x1, 0x1)
        /home/rik/dev/neo-go/pkg/core/storage/memory_store.go:100 +0x25c
github.com/nspcc-dev/neo-go/pkg/core/storage.(*MemoryStore).PutBatch(...)
        /home/rik/dev/neo-go/pkg/core/storage/memory_store.go:90
github.com/nspcc-dev/neo-go/pkg/core.(*Blockchain).removeOldStorageItems(0xc000206a00)
        /home/rik/dev/neo-go/pkg/core/blockchain.go:495 +0x33a
created by github.com/nspcc-dev/neo-go/pkg/core.(*Blockchain).jumpToStateInternal
        /home/rik/dev/neo-go/pkg/core/blockchain.go:553 +0x68a
FAIL    github.com/nspcc-dev/neo-go/pkg/core    52.084s

### Problem

...

### Solution

...
