### PR TITLE
core: improve Seek and optimise seek time for transfer logs

### DIFF
--- a/internal/fakechain/fakechain.go
+++ b/internal/fakechain/fakechain.go
@@ -286,12 +286,12 @@ func (chain *FakeChain) GetTokenLastUpdated(acc util.Uint160) (map[int32]uint32,
 }
 
 // ForEachNEP17Transfer implements Blockchainer interface.
-func (chain *FakeChain) ForEachNEP11Transfer(util.Uint160, func(*state.NEP11Transfer) (bool, error)) error {
+func (chain *FakeChain) ForEachNEP11Transfer(util.Uint160, uint64, func(*state.NEP11Transfer) (bool, error)) error {
 	panic("TODO")
 }
 
 // ForEachNEP17Transfer implements Blockchainer interface.
-func (chain *FakeChain) ForEachNEP17Transfer(util.Uint160, func(*state.NEP17Transfer) (bool, error)) error {
+func (chain *FakeChain) ForEachNEP17Transfer(util.Uint160, uint64, func(*state.NEP17Transfer) (bool, error)) error {
 	panic("TODO")
 }
 

--- a/pkg/core/bench_test.go
+++ b/pkg/core/bench_test.go
@@ -1,9 +1,18 @@
 package core
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/internal/random"
+	"github.com/nspcc-dev/neo-go/internal/testchain"
 	"github.com/nspcc-dev/neo-go/pkg/config/netmode"
+	"github.com/nspcc-dev/neo-go/pkg/core/state"
+	"github.com/nspcc-dev/neo-go/pkg/core/storage"
+	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
 	"github.com/nspcc-dev/neo-go/pkg/wallet"
 	"github.com/stretchr/testify/require"
@@ -21,4 +30,85 @@ func BenchmarkVerifyWitness(t *testing.B) {
 	for n := 0; n < t.N; n++ {
 		_, _ = bc.VerifyWitness(tx.Signers[0].Account, tx, &tx.Scripts[0], 100000000)
 	}
+}
+
+func BenchmarkBlockchain_ForEachNEP17Transfer(t *testing.B) {
+	var stores = map[string]func(testing.TB) storage.Store{
+		"MemPS": func(t testing.TB) storage.Store {
+			return storage.NewMemoryStore()
+		},
+		"BoltPS":  newBoltStoreForTesting,
+		"LevelPS": newLevelDBForTesting,
+	}
+	startFrom := []int{1, 100, 1000}
+	blocksToTake := []int{100, 1000}
+	for psName, newPS := range stores {
+		for _, startFromBlock := range startFrom {
+			for _, nBlocksToTake := range blocksToTake {
+				t.Run(fmt.Sprintf("%s_StartFromBlockN-%d_Take%dBlocks", psName, startFromBlock, nBlocksToTake), func(t *testing.B) {
+					ps := newPS(t)
+					t.Cleanup(func() { ps.Close() })
+					benchmarkForEachNEP17Transfer(t, ps, startFromBlock, nBlocksToTake)
+				})
+			}
+		}
+	}
+}
+
+func benchmarkForEachNEP17Transfer(t *testing.B, ps storage.Store, startFromBlock, nBlocksToTake int) {
+	var (
+		nonce             uint32 = 1
+		chainHeight              = 2_100                            // constant chain height to be able to compare paging results
+		transfersPerBlock        = state.TokenTransferBatchSize/4 + // 4 blocks per batch
+			state.TokenTransferBatchSize/32 // shift
+	)
+
+	bc := newTestChainWithCustomCfgAndStore(t, ps, nil)
+	gasHash := bc.contracts.GAS.Hash
+	acc := random.Uint160()
+
+	for j := 0; j < chainHeight; j++ {
+		w := io.NewBufBinWriter()
+		for i := 0; i < transfersPerBlock; i++ {
+			emit.AppCall(w.BinWriter, gasHash, "transfer", callflag.All, testchain.MultisigScriptHash(), acc, 1, nil)
+			emit.Opcodes(w.BinWriter, opcode.ASSERT)
+			require.NoError(t, w.Err)
+		}
+		script := w.Bytes()
+		tx := transaction.New(script, int64(1100_0000*transfersPerBlock))
+		tx.ValidUntilBlock = bc.BlockHeight() + 1
+		tx.Nonce = nonce
+		nonce++
+		tx.Signers = []transaction.Signer{{
+			Account:          testchain.MultisigScriptHash(),
+			Scopes:           transaction.CalledByEntry,
+			AllowedContracts: nil,
+			AllowedGroups:    nil,
+		}}
+		require.NoError(t, testchain.SignTx(bc, tx))
+		b := bc.newBlock(tx)
+		require.NoError(t, bc.AddBlock(b))
+		checkTxHalt(t, bc, tx.Hash())
+	}
+
+	newestB, err := bc.GetBlock(bc.GetHeaderHash(int(bc.BlockHeight()) - startFromBlock + 1))
+	require.NoError(t, err)
+	_ = newestB.Timestamp
+	oldestB, err := bc.GetBlock(bc.GetHeaderHash(int(newestB.Index) - nBlocksToTake))
+	require.NoError(t, err)
+	oldestTimestamp := oldestB.Timestamp
+
+	t.ResetTimer()
+	t.ReportAllocs()
+	t.StartTimer()
+	for i := 0; i < t.N; i++ {
+		require.NoError(t, bc.ForEachNEP17Transfer(acc, func(t *state.NEP17Transfer) (bool, error) {
+			if t.Timestamp < oldestTimestamp {
+				// iterating from newest to oldest, already have reached the needed height
+				return false, nil
+			}
+			return true, nil
+		}))
+	}
+	t.StopTimer()
 }

--- a/pkg/core/bench_test.go
+++ b/pkg/core/bench_test.go
@@ -93,7 +93,7 @@ func benchmarkForEachNEP17Transfer(t *testing.B, ps storage.Store, startFromBloc
 
 	newestB, err := bc.GetBlock(bc.GetHeaderHash(int(bc.BlockHeight()) - startFromBlock + 1))
 	require.NoError(t, err)
-	_ = newestB.Timestamp
+	newestTimestamp := newestB.Timestamp
 	oldestB, err := bc.GetBlock(bc.GetHeaderHash(int(newestB.Index) - nBlocksToTake))
 	require.NoError(t, err)
 	oldestTimestamp := oldestB.Timestamp
@@ -102,7 +102,7 @@ func benchmarkForEachNEP17Transfer(t *testing.B, ps storage.Store, startFromBloc
 	t.ReportAllocs()
 	t.StartTimer()
 	for i := 0; i < t.N; i++ {
-		require.NoError(t, bc.ForEachNEP17Transfer(acc, func(t *state.NEP17Transfer) (bool, error) {
+		require.NoError(t, bc.ForEachNEP17Transfer(acc, newestTimestamp, func(t *state.NEP17Transfer) (bool, error) {
 			if t.Timestamp < oldestTimestamp {
 				// iterating from newest to oldest, already have reached the needed height
 				return false, nil

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -486,9 +486,10 @@ func (bc *Blockchain) removeOldStorageItems() {
 
 	b := bc.dao.Store.Batch()
 	prefix := statesync.TemporaryPrefix(bc.dao.Version.StoragePrefix)
-	bc.dao.Store.Seek(storage.SeekRange{Prefix: []byte{byte(prefix)}}, func(k, _ []byte) {
+	bc.dao.Store.Seek(storage.SeekRange{Prefix: []byte{byte(prefix)}}, func(k, _ []byte) bool {
 		// #1468, but don't need to copy here, because it is done by Store.
 		b.Delete(k)
+		return true
 	})
 	b.Delete(storage.SYSCleanStorage.Bytes())
 

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -1768,11 +1768,12 @@ func TestBlockchain_InitWithIncompleteStateJump(t *testing.T) {
 	if bcSpout.dao.Version.StoragePrefix == tempPrefix {
 		tempPrefix = storage.STStorage
 	}
-	bcSpout.dao.Store.Seek(storage.SeekRange{Prefix: bcSpout.dao.Version.StoragePrefix.Bytes()}, func(k, v []byte) {
+	bcSpout.dao.Store.Seek(storage.SeekRange{Prefix: bcSpout.dao.Version.StoragePrefix.Bytes()}, func(k, v []byte) bool {
 		key := slice.Copy(k)
 		key[0] = byte(tempPrefix)
 		value := slice.Copy(v)
 		batch.Put(key, value)
+		return true
 	})
 	require.NoError(t, bcSpout.dao.Store.PutBatch(batch))
 

--- a/pkg/core/blockchainer/blockchainer.go
+++ b/pkg/core/blockchainer/blockchainer.go
@@ -36,8 +36,8 @@ type Blockchainer interface {
 	GetContractScriptHash(id int32) (util.Uint160, error)
 	GetEnrollments() ([]state.Validator, error)
 	GetGoverningTokenBalance(acc util.Uint160) (*big.Int, uint32)
-	ForEachNEP11Transfer(util.Uint160, func(*state.NEP11Transfer) (bool, error)) error
-	ForEachNEP17Transfer(util.Uint160, func(*state.NEP17Transfer) (bool, error)) error
+	ForEachNEP11Transfer(acc util.Uint160, newestTimestamp uint64, f func(*state.NEP11Transfer) (bool, error)) error
+	ForEachNEP17Transfer(acc util.Uint160, newestTimestamp uint64, f func(*state.NEP17Transfer) (bool, error)) error
 	GetHeaderHash(int) util.Uint256
 	GetHeader(hash util.Uint256) (*block.Header, error)
 	CurrentHeaderHash() util.Uint256

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -503,13 +503,14 @@ func (m *Management) InitializeCache(d dao.DAO) error {
 	defer m.mtx.Unlock()
 
 	var initErr error
-	d.Seek(m.ID, storage.SeekRange{Prefix: []byte{prefixContract}}, func(_, v []byte) {
+	d.Seek(m.ID, storage.SeekRange{Prefix: []byte{prefixContract}}, func(_, v []byte) bool {
 		var cs = new(state.Contract)
 		initErr = stackitem.DeserializeConvertible(v, cs)
 		if initErr != nil {
-			return
+			return false
 		}
 		m.updateContractCache(cs)
+		return true
 	})
 	return initErr
 }

--- a/pkg/core/state/tokens.go
+++ b/pkg/core/state/tokens.go
@@ -53,6 +53,10 @@ type TokenTransferInfo struct {
 	NextNEP11Batch uint32
 	// NextNEP17Batch stores the index of the next NEP-17 transfer batch.
 	NextNEP17Batch uint32
+	// NextNEP11NewestTimestamp stores the block timestamp of the first NEP-11 transfer in raw.
+	NextNEP11NewestTimestamp uint64
+	// NextNEP17NewestTimestamp stores the block timestamp of the first NEP-17 transfer in raw.
+	NextNEP17NewestTimestamp uint64
 	// NewNEP11Batch is true if batch with the `NextNEP11Batch` index should be created.
 	NewNEP11Batch bool
 	// NewNEP17Batch is true if batch with the `NextNEP17Batch` index should be created.
@@ -72,6 +76,8 @@ func NewTokenTransferInfo() *TokenTransferInfo {
 func (bs *TokenTransferInfo) DecodeBinary(r *io.BinReader) {
 	bs.NextNEP11Batch = r.ReadU32LE()
 	bs.NextNEP17Batch = r.ReadU32LE()
+	bs.NextNEP11NewestTimestamp = r.ReadU64LE()
+	bs.NextNEP17NewestTimestamp = r.ReadU64LE()
 	bs.NewNEP11Batch = r.ReadBool()
 	bs.NewNEP17Batch = r.ReadBool()
 	lenBalances := r.ReadVarUint()
@@ -87,6 +93,8 @@ func (bs *TokenTransferInfo) DecodeBinary(r *io.BinReader) {
 func (bs *TokenTransferInfo) EncodeBinary(w *io.BinWriter) {
 	w.WriteU32LE(bs.NextNEP11Batch)
 	w.WriteU32LE(bs.NextNEP17Batch)
+	w.WriteU64LE(bs.NextNEP11NewestTimestamp)
+	w.WriteU64LE(bs.NextNEP17NewestTimestamp)
 	w.WriteBool(bs.NewNEP11Batch)
 	w.WriteBool(bs.NewNEP17Batch)
 	w.WriteVarUint(uint64(len(bs.LastUpdated)))

--- a/pkg/core/stateroot/module.go
+++ b/pkg/core/stateroot/module.go
@@ -134,9 +134,10 @@ func (s *Module) CleanStorage() error {
 		return fmt.Errorf("can't clean MPT data for non-genesis block: expected local stateroot height 0, got %d", s.localHeight.Load())
 	}
 	b := s.Store.Batch()
-	s.Store.Seek(storage.SeekRange{Prefix: []byte{byte(storage.DataMPT)}}, func(k, _ []byte) {
+	s.Store.Seek(storage.SeekRange{Prefix: []byte{byte(storage.DataMPT)}}, func(k, _ []byte) bool {
 		// #1468, but don't need to copy here, because it is done by Store.
 		b.Delete(k)
+		return true
 	})
 	err := s.Store.PutBatch(b)
 	if err != nil {

--- a/pkg/core/statesync/module_test.go
+++ b/pkg/core/statesync/module_test.go
@@ -32,7 +32,7 @@ func TestModule_PR2019_discussion_r689629704(t *testing.T) {
 		nodes         = make(map[util.Uint256][]byte)
 		expectedItems []storage.KeyValue
 	)
-	expectedStorage.Seek(storage.SeekRange{Prefix: storage.DataMPT.Bytes()}, func(k, v []byte) {
+	expectedStorage.Seek(storage.SeekRange{Prefix: storage.DataMPT.Bytes()}, func(k, v []byte) bool {
 		key := slice.Copy(k)
 		value := slice.Copy(v)
 		expectedItems = append(expectedItems, storage.KeyValue{
@@ -43,6 +43,7 @@ func TestModule_PR2019_discussion_r689629704(t *testing.T) {
 		require.NoError(t, err)
 		nodeBytes := value[:len(value)-4]
 		nodes[hash] = nodeBytes
+		return true
 	})
 
 	actualStorage := storage.NewMemCachedStore(storage.NewMemoryStore())
@@ -95,13 +96,14 @@ func TestModule_PR2019_discussion_r689629704(t *testing.T) {
 
 	// Compare resulting storage items and refcounts.
 	var actualItems []storage.KeyValue
-	expectedStorage.Seek(storage.SeekRange{Prefix: storage.DataMPT.Bytes()}, func(k, v []byte) {
+	expectedStorage.Seek(storage.SeekRange{Prefix: storage.DataMPT.Bytes()}, func(k, v []byte) bool {
 		key := slice.Copy(k)
 		value := slice.Copy(v)
 		actualItems = append(actualItems, storage.KeyValue{
 			Key:   key,
 			Value: value,
 		})
+		return true
 	})
 	require.ElementsMatch(t, expectedItems, actualItems)
 }

--- a/pkg/core/statesync_test.go
+++ b/pkg/core/statesync_test.go
@@ -424,7 +424,7 @@ func TestStateSyncModule_RestoreBasicChain(t *testing.T) {
 	// compare storage states
 	fetchStorage := func(bc *Blockchain) []storage.KeyValue {
 		var kv []storage.KeyValue
-		bc.dao.Store.Seek(storage.SeekRange{Prefix: bc.dao.Version.StoragePrefix.Bytes()}, func(k, v []byte) {
+		bc.dao.Store.Seek(storage.SeekRange{Prefix: bc.dao.Version.StoragePrefix.Bytes()}, func(k, v []byte) bool {
 			key := slice.Copy(k)
 			value := slice.Copy(v)
 			if key[0] == byte(storage.STTempStorage) {
@@ -434,6 +434,7 @@ func TestStateSyncModule_RestoreBasicChain(t *testing.T) {
 				Key:   key,
 				Value: value,
 			})
+			return true
 		})
 		return kv
 	}
@@ -444,8 +445,9 @@ func TestStateSyncModule_RestoreBasicChain(t *testing.T) {
 	// no temp items should be left
 	require.Eventually(t, func() bool {
 		var haveItems bool
-		bcBolt.dao.Store.Seek(storage.SeekRange{Prefix: storage.STStorage.Bytes()}, func(_, _ []byte) {
+		bcBolt.dao.Store.Seek(storage.SeekRange{Prefix: storage.STStorage.Bytes()}, func(_, _ []byte) bool {
 			haveItems = true
+			return false
 		})
 		return !haveItems
 	}, time.Second*5, time.Millisecond*100)

--- a/pkg/core/storage/memcached_store_test.go
+++ b/pkg/core/storage/memcached_store_test.go
@@ -167,8 +167,9 @@ func TestCachedSeek(t *testing.T) {
 		require.NoError(t, ts.Put(v.Key, v.Value))
 	}
 	foundKVs := make(map[string][]byte)
-	ts.Seek(SeekRange{Prefix: goodPrefix}, func(k, v []byte) {
+	ts.Seek(SeekRange{Prefix: goodPrefix}, func(k, v []byte) bool {
 		foundKVs[string(k)] = v
+		return true
 	})
 	assert.Equal(t, len(foundKVs), len(lowerKVs)+len(updatedKVs))
 	for _, kv := range lowerKVs {
@@ -232,7 +233,7 @@ func benchmarkCachedSeek(t *testing.B, ps Store, psElementsCount, tsElementsCoun
 	t.ReportAllocs()
 	t.ResetTimer()
 	for n := 0; n < t.N; n++ {
-		ts.Seek(SeekRange{Prefix: searchPrefix}, func(k, v []byte) {})
+		ts.Seek(SeekRange{Prefix: searchPrefix}, func(k, v []byte) bool { return true })
 	}
 	t.StopTimer()
 }
@@ -290,7 +291,7 @@ func (b *BadStore) PutChangeSet(_ map[string][]byte, _ map[string]bool) error {
 	b.onPutBatch()
 	return ErrKeyNotFound
 }
-func (b *BadStore) Seek(rng SeekRange, f func(k, v []byte)) {
+func (b *BadStore) Seek(rng SeekRange, f func(k, v []byte) bool) {
 }
 func (b *BadStore) Close() error {
 	return nil
@@ -365,8 +366,9 @@ func TestCachedSeekSorting(t *testing.T) {
 		require.NoError(t, ts.Put(v.Key, v.Value))
 	}
 	var foundKVs []KeyValue
-	ts.Seek(SeekRange{Prefix: goodPrefix}, func(k, v []byte) {
+	ts.Seek(SeekRange{Prefix: goodPrefix}, func(k, v []byte) bool {
 		foundKVs = append(foundKVs, KeyValue{Key: slice.Copy(k), Value: slice.Copy(v)})
+		return true
 	})
 	assert.Equal(t, len(foundKVs), len(lowerKVs)+len(updatedKVs))
 	expected := append(lowerKVs, updatedKVs...)

--- a/pkg/core/storage/memory_store.go
+++ b/pkg/core/storage/memory_store.go
@@ -104,7 +104,7 @@ func (s *MemoryStore) PutChangeSet(puts map[string][]byte, dels map[string]bool)
 }
 
 // Seek implements the Store interface.
-func (s *MemoryStore) Seek(rng SeekRange, f func(k, v []byte)) {
+func (s *MemoryStore) Seek(rng SeekRange, f func(k, v []byte) bool) {
 	s.mut.RLock()
 	s.seek(rng, f)
 	s.mut.RUnlock()
@@ -130,7 +130,7 @@ func (s *MemoryStore) SeekAll(key []byte, f func(k, v []byte)) {
 // seek is an internal unlocked implementation of Seek. `start` denotes whether
 // seeking starting from the provided prefix should be performed. Backwards
 // seeking from some point is supported with corresponding SeekRange field set.
-func (s *MemoryStore) seek(rng SeekRange, f func(k, v []byte)) {
+func (s *MemoryStore) seek(rng SeekRange, f func(k, v []byte) bool) {
 	sPrefix := string(rng.Prefix)
 	lPrefix := len(sPrefix)
 	sStart := string(rng.Start)
@@ -162,7 +162,9 @@ func (s *MemoryStore) seek(rng SeekRange, f func(k, v []byte)) {
 		return less(memList[i].Key, memList[j].Key)
 	})
 	for _, kv := range memList {
-		f(kv.Key, kv.Value)
+		if !f(kv.Key, kv.Value) {
+			break
+		}
 	}
 }
 

--- a/pkg/core/storage/memory_store_test.go
+++ b/pkg/core/storage/memory_store_test.go
@@ -28,7 +28,7 @@ func BenchmarkMemorySeek(t *testing.B) {
 			t.ReportAllocs()
 			t.ResetTimer()
 			for n := 0; n < t.N; n++ {
-				ms.Seek(SeekRange{Prefix: searchPrefix}, func(k, v []byte) {})
+				ms.Seek(SeekRange{Prefix: searchPrefix}, func(k, v []byte) bool { return false })
 			}
 		})
 	}

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -51,7 +51,7 @@ type SeekRange struct {
 	// Empty Prefix means seeking through all keys in the DB starting from
 	// the Start if specified.
 	Prefix []byte
-	// Start denotes value upended to the Prefix to start Seek from.
+	// Start denotes value appended to the Prefix to start Seek from.
 	// Seeking starting from some key includes this key to the result;
 	// if no matching key was found then next suitable key is picked up.
 	// Start may be empty. Empty Start means seeking through all keys in
@@ -81,9 +81,10 @@ type (
 		// PutChangeSet allows to push prepared changeset to the Store.
 		PutChangeSet(puts map[string][]byte, dels map[string]bool) error
 		// Seek can guarantee that provided key (k) and value (v) are the only valid until the next call to f.
-		// Key and value slices should not be modified. Seek can guarantee that key-value items are sorted by
-		// key in ascending way.
-		Seek(rng SeekRange, f func(k, v []byte))
+		// Seek continues iteration until false is returned from f.
+		// Key and value slices should not be modified.
+		// Seek can guarantee that key-value items are sorted by key in ascending way.
+		Seek(rng SeekRange, f func(k, v []byte) bool)
 		Close() error
 	}
 

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -1019,7 +1019,7 @@ func (s *Server) getTokenTransfers(ps request.Params, isNEP11 bool) (interface{}
 		return received, sent, !(limit != 0 && resCount >= limit), nil
 	}
 	if !isNEP11 {
-		err = s.chain.ForEachNEP17Transfer(u, func(tr *state.NEP17Transfer) (bool, error) {
+		err = s.chain.ForEachNEP17Transfer(u, end, func(tr *state.NEP17Transfer) (bool, error) {
 			r, s, res, err := handleTransfer(tr)
 			if err == nil {
 				if r != nil {
@@ -1032,7 +1032,7 @@ func (s *Server) getTokenTransfers(ps request.Params, isNEP11 bool) (interface{}
 			return res, err
 		})
 	} else {
-		err = s.chain.ForEachNEP11Transfer(u, func(tr *state.NEP11Transfer) (bool, error) {
+		err = s.chain.ForEachNEP11Transfer(u, end, func(tr *state.NEP11Transfer) (bool, error) {
 			r, s, res, err := handleTransfer(&tr.NEP17Transfer)
 			if err == nil {
 				id := hex.EncodeToString(tr.ID)
@@ -1047,7 +1047,7 @@ func (s *Server) getTokenTransfers(ps request.Params, isNEP11 bool) (interface{}
 		})
 	}
 	if err != nil {
-		return nil, response.NewInternalServerError("invalid transfer log", err)
+		return nil, response.NewInternalServerError(fmt.Sprintf("invalid transfer log: %v", err), err)
 	}
 	return bs, nil
 }


### PR DESCRIPTION
Close #2322, close #2263.

TODO:

- [x] Apply and evaluate https://github.com/nspcc-dev/neo-go/commit/05b5fdc0f4e181777308b87f49433f3cab10be5d to improve GasPerVote retrieving a bit more.
- [x] Try to restore mainnet chain from dump and compare the resulting time.