### PR TITLE
core: adjust native Notary `withdraw` call flags

### DIFF
--- a/pkg/core/native/notary.go
+++ b/pkg/core/native/notary.go
@@ -72,7 +72,7 @@ func newNotary() *Notary {
 	desc = newDescriptor("withdraw", smartcontract.BoolType,
 		manifest.NewParameter("from", smartcontract.Hash160Type),
 		manifest.NewParameter("to", smartcontract.Hash160Type))
-	md = newMethodAndPrice(n.withdraw, 1<<15, callflag.States)
+	md = newMethodAndPrice(n.withdraw, 1<<15, callflag.All)
 	n.AddMethod(md, desc)
 
 	desc = newDescriptor("balanceOf", smartcontract.IntegerType,

--- a/pkg/interop/native/notary/notary.go
+++ b/pkg/interop/native/notary/notary.go
@@ -22,7 +22,7 @@ func LockDepositUntil(addr interop.Hash160, till int) bool {
 
 // Withdraw represents `withdraw` method of Notary native contract.
 func Withdraw(from, to interop.Hash160) bool {
-	return neogointernal.CallWithToken(Hash, "withdraw", int(contract.States),
+	return neogointernal.CallWithToken(Hash, "withdraw", int(contract.All),
 		from, to).(bool)
 }
 


### PR DESCRIPTION
It changes states and calls `transfer` method of GAS which emits `transfer`
notification, so it requires States | AllowCall | AllowNotify, i.e. the
widest permission.

See
https://github.com/nspcc-dev/neo-go/issues/1990#issuecomment-1014911528.