### PR TITLE
codecov: fix coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  codecov: codecov/codecov@1.0.5
 
 executors:
   go1_15:
@@ -62,20 +60,6 @@ jobs:
       - gomod
       - run: go test -v -race ./...
 
-  test_cover:
-    working_directory: /go/src/github.com/nspcc-dev/neo-go
-    executor: go1_17
-    environment:
-        CGO_ENABLED: 0
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - gomod
-      - run: go test -v ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./pkg...,./cli/...
-      - codecov/upload:
-          file: coverage.txt
-
   build_cli:
     working_directory: /go/src/github.com/nspcc-dev/neo-go
     executor: go1_17
@@ -122,10 +106,6 @@ workflows:
             tags:
               only: v/[0-9]+\.[0-9]+\.[0-9]+/
       - test_1_16:
-          filters:
-            tags:
-              only: v/[0-9]+\.[0-9]+\.[0-9]+/
-      - test_cover:
           filters:
             tags:
               only: v/[0-9]+\.[0-9]+\.[0-9]+/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,3 @@
 codecov:
   require_ci_to_pass: no # We have several CI jobs that upload codecov results,
                          # and sometimes some of them may fail, it's OK.
-coverage:
-  status:
-    project:
-      default: # This can be anything, but it needs to exist as the name
-        if_ci_failed: error #success, failure, error, ignore
-        only_pulls: false
-comment:
-  after_n_builds: 1


### PR DESCRIPTION
1. Set explicitly all required values in the codecov.yml. Keep `require_ci_to_pass: no` so that codecov is be able to upload coverage reports irrespectively to the other tests.
2. Keep the only coverage reporting job, so that CircleCI's reports do not conflict with GithubActions's ones.