### PR TITLE
*: fix windows tests

### DIFF
--- a/.github/workflows/publish_to_dockerhub.yml
+++ b/.github/workflows/publish_to_dockerhub.yml
@@ -138,6 +138,9 @@ jobs:
           # Allows to fetch all history for all branches and tags. Need this for proper versioning.
           fetch-depth: 0
 
+      - name: Show docker images
+        run: docker images
+
       - name: Build image
         run: make image-wsc
 

--- a/.github/workflows/publish_to_dockerhub.yml
+++ b/.github/workflows/publish_to_dockerhub.yml
@@ -128,9 +128,6 @@ jobs:
         run: make test
   publish_wsc:
     # Ensure test job passes before pushing image.
-    # TODO: currently test_wsc job is failing, so we have `always()` condition.
-    # After #2269 and #2268 this condition should be removed.
-    if: ${{ always() }}
     needs: tests_wsc
     name: Publish WindowsServerCore-based image to DockerHub
     runs-on: windows-2022

--- a/Dockerfile.wsc
+++ b/Dockerfile.wsc
@@ -1,5 +1,25 @@
 # Builder image
-FROM golang:windowsservercore-ltsc2022 as builder
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';", "$ProgressPreference = 'SilentlyContinue';"]
+
+ENV GIT_VERSION=2.23.0
+
+ENV GIT_TAG=v2.23.0.windows.1
+
+ENV GIT_DOWNLOAD_URL=https://github.com/git-for-windows/git/releases/download/v2.23.0.windows.1/MinGit-2.23.0-64-bit.zip
+
+ENV GIT_DOWNLOAD_SHA256=8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; 	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; 		Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); 	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { 		Write-Host 'FAILED!'; 		exit 1; 	}; 		Write-Host 'Expanding ...'; 	Expand-Archive -Path git.zip -DestinationPath C:\git\.; 		Write-Host 'Removing ...'; 	Remove-Item git.zip -Force; 		Write-Host 'Updating PATH ...'; 	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); 		Write-Host 'Verifying install ("git version") ...'; 	git version; 		Write-Host 'Complete.';
+
+ENV GOPATH=C:\\go
+
+RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH); 	Write-Host ('Updating PATH: {0}' -f $newPath); 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+
+ENV GOLANG_VERSION=1.17.6
+
+RUN $url = 'https://dl.google.com/go/go1.17.6.windows-amd64.zip'; 	Write-Host ('Downloading {0} ...' -f $url); 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; 		$sha256 = '5bf8f87aec7edfc08e6bc845f1c30dba6de32b863f89ae46553ff4bbcc1d4954'; 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { 		Write-Host 'FAILED!'; 		exit 1; 	}; 		Write-Host 'Expanding ...'; 	Expand-Archive go.zip -DestinationPath C:\; 		Write-Host 'Moving ...'; 	Move-Item -Path C:\go -Destination 'C:\Program Files\Go'; 		Write-Host 'Removing ...'; 	Remove-Item go.zip -Force; 		Write-Host 'Verifying install ("go version") ...'; 	go version; 		Write-Host 'Complete.';
 
 COPY . /neo-go
 

--- a/cli/server/server_test.go
+++ b/cli/server/server_test.go
@@ -41,7 +41,6 @@ func TestGetConfigFromContext(t *testing.T) {
 }
 
 func TestHandleLoggingParams(t *testing.T) {
-	// This test is failing on Windows, see https://github.com/nspcc-dev/neo-go/issues/2269
 	d := t.TempDir()
 	testLog := filepath.Join(d, "file.log")
 

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -235,9 +235,10 @@ func (c *codegen) fillDocumentInfo() {
 	fset := c.buildInfo.config.Fset
 	fset.Iterate(func(f *token.File) bool {
 		filePath := f.Position(f.Pos(0)).Filename
-		filePath, err := filepath.Rel(c.buildInfo.config.Dir, filePath)
-		if err != nil {
-			panic(err)
+		rel, err := filepath.Rel(c.buildInfo.config.Dir, filePath)
+		// It's OK if we can't construct relative path, e.g. for interop dependencies.
+		if err == nil {
+			filePath = rel
 		}
 		c.docIndex[filePath] = len(c.documents)
 		c.documents = append(c.documents, filePath)

--- a/pkg/network/server_test.go
+++ b/pkg/network/server_test.go
@@ -404,7 +404,7 @@ func TestBlock(t *testing.T) {
 	b := block.New(false)
 	b.Index = 12345
 	s.testHandleMessage(t, nil, CMDBlock, b)
-	require.Eventually(t, func() bool { return s.chain.BlockHeight() == 12345 }, time.Second, time.Millisecond*500)
+	require.Eventually(t, func() bool { return s.chain.BlockHeight() == 12345 }, 2*time.Second, time.Millisecond*500)
 }
 
 func TestConsensus(t *testing.T) {
@@ -497,8 +497,8 @@ func (s *Server) testHandleGetData(t *testing.T, invType payload.InventoryType, 
 
 	s.testHandleMessage(t, p, CMDGetData, payload.NewInventory(invType, hs))
 
-	require.Eventually(t, func() bool { return recvResponse.Load() }, time.Second, time.Millisecond)
-	require.Eventually(t, func() bool { return recvNotFound.Load() }, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return recvResponse.Load() }, 2*time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return recvNotFound.Load() }, 2*time.Second, time.Millisecond)
 }
 
 func TestGetData(t *testing.T) {

--- a/pkg/vm/cli/cli_test.go
+++ b/pkg/vm/cli/cli_test.go
@@ -84,6 +84,10 @@ func newTestVMCLIWithLogo(t *testing.T, printLogo bool) *executor {
 }
 
 func (e *executor) runProg(t *testing.T, commands ...string) {
+	e.runProgWithTimeout(t, 4*time.Second, commands...)
+}
+
+func (e *executor) runProgWithTimeout(t *testing.T, timeout time.Duration, commands ...string) {
 	cmd := strings.Join(commands, "\n") + "\n"
 	e.in.WriteString(cmd + "\n")
 	go func() {
@@ -92,7 +96,7 @@ func (e *executor) runProg(t *testing.T, commands ...string) {
 	}()
 	select {
 	case <-e.ch:
-	case <-time.After(4 * time.Second):
+	case <-time.After(timeout):
 		require.Fail(t, "command took too long time")
 	}
 }
@@ -213,7 +217,7 @@ go 1.16`)
 		require.NoError(t, ioutil.WriteFile(filepath.Join(tmpDir, "go.mod"), goMod, os.ModePerm))
 
 		e := newTestVMCLI(t)
-		e.runProg(t,
+		e.runProgWithTimeout(t, 10*time.Second,
 			"loadgo",
 			"loadgo "+filenameErr,
 			"loadgo "+filename,
@@ -318,7 +322,7 @@ func TestRunWithDifferentArguments(t *testing.T) {
 
 	filename = "'" + filename + "'"
 	e := newTestVMCLI(t)
-	e.runProg(t,
+	e.runProgWithTimeout(t, 30*time.Second,
 		"loadgo "+filename, "run notexists",
 		"loadgo "+filename, "run negate false",
 		"loadgo "+filename, "run negate true",


### PR DESCRIPTION
Close #2269, close #2277.

Part of #2268 is also fixed, but dealing with `NEO-GO-VM > ←[J←[2K` is still in progress.