### PR TITLE
Btree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/abiosoft/readline v0.0.0-20180607040430-155bce2042db
 	github.com/btcsuite/btcd v0.22.0-beta
 	github.com/davecgh/go-spew v1.1.1
+	github.com/google/btree v1.0.1
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/holiman/uint256 v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8l
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -1373,22 +1373,14 @@ func TestGetClaimable(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	defer func() {
-		r := recover()
-		assert.NotNil(t, r)
-	}()
 	bc := initTestChain(t, nil, nil)
 	go bc.Run()
+	hash0 := bc.GetHeaderHash(0)
 	_, err := bc.genBlocks(10)
 	require.NoError(t, err)
 	bc.Close()
-	// It's a hack, but we use internal knowledge of MemoryStore
-	// implementation which makes it completely unusable (up to panicing)
-	// after Close().
-	_ = bc.dao.Store.Put([]byte{0}, []byte{1})
-
-	// This should never be executed.
-	assert.Nil(t, t)
+	_, err = bc.GetBlock(hash0) // DB is closed, so this will fail.
+	require.Error(t, err)
 }
 
 func TestSubscriptions(t *testing.T) {

--- a/pkg/core/blockchain_test.go
+++ b/pkg/core/blockchain_test.go
@@ -1116,7 +1116,7 @@ func TestVerifyHashAgainstScript(t *testing.T) {
 	bc := newTestChain(t)
 
 	cs, csInvalid := getTestContractState(t, 4, 5, random.Uint160()) // sender and IDs are not important for the test
-	ic := bc.newInteropContext(trigger.Verification, bc.dao, nil, nil)
+	ic := bc.newInteropContext(trigger.Verification, bc.dao.GetWrapped(), nil, nil)
 	require.NoError(t, bc.contracts.Management.PutContractState(bc.dao, cs))
 	require.NoError(t, bc.contracts.Management.PutContractState(bc.dao, csInvalid))
 

--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -50,6 +50,7 @@ type DAO interface {
 	GetStorageItemsWithPrefix(id int32, prefix []byte) ([]state.StorageItemWithKey, error)
 	GetTransaction(hash util.Uint256) (*transaction.Transaction, uint32, error)
 	GetVersion() (Version, error)
+	GetCloned() DAO
 	GetWrapped() DAO
 	HasTransaction(hash util.Uint256) error
 	Persist() (int, error)
@@ -100,6 +101,15 @@ func (dao *Simple) GetWrapped() DAO {
 	d := NewSimple(dao.Store, dao.Version.StateRootInHeader, dao.Version.P2PSigExtensions)
 	d.Version = dao.Version
 	return d
+}
+
+// GetCloned returns new DAO instance with shared trie of MemCachedStore, use it for
+// the latest layer that either doesn't need to Persist, or Persists to another well-known
+// non-shared (!) layer.
+func (dao *Simple) GetCloned() DAO {
+	d := *dao
+	d.Store = dao.Store.Clone()
+	return &d
 }
 
 // GetAndDecode performs get operation and decoding with serializable structures.

--- a/pkg/core/interop/context.go
+++ b/pkg/core/interop/context.go
@@ -71,7 +71,7 @@ func NewContext(trigger trigger.Type, bc Ledger, d dao.DAO,
 	getContract func(dao.DAO, util.Uint160) (*state.Contract, error), natives []Contract,
 	block *block.Block, tx *transaction.Transaction, log *zap.Logger) *Context {
 	baseExecFee := int64(DefaultBaseExecFee)
-	dao := d.GetWrapped()
+	dao := d.GetCloned()
 
 	if bc != nil && (block == nil || block.Index != 0) {
 		baseExecFee = bc.GetBaseExecFee()

--- a/pkg/core/storage/memcached_store.go
+++ b/pkg/core/storage/memcached_store.go
@@ -14,6 +14,9 @@ import (
 type MemCachedStore struct {
 	MemoryStore
 
+	// lowerTrie stores lower level MemCachedStore trie for cloned MemCachedStore,
+	// which allows for much more efficient Persist.
+	lowerTrie *btree.BTree
 	// plock protects Persist from double entrance.
 	plock sync.Mutex
 	// Persistent Store.
@@ -52,6 +55,16 @@ func NewMemCachedStore(lower Store) *MemCachedStore {
 	return &MemCachedStore{
 		MemoryStore: *NewMemoryStore(),
 		ps:          lower,
+	}
+}
+
+// NewClonedMemCachedStore creates a cloned MemCachedStore which shares the trie
+// with another MemCachedStore (until you write into it).
+func (s *MemCachedStore) Clone() *MemCachedStore {
+	return &MemCachedStore{
+		MemoryStore: MemoryStore{mem: *s.mem.Clone()}, // Shared COW trie.
+		lowerTrie:   &s.mem,
+		ps:          s.ps, // But the same PS.
 	}
 }
 
@@ -239,6 +252,13 @@ func (s *MemCachedStore) persist(isSync bool) (int, error) {
 	s.plock.Lock()
 	defer s.plock.Unlock()
 	s.mut.Lock()
+
+	if s.lowerTrie != nil {
+		keys = s.mem.Len() - s.lowerTrie.Len()
+		*s.lowerTrie = s.mem
+		s.mut.Unlock()
+		return keys, nil
+	}
 
 	keys = s.mem.Len()
 	if keys == 0 {

--- a/pkg/core/storage/memcached_store_test.go
+++ b/pkg/core/storage/memcached_store_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/google/btree"
 	"github.com/nspcc-dev/neo-go/internal/random"
 	"github.com/nspcc-dev/neo-go/pkg/util/slice"
 	"github.com/stretchr/testify/assert"
@@ -243,8 +244,8 @@ func BenchmarkCachedSeek(t *testing.B) {
 		"MemPS": func(t testing.TB) Store {
 			return NewMemoryStore()
 		},
-		"BoltPS":  newBoltStoreForTesting,
-		"LevelPS": newLevelDBForTesting,
+		//		"BoltPS":  newBoltStoreForTesting,
+		//		"LevelPS": newLevelDBForTesting,
 	}
 	for psName, newPS := range stores {
 		for psCount := 100; psCount <= 10000; psCount *= 10 {
@@ -287,7 +288,7 @@ func (b *BadStore) Put(k, v []byte) error {
 func (b *BadStore) PutBatch(Batch) error {
 	return nil
 }
-func (b *BadStore) PutChangeSet(_ map[string][]byte) error {
+func (b *BadStore) PutChangeSet(_ *btree.BTree) error {
 	b.onPutBatch()
 	return ErrKeyNotFound
 }

--- a/pkg/core/storage/memory_store.go
+++ b/pkg/core/storage/memory_store.go
@@ -2,10 +2,9 @@ package storage
 
 import (
 	"bytes"
-	"sort"
-	"strings"
 	"sync"
 
+	"github.com/google/btree"
 	"github.com/nspcc-dev/neo-go/pkg/util/slice"
 )
 
@@ -13,7 +12,7 @@ import (
 // used for testing. Do not use MemoryStore in production.
 type MemoryStore struct {
 	mut sync.RWMutex
-	mem map[string][]byte
+	mem btree.BTree
 }
 
 // MemoryBatch is an in-memory batch compatible with MemoryStore.
@@ -23,18 +22,18 @@ type MemoryBatch struct {
 
 // Put implements the Batch interface.
 func (b *MemoryBatch) Put(k, v []byte) {
-	b.MemoryStore.put(string(k), slice.Copy(v))
+	b.MemoryStore.put(dupKV(k, v))
 }
 
 // Delete implements Batch interface.
 func (b *MemoryBatch) Delete(k []byte) {
-	b.MemoryStore.drop(string(k))
+	b.MemoryStore.drop(slice.Copy(k))
 }
 
 // NewMemoryStore creates a new MemoryStore object.
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		mem: make(map[string][]byte),
+		mem: *btree.New(16),
 	}
 }
 
@@ -42,37 +41,40 @@ func NewMemoryStore() *MemoryStore {
 func (s *MemoryStore) Get(key []byte) ([]byte, error) {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
-	if val, ok := s.mem[string(key)]; ok && val != nil {
-		return val, nil
+	itm := s.mem.Get(KeyValue{Key: key})
+	if itm != nil {
+		kv := itm.(KeyValue)
+		if kv.Value != nil {
+			return kv.Value, nil
+		}
 	}
 	return nil, ErrKeyNotFound
 }
 
 // put puts a key-value pair into the store, it's supposed to be called
 // with mutex locked.
-func (s *MemoryStore) put(key string, value []byte) {
-	s.mem[key] = value
+func (s *MemoryStore) put(kv KeyValue) {
+	_ = s.mem.ReplaceOrInsert(kv)
 }
 
 // Put implements the Store interface. Never returns an error.
 func (s *MemoryStore) Put(key, value []byte) error {
-	newKey := string(key)
-	vcopy := slice.Copy(value)
+	kv := dupKV(key, value)
 	s.mut.Lock()
-	s.put(newKey, vcopy)
+	s.put(kv)
 	s.mut.Unlock()
 	return nil
 }
 
 // drop deletes a key-value pair from the store, it's supposed to be called
 // with mutex locked.
-func (s *MemoryStore) drop(key string) {
-	s.mem[key] = nil
+func (s *MemoryStore) drop(key []byte) {
+	s.put(KeyValue{Key: key})
 }
 
 // Delete implements Store interface. Never returns an error.
 func (s *MemoryStore) Delete(key []byte) error {
-	newKey := string(key)
+	newKey := slice.Copy(key)
 	s.mut.Lock()
 	s.drop(newKey)
 	s.mut.Unlock()
@@ -82,15 +84,16 @@ func (s *MemoryStore) Delete(key []byte) error {
 // PutBatch implements the Store interface. Never returns an error.
 func (s *MemoryStore) PutBatch(batch Batch) error {
 	b := batch.(*MemoryBatch)
-	return s.PutChangeSet(b.mem)
+	return s.PutChangeSet(&b.mem)
 }
 
 // PutChangeSet implements the Store interface. Never returns an error.
-func (s *MemoryStore) PutChangeSet(puts map[string][]byte) error {
+func (s *MemoryStore) PutChangeSet(puts *btree.BTree) error {
 	s.mut.Lock()
-	for k := range puts {
-		s.put(k, puts[k])
-	}
+	puts.Ascend(func(i btree.Item) bool {
+		s.put(i.(KeyValue))
+		return true
+	})
 	s.mut.Unlock()
 	return nil
 }
@@ -106,49 +109,59 @@ func (s *MemoryStore) Seek(rng SeekRange, f func(k, v []byte) bool) {
 func (s *MemoryStore) SeekAll(key []byte, f func(k, v []byte)) {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
-	sk := string(key)
-	for k, v := range s.mem {
-		if strings.HasPrefix(k, sk) {
-			f([]byte(k), v)
+	s.mem.AscendGreaterOrEqual(KeyValue{Key: key}, func(i btree.Item) bool {
+		kv := i.(KeyValue)
+		if !bytes.HasPrefix(kv.Key, key) {
+			return false
+		}
+		f(kv.Key, kv.Value)
+		return true
+	})
+}
+
+// getSeekPairs returns KV pairs for current Seek.
+func (s *MemoryStore) getSeekPairs(rng SeekRange) []KeyValue {
+	lPrefix := len(rng.Prefix)
+	lStart := len(rng.Start)
+
+	var pivot KeyValue
+	pivot.Key = make([]byte, lPrefix+lStart, lPrefix+lStart+1)
+	copy(pivot.Key, rng.Prefix)
+	if lStart != 0 {
+		copy(pivot.Key[lPrefix:], rng.Start)
+	}
+
+	var memList []KeyValue
+	var appender = func(i btree.Item) bool {
+		kv := i.(KeyValue)
+		if !bytes.HasPrefix(kv.Key, rng.Prefix) {
+			return false
+		}
+		memList = append(memList, kv)
+		return true
+	}
+
+	if !rng.Backwards {
+		s.mem.AscendGreaterOrEqual(pivot, appender)
+	} else {
+		if lStart != 0 {
+			pivot.Key = append(pivot.Key, 0) // Right after the start key.
+			s.mem.AscendRange(KeyValue{Key: rng.Prefix}, pivot, appender)
+		} else {
+			s.mem.AscendGreaterOrEqual(KeyValue{Key: rng.Prefix}, appender)
+		}
+		for i, j := 0, len(memList)-1; i <= j; i, j = i+1, j-1 {
+			memList[i], memList[j] = memList[j], memList[i]
 		}
 	}
+	return memList
 }
 
 // seek is an internal unlocked implementation of Seek. `start` denotes whether
 // seeking starting from the provided prefix should be performed. Backwards
 // seeking from some point is supported with corresponding SeekRange field set.
 func (s *MemoryStore) seek(rng SeekRange, f func(k, v []byte) bool) {
-	sPrefix := string(rng.Prefix)
-	lPrefix := len(sPrefix)
-	sStart := string(rng.Start)
-	lStart := len(sStart)
-	var memList []KeyValue
-
-	isKeyOK := func(key string) bool {
-		return strings.HasPrefix(key, sPrefix) && (lStart == 0 || strings.Compare(key[lPrefix:], sStart) >= 0)
-	}
-	if rng.Backwards {
-		isKeyOK = func(key string) bool {
-			return strings.HasPrefix(key, sPrefix) && (lStart == 0 || strings.Compare(key[lPrefix:], sStart) <= 0)
-		}
-	}
-	less := func(k1, k2 []byte) bool {
-		res := bytes.Compare(k1, k2)
-		return res != 0 && rng.Backwards == (res > 0)
-	}
-
-	for k, v := range s.mem {
-		if v != nil && isKeyOK(k) {
-			memList = append(memList, KeyValue{
-				Key:   []byte(k),
-				Value: v,
-			})
-		}
-	}
-	sort.Slice(memList, func(i, j int) bool {
-		return less(memList[i].Key, memList[j].Key)
-	})
-	for _, kv := range memList {
+	for _, kv := range s.getSeekPairs(rng) {
 		if !f(kv.Key, kv.Value) {
 			break
 		}
@@ -169,7 +182,20 @@ func newMemoryBatch() *MemoryBatch {
 // error.
 func (s *MemoryStore) Close() error {
 	s.mut.Lock()
-	s.mem = nil
+	s.mem.Clear(false)
 	s.mut.Unlock()
 	return nil
+}
+
+func dupKV(key []byte, value []byte) KeyValue {
+	var res KeyValue
+
+	s := make([]byte, len(key)+len(value))
+	copy(s, key)
+	res.Key = s[:len(key)]
+	if value != nil {
+		copy(s[len(key):], value)
+		res.Value = s[len(key):]
+	}
+	return res
 }

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
+	"github.com/google/btree"
 )
 
 // KeyPrefix constants.
@@ -88,7 +90,7 @@ type (
 		Put(k, v []byte) error
 		PutBatch(Batch) error
 		// PutChangeSet allows to push prepared changeset to the Store.
-		PutChangeSet(puts map[string][]byte) error
+		PutChangeSet(puts *btree.BTree) error
 		// Seek can guarantee that provided key (k) and value (v) are the only valid until the next call to f.
 		// Seek continues iteration until false is returned from f.
 		// Key and value slices should not be modified.


### PR DESCRIPTION
Closes #2361. Benchmarks are there, but they're showing different dynamics for different tests which is very annoying, there is no clear winner, so this can't be merged right away. We can of course try separating things that need to be sorted from things that don't in the MemoryStorage itself, but that seems like a big kludge.