### PR TITLE
core: remove stale transfer entries, fix #2096

### DIFF
--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -33,7 +33,6 @@ const (
 	SYSStateSyncCurrentBlockHeight KeyPrefix = 0xc2
 	SYSStateSyncPoint              KeyPrefix = 0xc3
 	SYSStateJumpStage              KeyPrefix = 0xc4
-	SYSCleanStorage                KeyPrefix = 0xc5
 	SYSVersion                     KeyPrefix = 0xf0
 )
 

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -16,7 +16,6 @@ const (
 	// DataMPTAux is used to store additional MPT data like height-root
 	// mappings and local/validated heights.
 	DataMPTAux   KeyPrefix = 0x04
-	STAccount    KeyPrefix = 0x40
 	STContractID KeyPrefix = 0x51
 	STStorage    KeyPrefix = 0x70
 	// STTempStorage is used to store contract storage items during state sync process

--- a/pkg/core/storage/store_test.go
+++ b/pkg/core/storage/store_test.go
@@ -10,7 +10,7 @@ import (
 var (
 	prefixes = []KeyPrefix{
 		DataExecutable,
-		STAccount,
+		DataMPT,
 		STStorage,
 		IXHeaderHashList,
 		SYSCurrentBlock,
@@ -20,7 +20,7 @@ var (
 
 	expected = []uint8{
 		0x01,
-		0x40,
+		0x03,
 		0x70,
 		0x80,
 		0xc0,
@@ -49,12 +49,12 @@ func TestBatchToOperations(t *testing.T) {
 	b := &MemBatch{
 		Put: []KeyValueExists{
 			{KeyValue: KeyValue{Key: []byte{byte(STStorage), 0x01}, Value: []byte{0x01}}},
-			{KeyValue: KeyValue{Key: []byte{byte(STAccount), 0x02}, Value: []byte{0x02}}},
+			{KeyValue: KeyValue{Key: []byte{byte(DataMPT), 0x02}, Value: []byte{0x02}}},
 			{KeyValue: KeyValue{Key: []byte{byte(STStorage), 0x03}, Value: []byte{0x03}}, Exists: true},
 		},
 		Deleted: []KeyValueExists{
 			{KeyValue: KeyValue{Key: []byte{byte(STStorage), 0x04}, Value: []byte{0x04}}},
-			{KeyValue: KeyValue{Key: []byte{byte(STAccount), 0x05}, Value: []byte{0x05}}},
+			{KeyValue: KeyValue{Key: []byte{byte(DataMPT), 0x05}, Value: []byte{0x05}}},
 			{KeyValue: KeyValue{Key: []byte{byte(STStorage), 0x06}, Value: []byte{0x06}}, Exists: true},
 		},
 	}


### PR DESCRIPTION
Initially I thought of doing it in the next persist cycle, but testing shows
that it needs just ~2-5% of the time MPT GC does, so doing it in the same
cycle doesn't affect anything.

Also, for the record, we've got just slightly more than 33K entries after mainnet's 1050K blocks processing with MaxTraceableBlocks of 10K.