### PR TITLE
Revert "Makefile: add `unsupported` to docker windows image tag and b…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,8 @@ UNITWORKDIR = "/var/lib/neo-go"
 
 DC_FILE=.docker/docker-compose.yml
 
-GOOS ?= $(shell go env GOOS)
 REPO ?= "$(shell go list -m)"
-VERSION ?= "$(shell git describe --tags 2>/dev/null | sed 's/^v//')$(shell if [ "$(GOOS)" = "windows" ]; then echo "_unsupported"; fi)"
+VERSION ?= "$(shell git describe --tags 2>/dev/null | sed 's/^v//')"
 MODVERSION ?= "$(shell cat go.mod | cat go.mod | sed -r -n -e 's|.*pkg/interop (.*)|\1|p')"
 BUILD_FLAGS = "-X '$(REPO)/pkg/config.Version=$(VERSION)' -X '$(REPO)/cli/smartcontract.ModVersion=$(MODVERSION)'"
 


### PR DESCRIPTION
…in version"

This reverts commit 6d28e7534c4f40568c7e013466bb4d58a5c9b4f2. It's no longer
relevant after #2353 and #2365.
