### PR TITLE
Return error on negative instruction pointer in `Context.Next`

### DIFF
--- a/pkg/vm/context.go
+++ b/pkg/vm/context.go
@@ -95,6 +95,9 @@ func (c *Context) Next() (opcode.Opcode, []byte, error) {
 	var err error
 
 	c.ip = c.nextip
+	if c.ip < 0 {
+		return 0, nil, errors.New("invalid instruction offset")
+	}
 	if c.ip >= len(c.prog) {
 		return opcode.RET, nil, nil
 	}

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1385,6 +1385,17 @@ func TestKEYS(t *testing.T) {
 	t.Run("WrongType", getTestFuncForVM(prog, nil, []stackitem.Item{}))
 }
 
+func TestTry_ENDFINALLY_before_ENDTRY(t *testing.T) {
+	prog := makeProgram(opcode.TRY, 0, 3, opcode.ENDFINALLY)
+	require.NoError(t, IsScriptCorrect(prog, nil))
+
+	v := load(prog)
+
+	var err error
+	require.NotPanics(t, func() { err = v.Run() })
+	require.Error(t, err)
+}
+
 func TestVALUESMap(t *testing.T) {
 	prog := makeProgram(opcode.VALUES)
 	vm := load(prog)


### PR DESCRIPTION
Check instruction offset to be positive. C# node is not affected, because everything is executed in `try/catch` block. I will create a PR to update JSON tests there.

I think we can't do this in `IsScriptCorrect`, because this is inherently about runtime execution flow.