### PR TITLE
block/dao: simplify trimming, avoid allocations

### DIFF
--- a/pkg/core/block/block_test.go
+++ b/pkg/core/block/block_test.go
@@ -55,10 +55,11 @@ func TestDecodeBlock1(t *testing.T) {
 func TestTrimmedBlock(t *testing.T) {
 	block := getDecodedBlock(t, 1)
 
-	b, err := block.Trim()
-	require.NoError(t, err)
+	buf := io.NewBufBinWriter()
+	block.EncodeTrimmed(buf.BinWriter)
+	require.NoError(t, buf.Err)
 
-	r := io.NewBinReaderFromBuf(b)
+	r := io.NewBinReaderFromBuf(buf.Bytes())
 	trimmedBlock, err := NewTrimmedFromReader(false, r)
 	require.NoError(t, err)
 

--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -648,11 +648,7 @@ func (dao *Simple) StoreAsBlock(block *block.Block, aer1 *state.AppExecResult, a
 		buf = dao.getDataBuf()
 	)
 	buf.WriteB(storage.ExecBlock)
-	b, err := block.Trim()
-	if err != nil {
-		return err
-	}
-	buf.WriteBytes(b)
+	block.EncodeTrimmed(buf.BinWriter)
 	if aer1 != nil {
 		aer1.EncodeBinary(buf.BinWriter)
 	}


### PR DESCRIPTION
The only user of (*Block).Trim() is in DAO and it already has a nice buffer
usually, so creating another one makes no sense. It also simplifies error
handling a lot.
