### PR TITLE
github: adjust Docker image publishing workflows

### DIFF
--- a/.github/workflows/publish_to_dockerhub.yml
+++ b/.github/workflows/publish_to_dockerhub.yml
@@ -73,6 +73,11 @@ jobs:
           # Allows to fetch all history for all branches and tags. Need this for proper versioning.
           fetch-depth: 0
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+
       - name: Build image
         run: make image
 
@@ -140,6 +145,11 @@ jobs:
 
       - name: Show docker images
         run: docker images
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
 
       - name: Build image
         run: make image-wsc


### PR DESCRIPTION
### Problem
Failing Publish workflow run (https://github.com/nspcc-dev/neo-go/runs/5627943309?check_suite_focus=true:
```
Run make image
go mod tidy: go.mod file indicates go 1.1[6](https://github.com/nspcc-dev/neo-go/runs/5627943309?check_suite_focus=true#step:3:6), but maximum supported version is 1.15
make: *** [Makefile:[8](https://github.com/nspcc-dev/neo-go/runs/5627943309?check_suite_focus=true#step:3:8)1: deps] Error 1
Error: Process completed with exit code 2.
```

### Solution

Upgrade runner go version.
