### PR TITLE
Update generate-wrapper usage text to reflect requirements

### DIFF
--- a/cli/smartcontract/generate.go
+++ b/cli/smartcontract/generate.go
@@ -14,7 +14,7 @@ import (
 var generateWrapperCmd = cli.Command{
 	Name:        "generate-wrapper",
 	Usage:       "generate wrapper to use in other contracts",
-	UsageText:   "neo-go contract generate-wrapper --manifest manifest.json --out file.go",
+	UsageText:   "neo-go contract generate-wrapper --manifest <file.json> --out <file.go> --hash <hash>",
 	Description: ``,
 	Action:      contractGenerateWrapper,
 	Flags: []cli.Flag{


### PR DESCRIPTION
### Problem

The usage text to the new `contract generate-wrapper` command suggested to me that you can call it without the `--hash` parameter

> USAGE:
   neo-go contract generate-wrapper --manifest manifest.json --out file.go

but when doing so you get an invalid contract hash error

> ./neo-go contract generate-wrapper --manifest ../../demo/boa/cpm/mycontract.manifest.json --out bla
invalid contract hash: expected string size of 40 got 0

### Solution

update usage text
