### PR TITLE
interop: add a physical copy of LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2018 Anthony De Meulemeester (@anthdm) & City of Zion community (@CityOfZion)
+Copyright (c) 2018-2022 Anthony De Meulemeester (@anthdm), City of Zion
+community (@CityOfZion), NeoSPCC (@nspcc-dev)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/interop/LICENSE.md
+++ b/pkg/interop/LICENSE.md
@@ -1,1 +1,21 @@
-../../LICENSE.md
+MIT License
+
+Copyright (c) 2018 Anthony De Meulemeester (@anthdm) & City of Zion community (@CityOfZion)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/interop/LICENSE.md
+++ b/pkg/interop/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2018 Anthony De Meulemeester (@anthdm) & City of Zion community (@CityOfZion)
+Copyright (c) 2018-2022 Anthony De Meulemeester (@anthdm), City of Zion
+community (@CityOfZion), NeoSPCC (@nspcc-dev)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Seems like pkg.go.dev can't pick it up from the symlink.

