### PR TITLE
rpc: avoid panic on double-call to *WSClient.Close()

### DIFF
--- a/pkg/rpc/client/wsclient_test.go
+++ b/pkg/rpc/client/wsclient_test.go
@@ -441,3 +441,15 @@ func TestWSConcurrentAccess(t *testing.T) {
 		batchCount*3+1) // batchCount*requestsPerBatch+1
 	wsc.Close()
 }
+
+func TestWSDoubleClose(t *testing.T) {
+	srv := initTestServer(t, "")
+
+	c, err := NewWS(context.TODO(), httpURLtoWS(srv.URL), Options{})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		c.Close()
+		c.Close()
+	})
+}


### PR DESCRIPTION
Although it's the caller's duty to avoid WSClient re-closing, we
still can handle it.

Fixes the following neofs-node error:
```
panic: close of closed channel

goroutine 98 [running]:
github.com/nspcc-dev/neo-go/pkg/rpc/client.(*WSClient).Close(...)
        github.com/nspcc-dev/neo-go@v0.98.3-pre.0.20220321144433-3b639f518ebb/pkg/rpc/client/wsclient.go:120
github.com/nspcc-dev/neofs-node/pkg/morph/subscriber.(*subscriber).Close(0x13)
        github.com/nspcc-dev/neofs-node/pkg/morph/subscriber/subscriber.go:108 +0x29
github.com/nspcc-dev/neofs-node/pkg/morph/event.listener.Stop(...)
        github.com/nspcc-dev/neofs-node/pkg/morph/event/listener.go:573
created by github.com/nspcc-dev/neofs-node/pkg/innerring.(*Server).Stop
        github.com/nspcc-dev/neofs-node/pkg/innerring/innerring.go:285 +0x12f
```