### PR TITLE
Add hash to debug info and use absolute path

### DIFF
--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
-	"path/filepath"
 	"strings"
 
 	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
@@ -235,11 +234,6 @@ func (c *codegen) fillDocumentInfo() {
 	fset := c.buildInfo.config.Fset
 	fset.Iterate(func(f *token.File) bool {
 		filePath := f.Position(f.Pos(0)).Filename
-		rel, err := filepath.Rel(c.buildInfo.config.Dir, filePath)
-		// It's OK if we can't construct relative path, e.g. for interop dependencies.
-		if err == nil {
-			filePath = rel
-		}
 		c.docIndex[filePath] = len(c.documents)
 		c.documents = append(c.documents, filePath)
 		return true

--- a/pkg/compiler/debug.go
+++ b/pkg/compiler/debug.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/binding"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
@@ -22,6 +23,7 @@ import (
 // DebugInfo represents smart-contract debug information.
 type DebugInfo struct {
 	MainPkg   string            `json:"-"`
+	Hash      util.Uint160      `json:"hash"`
 	Documents []string          `json:"documents"`
 	Methods   []MethodDebugInfo `json:"methods"`
 	Events    []EventDebugInfo  `json:"events"`
@@ -125,6 +127,7 @@ func (c *codegen) saveSequencePoint(n ast.Node) {
 
 func (c *codegen) emitDebugInfo(contract []byte) *DebugInfo {
 	d := &DebugInfo{
+		Hash:            hash.Hash160(contract),
 		MainPkg:         c.mainPkg.Name,
 		Events:          []EventDebugInfo{},
 		Documents:       c.documents,


### PR DESCRIPTION
### Problem

neo-debugger doesn't work with 0.98.2.

### Solution

Most of the problems solved here.
