### PR TITLE
rpc: adjust `getversion` RPC response

### DIFF
--- a/pkg/rpc/response/result/version.go
+++ b/pkg/rpc/response/result/version.go
@@ -2,7 +2,6 @@ package result
 
 import (
 	"github.com/nspcc-dev/neo-go/pkg/config/netmode"
-	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
 )
 
 type (
@@ -32,7 +31,7 @@ type (
 		MaxTransactionsPerBlock     uint16        `json:"maxtransactionsperblock"`
 		MemoryPoolMaxTransactions   int           `json:"memorypoolmaxtransactions"`
 		ValidatorsCount             byte          `json:"validatorscount"`
-		InitialGasDistribution      fixedn.Fixed8 `json:"initialgasdistribution"`
+		InitialGasDistribution      int64         `json:"initialgasdistribution"`
 		// StateRootInHeader is true if state root is contained in block header.
 		StateRootInHeader bool `json:"staterootinheader,omitempty"`
 	}

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -537,7 +537,7 @@ func (s *Server) getVersion(_ request.Params) (interface{}, *response.Error) {
 			MaxTransactionsPerBlock:     cfg.MaxTransactionsPerBlock,
 			MemoryPoolMaxTransactions:   cfg.MemPoolSize,
 			ValidatorsCount:             byte(cfg.GetNumOfCNs(s.chain.BlockHeight())),
-			InitialGasDistribution:      cfg.InitialGASSupply,
+			InitialGasDistribution:      int64(cfg.InitialGASSupply),
 			StateRootInHeader:           cfg.StateRootInHeader,
 		},
 	}, nil


### PR DESCRIPTION
Reference implementation includes `initialgasdistribution` as integer
value with decimals.

C# response:
```
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": {
        "nonce": 1677922561,
        "protocol": {
            "addressversion": 53,
            "initialgasdistribution": 5200000000000000,
            "maxtraceableblocks": 2102400,
            "maxtransactionsperblock": 512,
            "maxvaliduntilblockincrement": 5760,
            "memorypoolmaxtransactions": 50000,
            "msperblock": 15000,
            "network": 860833102,
            "validatorscount": 7
        },
        "tcpport": 10333,
        "useragent": "/Neo:3.1.0/",
        "wsport": 10334
    }
}
```

Neo-Go response:
```
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": {
        "network": 860833102,
        "nonce": 2847278838,
        "protocol": {
            "addressversion": 53,
            "initialgasdistribution": "52000000",
            "maxtraceableblocks": 2102400,
            "maxtransactionsperblock": 512,
            "maxvaliduntilblockincrement": 5760,
            "memorypoolmaxtransactions": 50000,
            "msperblock": 15000,
            "network": 860833102,
            "validatorscount": 7
        },
        "tcpport": 10333,
        "useragent": "/NEO-GO:0.98.2/"
    }
}
```