### PR TITLE
core: fix broken stateroot storage

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -46,7 +46,7 @@ import (
 // Tuning parameters.
 const (
 	headerBatchCount = 2000
-	version          = "0.2.5"
+	version          = "0.2.6"
 
 	defaultInitialGAS                      = 52000000_00000000
 	defaultGCPeriod                        = 10000

--- a/pkg/core/blockchain_neotest_test.go
+++ b/pkg/core/blockchain_neotest_test.go
@@ -277,7 +277,7 @@ func TestBlockchain_StartFromExistingDB(t *testing.T) {
 		cache := storage.NewMemCachedStore(ps) // Extra wrapper to avoid good DB corruption.
 		key := make([]byte, 5)
 		key[0] = byte(storage.DataMPTAux)
-		binary.BigEndian.PutUint32(key, h)
+		binary.BigEndian.PutUint32(key[1:], h)
 		cache.Delete(key)
 
 		_, _, _, err := chain.NewMultiWithCustomConfigAndStoreNoCheck(t, customConfig, cache)

--- a/pkg/core/stateroot/store.go
+++ b/pkg/core/stateroot/store.go
@@ -51,7 +51,7 @@ func (s *Module) getStateRoot(key []byte) (*state.MPTRoot, error) {
 func makeStateRootKey(index uint32) []byte {
 	key := make([]byte, 5)
 	key[0] = byte(storage.DataMPTAux)
-	binary.BigEndian.PutUint32(key, index)
+	binary.BigEndian.PutUint32(key[1:], index)
 	return key
 }
 


### PR DESCRIPTION
Store stateroot by DataMPTAux prefix instead of storing it by index only.

Costs me a lot...