### PR TITLE
core: consider Rules witness scope as valid

### DIFF
--- a/pkg/core/transaction/signer.go
+++ b/pkg/core/transaction/signer.go
@@ -39,7 +39,7 @@ func (c *Signer) EncodeBinary(bw *io.BinWriter) {
 func (c *Signer) DecodeBinary(br *io.BinReader) {
 	br.ReadBytes(c.Account[:])
 	c.Scopes = WitnessScope(br.ReadB())
-	if c.Scopes & ^(Global|CalledByEntry|CustomContracts|CustomGroups|None) != 0 {
+	if c.Scopes & ^(Global|CalledByEntry|CustomContracts|CustomGroups|Rules|None) != 0 {
 		br.Err = errors.New("unknown witness scope")
 		return
 	}

--- a/pkg/core/transaction/signer_test.go
+++ b/pkg/core/transaction/signer_test.go
@@ -4,14 +4,20 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/internal/testserdes"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCosignerEncodeDecode(t *testing.T) {
+	pk, err := keys.NewPrivateKey()
+	require.NoError(t, err)
 	expected := &Signer{
 		Account:          util.Uint160{1, 2, 3, 4, 5},
-		Scopes:           CustomContracts,
+		Scopes:           CustomContracts | CustomGroups | Rules,
 		AllowedContracts: []util.Uint160{{1, 2, 3, 4}, {6, 7, 8, 9}},
+		AllowedGroups:    []*keys.PublicKey{pk.PublicKey()},
+		Rules:            []WitnessRule{{Action: WitnessAllow, Condition: ConditionCalledByEntry{}}},
 	}
 	actual := &Signer{}
 	testserdes.EncodeDecodeBinary(t, expected, actual)


### PR DESCRIPTION
### Problem

Transaction with Rules witness scope can't be decoded due to the following error:
```
Error:      	Received unexpected error:
        	     unknown witness scope
```
