### PR TITLE
rpc: move latest getversion compat to 0.98.3

### DIFF
--- a/pkg/rpc/response/result/version.go
+++ b/pkg/rpc/response/result/version.go
@@ -98,7 +98,7 @@ type (
 
 // latestNonBreakingVersion is a latest NeoGo revision that keeps older RPC
 // clients compatibility with newer RPC servers (https://github.com/nspcc-dev/neo-go/pull/2435).
-var latestNonBreakingVersion = *semver.New("0.98.2")
+var latestNonBreakingVersion = *semver.New("0.98.3")
 
 // MarshalJSON implements the json marshaller interface.
 func (v *Version) MarshalJSON() ([]byte, error) {

--- a/pkg/rpc/response/result/version_test.go
+++ b/pkg/rpc/response/result/version_test.go
@@ -42,7 +42,7 @@ func TestVersion_MarshalUnmarshalJSON(t *testing.T) {
             "validatorscount": 7
         },
         "tcpport": 10333,
-        "useragent": "/NEO-GO:0.98.3/",
+        "useragent": "/NEO-GO:0.98.4/",
         "wsport": 10334
     }`
 	responseFromSharp := `{
@@ -67,7 +67,7 @@ func TestVersion_MarshalUnmarshalJSON(t *testing.T) {
 		TCPPort:   10333,
 		WSPort:    10334,
 		Nonce:     1677922561,
-		UserAgent: "/NEO-GO:0.98.3/",
+		UserAgent: "/NEO-GO:0.98.4/",
 		Protocol: Protocol{
 			AddressVersion:              53,
 			Network:                     860833102,
@@ -123,12 +123,12 @@ func TestVersionFromUserAgent(t *testing.T) {
 	}
 	var testcases = map[string]testCase{
 		"/Neo:3.1.0/":               {success: false},
-		"/NEO-GO:0.98.4":            {success: true, cmpWithBreaking: 1},
+		"/NEO-GO:0.98.5":            {success: true, cmpWithBreaking: 1},
 		"/NEO-GO:0.98.4-pre-12344/": {success: true, cmpWithBreaking: 1},
-		"/NEO-GO:0.98.3/":           {success: true, cmpWithBreaking: 1},
-		"/NEO-GO:0.98.3-pre-123/":   {success: true, cmpWithBreaking: 1},
-		"/NEO-GO:0.98.2/":           {success: true, cmpWithBreaking: 0},
-		"/NEO-GO:0.98.2-pre-12345/": {success: true, cmpWithBreaking: -1},
+		"/NEO-GO:0.98.4/":           {success: true, cmpWithBreaking: 1},
+		"/NEO-GO:0.98.4-pre-123/":   {success: true, cmpWithBreaking: 1},
+		"/NEO-GO:0.98.3/":           {success: true, cmpWithBreaking: 0},
+		"/NEO-GO:0.98.3-pre-12345/": {success: true, cmpWithBreaking: -1},
 		"/NEO-GO:123456":            {success: false},
 	}
 	for str, tc := range testcases {

--- a/pkg/rpc/server/server_helper_test.go
+++ b/pkg/rpc/server/server_helper_test.go
@@ -102,7 +102,7 @@ func initClearServerWithServices(t testing.TB, needOracle bool, needNotary bool)
 	chain, orc, cfg, logger := getUnitTestChain(t, needOracle, needNotary)
 
 	serverConfig := network.NewServerConfig(cfg)
-	serverConfig.UserAgent = fmt.Sprintf(config.UserAgentFormat, "0.98.3-test")
+	serverConfig.UserAgent = fmt.Sprintf(config.UserAgentFormat, "0.98.4-test")
 	serverConfig.Port = 0
 	server, err := network.NewServer(serverConfig, chain, chain.GetStateSyncModule(), logger)
 	require.NoError(t, err)

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -851,7 +851,7 @@ var rpcTestCases = map[string][]rpcTestCase{
 			check: func(t *testing.T, e *executor, ver interface{}) {
 				resp, ok := ver.(*result.Version)
 				require.True(t, ok)
-				require.Equal(t, "/NEO-GO:0.98.3-test/", resp.UserAgent)
+				require.Equal(t, "/NEO-GO:0.98.4-test/", resp.UserAgent)
 
 				cfg := e.chain.GetConfig()
 				require.EqualValues(t, address.NEO3Prefix, resp.Protocol.AddressVersion)
@@ -2984,7 +2984,7 @@ func BenchmarkHandleIn(b *testing.B) {
 	chain, orc, cfg, logger := getUnitTestChain(b, false, false)
 
 	serverConfig := network.NewServerConfig(cfg)
-	serverConfig.UserAgent = fmt.Sprintf(config.UserAgentFormat, "0.98.3-test")
+	serverConfig.UserAgent = fmt.Sprintf(config.UserAgentFormat, "0.98.4-test")
 	serverConfig.LogLevel = zapcore.FatalLevel
 	server, err := network.NewServer(serverConfig, chain, chain.GetStateSyncModule(), logger)
 	require.NoError(b, err)


### PR DESCRIPTION
Version 0.98.3 is officially released with the old behavior.
