### PR TITLE
Improve compare-states.go script

### DIFF
--- a/scripts/compare-states/compare-states.go
+++ b/scripts/compare-states/compare-states.go
@@ -133,7 +133,7 @@ func cliMain(c *cli.Context) error {
 		})
 		fmt.Println(diff)
 	}
-	return nil
+	return errors.New("different state found")
 }
 
 func main() {
@@ -145,7 +145,6 @@ func main() {
 
 	if err := ctl.Run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		fmt.Fprintln(os.Stderr, ctl.Usage)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Make it usable as a status checker, returning 0 if everything is fine and 1 (with relevant output) otherwise.