### PR TITLE
rpc: check transaction for validness before network fee calculation

### DIFF
--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -226,10 +226,6 @@ func (t *Transaction) EncodeBinary(bw *io.BinWriter) {
 // encodeHashableFields encodes the fields that are not used for
 // signing the transaction, which are all fields except the scripts.
 func (t *Transaction) encodeHashableFields(bw *io.BinWriter) {
-	if len(t.Script) == 0 {
-		bw.Err = errors.New("transaction has no script")
-		return
-	}
 	bw.WriteB(byte(t.Version))
 	bw.WriteU32LE(t.Nonce)
 	bw.WriteU64LE(uint64(t.SystemFee))

--- a/pkg/core/transaction/transaction_test.go
+++ b/pkg/core/transaction/transaction_test.go
@@ -109,7 +109,7 @@ func TestNewTransactionFromBytes(t *testing.T) {
 
 func TestEncodingTXWithNoScript(t *testing.T) {
 	_, err := testserdes.EncodeBinary(new(Transaction))
-	require.Error(t, err)
+	require.NoError(t, err) // Garbage in -> garbage out.
 }
 
 func TestDecodingTXWithNoScript(t *testing.T) {


### PR DESCRIPTION
Allows to avoid panic:
```
(18:28:29)[sergio@transient:morph-control-load]% downloads/neofs-adm morph -c configuration/config.yaml init --contracts downloads/neofs-contract-v0.15.1
Stage 1: transfer GAS to alphabet nodes.
Waiting for transactions to persist...
Stage 2: set notary and alphabet nodes in designate contract.
Stage 2: already performed.
Stage 3: deploy NNS contract.
NNS contract is already deployed.
Stage 4: deploy NeoFS contracts.
Alphabet contract #0 is already deployed.
Alphabet contract #1 is already deployed.
Alphabet contract #2 is already deployed.
Alphabet contract #3 is already deployed.
audit contract is already deployed.
balance contract is already deployed.
container contract is already deployed.
neofsid contract is already deployed.
netmap contract is already deployed.
proxy contract is already deployed.
reputation contract is already deployed.
subnet contract is already deployed.
Waiting for transactions to persist...
Stage 4.1: Transfer GAS to proxy contract.
Stage 5: register candidates.
Stage 6: transfer NEO to alphabet contracts.
Stage 7: set addresses in NNS.
NNS: Set alphabet0.neofs -> 2efeb27866fa774ec6bfb43babaadcc7b28f9bb7
NNS: Set alphabet1.neofs -> 5606bc6598a538ac59ded3caa842247b9b26097a
NNS: Set alphabet2.neofs -> 2a8308cfd2706ddd5f67adfdf3954c6836806b5d
NNS: Set alphabet3.neofs -> 718d0459e6787f0f13f1e1898bf2ce6bc4bb452d
NNS: Set audit.neofs -> 54d516b36c3380efa2b2f26bda300b6c6302b8e7
NNS: Set balance.neofs -> 72b3255944524cb822788a7542c9d06cba208c0c
NNS: Set container.neofs -> 20a20f4352a49f161eccb7d5a806fd46dcab81ea
NNS: Set neofsid.neofs -> 04a3a71535689b820093cefe7ae188ed7591ad27
NNS: Set netmap.neofs -> 9a34c97b2ba6bd986fd9140a9c3d59059fa430f4
NNS: Set proxy.neofs -> 4eba34ec016f8709a511b02765a1195e31a921ea
NNS: Set reputation.neofs -> 77b5b2cf596957cc05ca3d57503ef08d72792301
NNS: Set subnet.neofs -> b0abe16bc7f56b2e7e0694ae2b36207c6aaa8636
panic: error serializing *transaction.Transaction: transaction has no script

goroutine 1 [running]:
github.com/nspcc-dev/neo-go/pkg/io.GetVarSize({0xbf6240, 0xc0003634a0})
	github.com/nspcc-dev/neo-go@v0.98.2/pkg/io/size.go:68 +0x6fd
github.com/nspcc-dev/neo-go/pkg/rpc/client.(*Client).AddNetworkFee(0xc0004080c0, 0xc0003634a0, 0x0, {0xc00000e248, 0x1, 0x93})
	github.com/nspcc-dev/neo-go@v0.98.2/pkg/rpc/client/rpc.go:966 +0x6b
github.com/nspcc-dev/neo-go/pkg/rpc/client.(*Client).CreateTxFromScript(0x0, {0x0, 0x0, 0x0}, 0x1, 0x0, 0x0, {0xc0001c7990, 0x1, 0x1})
	github.com/nspcc-dev/neo-go@v0.98.2/pkg/rpc/client/nep17.go:128 +0x345
github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules/morph.(*initializeContext).sendCommitteeTx(0xc00014a370, {0x0, 0x0, 0x0}, 0xc0016bcf30, 0x2)
	github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules/morph/initialize.go:336 +0x131
github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules/morph.(*initializeContext).updateNNSGroup(0xc0001c7c88, {0x13, 0xd3, 0x6b, 0x85, 0x3e, 0x86, 0xbe, 0x77, 0xb7, ...}, ...)
	github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules/morph/initialize_nns.go:89 +0x134
github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules/morph.(*initializeContext).setNNS(0xc00014a370)
	github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules/morph/initialize_nns.go:74 +0x8c5
github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules/morph.initializeSideChainCmd(0x12a00e0, {0xc22a22, 0x4, 0x4})
	github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules/morph/initialize.go:94 +0x2bc
github.com/spf13/cobra.(*Command).execute(0x12a00e0, {0xc00013a6c0, 0x4, 0x4})
	github.com/spf13/cobra@v1.1.3/command.go:852 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0x129c760)
	github.com/spf13/cobra@v1.1.3/command.go:960 +0x3ad
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.1.3/command.go:897
github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules.Execute(...)
	github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules/root.go:48
main.main()
	github.com/nspcc-dev/neofs-node/cmd/neofs-adm/main.go:10 +0x25
zsh: exit 2     downloads/neofs-adm morph -c configuration/config.yaml init --contracts
```