### PR TITLE
config: set Aspidochelone hard fork for mainnet

### DIFF
--- a/config/protocol.mainnet.yml
+++ b/config/protocol.mainnet.yml
@@ -36,6 +36,8 @@ ProtocolConfiguration:
   VerifyBlocks: true
   VerifyTransactions: false
   P2PSigExtensions: false
+  Hardforks:
+    HF_Aspidochelone: 2000000
   NativeActivations:
     ContractManagement: [0]
     StdLib: [0]


### PR DESCRIPTION
See neo-project/neo-node#862. It's not yet official, but this change makes
testing against mainnet dumps easier for now.
