### PR TITLE
core: sort native methods in ASCII-compatible way

### DIFF
--- a/pkg/core/interop/context.go
+++ b/pkg/core/interop/context.go
@@ -207,7 +207,7 @@ func (c *ContractMD) AddMethod(md *MethodAndPrice, desc *manifest.Method) {
 	index := sort.Search(len(c.Manifest.ABI.Methods), func(i int) bool {
 		md := c.Manifest.ABI.Methods[i]
 		if md.Name != desc.Name {
-			return strings.ToLower(md.Name) >= strings.ToLower(desc.Name)
+			return md.Name >= desc.Name
 		}
 		return len(md.Parameters) > len(desc.Parameters)
 	})
@@ -236,7 +236,7 @@ func (c *ContractMD) GetMethodByOffset(offset int) (MethodAndPrice, bool) {
 func (c *ContractMD) GetMethod(name string, paramCount int) (MethodAndPrice, bool) {
 	index := sort.Search(len(c.Methods), func(i int) bool {
 		md := c.Methods[i]
-		res := strings.Compare(strings.ToLower(name), strings.ToLower(md.MD.Name))
+		res := strings.Compare(name, md.MD.Name)
 		switch res {
 		case -1, 1:
 			return res == -1

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -75,7 +75,7 @@ const (
 	nfsoContractHash           = "c7ec8e0fb4d669913e4ffdd4ba4fa3502e5d2d10"
 	nfsoToken1ID               = "7e244ffd6aa85fb1579d2ed22e9b761ab62e3486"
 	invokescriptContractAVM    = "VwIADBQBDAMOBQYMDQIODw0DDgcJAAAAAErZMCQE2zBwaEH4J+yMqiYEEUAMFA0PAwIJAAIBAwcDBAUCAQAOBgwJStkwJATbMHFpQfgn7IyqJgQSQBNA"
-	block20StateRootLE         = "3cba730383c4c2c34475939a4efe9de9ac377bffaf0abdb6f8a1a8fe145d8f69"
+	block20StateRootLE         = "af7fad57fc622305b162c4440295964168a07967d07244964e4ed0121b247dee"
 )
 
 var (


### PR DESCRIPTION
Port https://github.com/neo-project/neo/pull/2768.

This partially reverts commit ca127f161596c2d7b26f9fe20b526ae648333986.