### PR TITLE
wallet: export `SavePretty` method

### DIFF
--- a/pkg/wallet/regenerate_test.go
+++ b/pkg/wallet/regenerate_test.go
@@ -201,7 +201,7 @@ func createWallet(t *testing.T, path string, accs ...*Account) {
 	for _, acc := range accs {
 		w.AddAccount(acc)
 	}
-	require.NoError(t, w.savePretty())
+	require.NoError(t, w.SavePretty())
 	w.Close()
 }
 

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -149,8 +149,8 @@ func (w *Wallet) Save() error {
 	return w.writeRaw(data)
 }
 
-// savePretty saves the wallet in a beautiful JSON.
-func (w *Wallet) savePretty() error {
+// SavePretty saves the wallet in a beautiful JSON.
+func (w *Wallet) SavePretty() error {
 	data, err := json.MarshalIndent(w, "", "  ")
 	if err != nil {
 		return err


### PR DESCRIPTION
Client code can make use of it, see nspcc-dev/neofs-node#1498.

Signed-off-by: Evgeniy Stratonikov <evgeniy@nspcc.ru>
