### PR TITLE
core: adjust stateheight prometheus metric

### DIFF
--- a/pkg/core/prometheus.go
+++ b/pkg/core/prometheus.go
@@ -6,7 +6,7 @@ import (
 
 // Metrics for monitoring service.
 var (
-	//blockHeight prometheus metric.
+	// blockHeight prometheus metric.
 	blockHeight = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Help:      "Current index of processed block",
@@ -14,7 +14,7 @@ var (
 			Namespace: "neogo",
 		},
 	)
-	//persistedHeight prometheus metric.
+	// persistedHeight prometheus metric.
 	persistedHeight = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Help:      "Current persisted block count",
@@ -22,7 +22,7 @@ var (
 			Namespace: "neogo",
 		},
 	)
-	//headerHeight prometheus metric.
+	// headerHeight prometheus metric.
 	headerHeight = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Help:      "Current header height",

--- a/pkg/core/stateroot/module.go
+++ b/pkg/core/stateroot/module.go
@@ -260,7 +260,9 @@ func (s *Module) UpdateCurrentLocal(mpt *mpt.Trie, sr *state.MPTRoot) {
 	s.localHeight.Store(sr.Index)
 	if s.srInHead {
 		s.validatedHeight.Store(sr.Index)
-		updateStateHeightMetric(sr.Index)
+		updateStateHeightMetric(sr.Index, sr.Root, true)
+	} else {
+		updateStateHeightMetric(sr.Index, sr.Root, false)
 	}
 }
 

--- a/pkg/core/stateroot/prometheus.go
+++ b/pkg/core/stateroot/prometheus.go
@@ -1,20 +1,30 @@
 package stateroot
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
-// stateHeight prometheus metric.
-var stateHeight = prometheus.NewGauge(
+// stateHeight (local and validated) prometheus metric.
+var stateHeight = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
-		Help:      "Current verified state height",
+		Help:      "Current local or verified state height",
 		Name:      "current_state_height",
 		Namespace: "neogo",
 	},
+	[]string{"description", "value"},
 )
 
 func init() {
 	prometheus.MustRegister(stateHeight)
 }
 
-func updateStateHeightMetric(sHeight uint32) {
-	stateHeight.Set(float64(sHeight))
+func updateStateHeightMetric(sHeight uint32, sRoot util.Uint256, verified bool) {
+	var label string
+	if verified {
+		label = "Verified stateroot"
+	} else {
+		label = "Local stateroot"
+	}
+	stateHeight.WithLabelValues(label, sRoot.StringLE()).Set(float64(sHeight))
 }

--- a/pkg/core/stateroot/store.go
+++ b/pkg/core/stateroot/store.go
@@ -78,7 +78,7 @@ func (s *Module) AddStateRoot(sr *state.MPTRoot) error {
 	s.Store.Put([]byte{byte(storage.DataMPTAux), prefixValidated}, data)
 	s.validatedHeight.Store(sr.Index)
 	if !s.srInHead {
-		updateStateHeightMetric(sr.Index)
+		updateStateHeightMetric(sr.Index, sr.Root, true)
 	}
 	return nil
 }


### PR DESCRIPTION
### Problem

Infrustructure team needs to monitor stateroot hashes via Prometheus.

### Solution

Adjust stateheight prometheus metric:

1. Store not only validated stateroot heights, but also local ones.
2. Added stateroot hash to the metric as label. Although prometheus
   labels are not intended to be used in such way, there's a users
   demand to monitor stateroot hash via prometheus.