### PR TITLE
consensus: add dBFT watchdog

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -571,6 +571,9 @@ Main:
 			// After that, gracefully shutdown the old consensus service and replace it by the new one.
 			consensusService.Shutdown()
 			consensusService = newConsensusService
+			// Maybe doing this before consensus start is better because that's the way the node normally works.
+			// But it adds some network activity before consensus is able to handle anything.
+			serv.DropPeers(errors.New("dogs bite"))
 			// Start new consensus service irrespective to serv.IsInSync(), because if server is temporary out of sync
 			// then consensus service will never be started by serv. See https://github.com/nspcc-dev/neo-go/issues/2564.
 			consensusService.Start()

--- a/pkg/consensus/prometheus.go
+++ b/pkg/consensus/prometheus.go
@@ -1,0 +1,23 @@
+package consensus
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Metric used in monitoring service.
+var consensusReset = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Help:      "Height of dBFT service restart",
+		Name:      "dbft_restart_height",
+		Namespace: "neogo",
+	},
+)
+
+// InitializeDBFTRestartedMetric adds consensus restart metric to Prometheus.
+func initializeConsensusResetMetric() {
+	prometheus.MustRegister(
+		consensusReset,
+	)
+}
+
+func updateConsensusResetMetric(height uint32) {
+	consensusReset.Set(float64(height))
+}

--- a/pkg/consensus/watchdog.go
+++ b/pkg/consensus/watchdog.go
@@ -45,6 +45,7 @@ func NewWatchdog(cfg WatchdogConfig) (*Watchdog, error) {
 		quit:           make(chan struct{}),
 		finished:       make(chan struct{}),
 	}
+	initializeConsensusResetMetric()
 	return wd, nil
 }
 func (w *Watchdog) Start() {
@@ -92,6 +93,7 @@ events:
 				zap.Duration("time since latest block", time.Millisecond*time.Duration(now-int64(latestBlock.Timestamp))),
 				zap.Duration("time till next restart", resetAfter))
 			w.ConsensusRestartChan <- struct{}{}
+			updateConsensusResetMetric(latestBlock.Index)
 		}
 	}
 

--- a/pkg/consensus/watchdog.go
+++ b/pkg/consensus/watchdog.go
@@ -1,0 +1,132 @@
+package consensus
+
+import (
+	"errors"
+	"time"
+
+	coreb "github.com/nspcc-dev/neo-go/pkg/core/block"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+)
+
+type Watchdog struct {
+	WatchdogConfig
+
+	// blockEvents is used to pass a new block event to the consensus
+	// process.
+	blockEvents chan *coreb.Block
+
+	log *zap.Logger
+	// started is a flag set with Start method that runs an event handling
+	// goroutine.
+	started  *atomic.Bool
+	quit     chan struct{}
+	finished chan struct{}
+}
+
+type WatchdogConfig struct {
+	Logger *zap.Logger
+	// Chain is a Ledger instance.
+	Chain Ledger
+	// ConsensusRestartChan is a channel used to send restart signal to the consensus service caller
+	// if consensus watchdog is on.
+	ConsensusRestartChan chan struct{}
+}
+
+func NewWatchdog(cfg WatchdogConfig) (*Watchdog, error) {
+	if cfg.Logger == nil {
+		return nil, errors.New("empty logger")
+	}
+	wd := &Watchdog{
+		WatchdogConfig: cfg,
+		log:            cfg.Logger,
+		blockEvents:    make(chan *coreb.Block, 1),
+		started:        atomic.NewBool(false),
+		quit:           make(chan struct{}),
+		finished:       make(chan struct{}),
+	}
+	return wd, nil
+}
+func (w *Watchdog) Start() {
+	if w.started.CAS(false, true) {
+		w.log.Info("starting consensus watchdog service")
+		w.Chain.SubscribeForBlocks(w.blockEvents)
+		go w.eventLoop()
+	}
+}
+
+func (w *Watchdog) eventLoop() {
+	cfg := w.Chain.GetConfig()
+	latestBlock, err := w.Chain.GetBlock(w.Chain.CurrentBlockHash())
+	if err != nil {
+		w.log.Error("failed to retrieve last block timestamp",
+			zap.Error(err))
+		close(w.finished)
+		return
+	}
+	threshold := time.Second * time.Duration(cfg.DBFTWatchdogThresholdMultiplier*cfg.SecondsPerBlock)
+	_, resetAfter := calculateReset(latestBlock.Timestamp, threshold)
+	timer := time.NewTimer(resetAfter)
+
+events:
+	for {
+		select {
+		case <-w.quit:
+			w.Chain.UnsubscribeFromBlocks(w.blockEvents)
+			if !timer.Stop() {
+				<-timer.C
+			}
+			break events
+		case b := <-w.blockEvents:
+			if b.Index > latestBlock.Index {
+				latestBlock = b
+				_, resetAfter = calculateReset(latestBlock.Timestamp, threshold)
+				timer.Reset(resetAfter)
+			}
+		case <-timer.C:
+			now, resetAfter := calculateReset(latestBlock.Timestamp, threshold)
+			timer.Reset(resetAfter)
+			w.log.Warn("couldn't accept new block, sending signal to restart consensus service",
+				zap.Uint32("latest block index", latestBlock.Index),
+				zap.Uint64("latest block timestamp", latestBlock.Timestamp),
+				zap.Duration("time since latest block", time.Millisecond*time.Duration(now-int64(latestBlock.Timestamp))),
+				zap.Duration("time till next restart", resetAfter))
+			w.ConsensusRestartChan <- struct{}{}
+		}
+	}
+
+drainBlocksLoop:
+	for {
+		select {
+		case <-w.blockEvents:
+		default:
+			break drainBlocksLoop
+		}
+	}
+	close(w.blockEvents)
+	close(w.finished)
+}
+
+func calculateReset(latestTimestamp uint64, threshold time.Duration) (int64, time.Duration) {
+	now := time.Now().UnixMilli()
+	delta := time.Millisecond * time.Duration(int64(latestTimestamp)-now)
+	resetAfter := delta
+	for {
+		resetAfter += threshold
+		if resetAfter > 0 {
+			break
+		}
+	}
+	return now, resetAfter
+}
+
+func (w *Watchdog) Name() string {
+	return "consensus watchdog"
+}
+
+func (w *Watchdog) Shutdown() {
+	if w.started.Load() {
+		close(w.quit)
+		<-w.finished
+	}
+}

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -57,8 +57,9 @@ const (
 	defaultMaxTraceableBlocks              = 2102400 // 1 year of 15s blocks
 	defaultMaxTransactionsPerBlock         = 512
 	// HeaderVerificationGasLimit is the maximum amount of GAS for block header verification.
-	HeaderVerificationGasLimit = 3_00000000 // 3 GAS
-	defaultStateSyncInterval   = 40000
+	HeaderVerificationGasLimit             = 3_00000000 // 3 GAS
+	defaultStateSyncInterval               = 40000
+	defaultDBFTWatchdogThresholdMultiplier = 60 // 60 blocks ~ 15min of reset threshold for 15-seconds blocks.
 )
 
 // stateJumpStage denotes the stage of state jump process.
@@ -262,6 +263,10 @@ func NewBlockchain(s storage.Store, cfg config.ProtocolConfiguration, log *zap.L
 	if cfg.Hardforks == nil {
 		cfg.Hardforks = map[string]uint32{}
 		log.Info("Hardforks are not set, using default value")
+	}
+	if cfg.EnableDBFTWatchdog && cfg.DBFTWatchdogThresholdMultiplier == 0 {
+		cfg.DBFTWatchdogThresholdMultiplier = defaultDBFTWatchdogThresholdMultiplier
+		log.Info("DBFTWatchdogThresholdMultiplier is not set, using default value", zap.Int("DBFTWatchdogThresholdMultiplier", defaultDBFTWatchdogThresholdMultiplier))
 	}
 	bc := &Blockchain{
 		config:      cfg,

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -256,9 +256,7 @@ func (s *Server) Shutdown() {
 	s.log.Info("shutting down server", zap.Int("peers", s.PeerCount()))
 	s.transport.Close()
 	s.discovery.Close()
-	for _, p := range s.getPeers(nil) {
-		p.Disconnect(errServerShutdown)
-	}
+	s.DropPeers(errServerShutdown)
 	s.bQueue.discard()
 	s.bSyncQueue.discard()
 	for _, svc := range s.services {
@@ -268,6 +266,13 @@ func (s *Server) Shutdown() {
 		s.notaryRequestPool.StopSubscriptions()
 	}
 	close(s.quit)
+}
+
+// DropPeers drop connection to all current peers.
+func (s *Server) DropPeers(reason error) {
+	for _, p := range s.getPeers(nil) {
+		p.Disconnect(reason)
+	}
 }
 
 // AddService allows to add a service to be started/stopped by Server.


### PR DESCRIPTION
Requested by @realloc.

#### Problem

dBFT is not perfect, and sometimes it hangs in a deadlock.

#### Solution

Add dBFT watchdog. Watchdog tracks time spent since the last accepted block and enforses the consensus reset on threshold.

No documentation update included. If we'll decide to include this feature into master, then a separate PR will be created.

Depends on #2567 and #2566.