### PR TITLE
consensus: check whether server is started before transaction handling

### DIFF
--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -414,7 +414,7 @@ func (s *service) OnPayload(cp *npayload.Extensible) error {
 }
 
 func (s *service) OnTransaction(tx *transaction.Transaction) {
-	if s.dbft != nil {
+	if s.dbft != nil && s.started.Load() {
 		s.transactions <- tx
 	}
 }


### PR DESCRIPTION
consensus.OnTransaction is a callback, so it can be called at any time.
We need to check whether service (and dBFT) is started before the
subsequent transaction handling like it is done inside the OnPayload
callback.