### PR TITLE
smartcontract: print proper error message on failed testinvoke

### DIFF
--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -664,7 +664,7 @@ func invokeWithArgs(ctx *cli.Context, acc *wallet.Account, wall *wallet.Wallet, 
 		return sender, cli.NewExitError(err, 1)
 	}
 	if resp.State != "HALT" {
-		errText := fmt.Sprintf("Warning: %s VM state returned from the RPC node: %s\n", resp.State, resp.FaultException)
+		errText := fmt.Sprintf("Warning: %s VM state returned from the RPC node: %s", resp.State, resp.FaultException)
 		if out == "" && !signAndPush {
 			return sender, cli.NewExitError(errText, 1)
 		}
@@ -681,9 +681,9 @@ func invokeWithArgs(ctx *cli.Context, acc *wallet.Account, wall *wallet.Wallet, 
 			}
 		}
 		if !ctx.Bool("force") {
-			return sender, cli.NewExitError(errText+". Use --force flag to "+action+" the transaction anyway.", 1)
+			return sender, cli.NewExitError(errText+".\nUse --force flag to "+action+" the transaction anyway.", 1)
 		}
-		fmt.Fprintln(ctx.App.Writer, errText+". "+process+" transaction...")
+		fmt.Fprintln(ctx.App.Writer, errText+".\n"+process+" transaction...")
 	}
 	if out != "" {
 		tx, err := c.CreateTxFromScript(resp.Script, acc, resp.GasConsumed+int64(sysgas), int64(gas), cosignersAccounts)

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -665,6 +665,10 @@ func invokeWithArgs(ctx *cli.Context, acc *wallet.Account, wall *wallet.Wallet, 
 	}
 	if resp.State != "HALT" {
 		errText := fmt.Sprintf("Warning: %s VM state returned from the RPC node: %s\n", resp.State, resp.FaultException)
+		if out == "" && !signAndPush {
+			return sender, cli.NewExitError(errText, 1)
+		}
+
 		action := "save"
 		process := "Saving"
 		if signAndPush {


### PR DESCRIPTION
```
> neo-go contract testinvokefunction 152d147a02525ccfa46ed98e2c983bb70f0472e1 notexist -r http://172.21.0.2:30333
Warning: FAULT VM state returned from the RPC node: at instruction 36 (SYSCALL): failed to invoke syscall 1381727586: method not found: notexist/0
. Use --force flag to save the transaction anyway.
```

1. Do not print info about `--force` flag if we don't send or save a transaction.
2. Do not print dots on a new line.

Signed-off-by: Evgeniy Stratonikov <evgeniy@nspcc.ru>