### PR TITLE
Fancy service restart

### DIFF
--- a/cli/executor_test.go
+++ b/cli/executor_test.go
@@ -147,7 +147,7 @@ func newTestChain(t *testing.T, f func(*config.Config), run bool) (*core.Blockch
 		Chain:                 chain,
 		ProtocolConfiguration: chain.GetConfig(),
 		RequestTx:             netSrv.RequestTx,
-		Wallet:                serverConfig.Wallet,
+		Wallet:                &cfg.ApplicationConfiguration.UnlockWallet,
 		TimePerBlock:          serverConfig.TimePerBlock,
 	})
 	require.NoError(t, err)

--- a/cli/executor_test.go
+++ b/cli/executor_test.go
@@ -151,7 +151,7 @@ func newTestChain(t *testing.T, f func(*config.Config), run bool) (*core.Blockch
 		TimePerBlock:          serverConfig.TimePerBlock,
 	})
 	require.NoError(t, err)
-	netSrv.AddExtensibleHPService(cons, consensus.Category, cons.OnPayload, cons.OnTransaction)
+	netSrv.AddConsensusService(cons, cons.OnPayload, cons.OnTransaction)
 	go netSrv.Start(make(chan error, 1))
 	errCh := make(chan error, 2)
 	rpcServer := rpcsrv.New(chain, cfg.ApplicationConfiguration.RPC, netSrv, nil, logger, errCh)

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
-	"syscall"
 	"time"
 
 	"github.com/nspcc-dev/neo-go/cli/options"
@@ -516,9 +515,9 @@ func startServer(ctx *cli.Context) error {
 	}
 
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGHUP)
-	signal.Notify(sigCh, syscall.SIGUSR1)
-	signal.Notify(sigCh, syscall.SIGUSR2)
+	signal.Notify(sigCh, sighup)
+	signal.Notify(sigCh, sigusr1)
+	signal.Notify(sigCh, sigusr2)
 
 	fmt.Fprintln(ctx.App.Writer, Logo())
 	fmt.Fprintln(ctx.App.Writer, serv.UserAgent)
@@ -548,7 +547,7 @@ Main:
 			}
 			configureAddresses(&cfgnew.ApplicationConfiguration)
 			switch sig {
-			case syscall.SIGHUP:
+			case sighup:
 				serv.DelService(&rpcServer)
 				rpcServer.Shutdown()
 				rpcServer = rpcsrv.New(chain, cfgnew.ApplicationConfiguration.RPC, serv, oracleSrv, log, errChan)
@@ -562,7 +561,7 @@ Main:
 				prometheus.ShutDown()
 				prometheus = metrics.NewPrometheusService(cfgnew.ApplicationConfiguration.Prometheus, log)
 				go prometheus.Start()
-			case syscall.SIGUSR1:
+			case sigusr1:
 				if oracleSrv != nil {
 					serv.DelService(oracleSrv)
 					chain.SetOracle(nil)
@@ -605,7 +604,7 @@ Main:
 				if serv.IsInSync() {
 					sr.Start()
 				}
-			case syscall.SIGUSR2:
+			case sigusr2:
 				if dbftSrv != nil {
 					serv.DelExtensibleHPService(dbftSrv, consensus.Category)
 					dbftSrv.Shutdown()

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -588,6 +588,17 @@ Main:
 				if p2pNotary != nil && serv.IsInSync() {
 					p2pNotary.Start()
 				}
+				srMod.SetUpdateValidatorsCallback(nil)
+				sr.Shutdown()
+				sr, err = stateroot.New(cfgnew.ApplicationConfiguration.StateRoot, srMod, log, chain, serv.BroadcastExtensible)
+				if err != nil {
+					log.Error("failed to create state validation service", zap.Error(err))
+					break // The show must go on.
+				}
+				serv.AddExtensibleService(sr, stateroot.Category, sr.OnPayload)
+				if serv.IsInSync() {
+					sr.Start()
+				}
 			}
 			cfg = cfgnew
 		case <-grace.Done():

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -542,15 +542,17 @@ Main:
 				log.Warn("ApplicationConfiguration changed in incompatible way, signal ignored")
 				break // Continue working.
 			}
+			configureAddresses(&cfgnew.ApplicationConfiguration)
 			switch sig {
 			case syscall.SIGHUP:
 				rpcServer.Shutdown()
-				rpcServer = rpcsrv.New(chain, cfg.ApplicationConfiguration.RPC, serv, oracleSrv, log, errChan)
+				rpcServer = rpcsrv.New(chain, cfgnew.ApplicationConfiguration.RPC, serv, oracleSrv, log, errChan)
 				serv.AddService(&rpcServer) // Replaces old one by service name.
-				if !cfg.ApplicationConfiguration.RPC.StartWhenSynchronized || serv.IsInSync() {
+				if !cfgnew.ApplicationConfiguration.RPC.StartWhenSynchronized || serv.IsInSync() {
 					rpcServer.Start()
 				}
 			}
+			cfg = cfgnew
 		case <-grace.Done():
 			signal.Stop(sighupCh)
 			serv.Shutdown()

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -423,7 +423,7 @@ func mkConsensus(config config.Wallet, tpb time.Duration, chain *core.Blockchain
 		return nil, fmt.Errorf("can't initialize Consensus module: %w", err)
 	}
 
-	serv.AddExtensibleHPService(srv, consensus.Category, srv.OnPayload, srv.OnTransaction)
+	serv.AddConsensusService(srv, srv.OnPayload, srv.OnTransaction)
 	return srv, nil
 }
 
@@ -606,7 +606,7 @@ Main:
 				}
 			case sigusr2:
 				if dbftSrv != nil {
-					serv.DelExtensibleHPService(dbftSrv, consensus.Category)
+					serv.DelConsensusService(dbftSrv)
 					dbftSrv.Shutdown()
 				}
 				dbftSrv, err = mkConsensus(cfgnew.ApplicationConfiguration.UnlockWallet, serverConfig.TimePerBlock, chain, serv, log)

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -551,6 +551,12 @@ Main:
 				if !cfgnew.ApplicationConfiguration.RPC.StartWhenSynchronized || serv.IsInSync() {
 					rpcServer.Start()
 				}
+				pprof.ShutDown()
+				pprof = metrics.NewPprofService(cfgnew.ApplicationConfiguration.Pprof, log)
+				go pprof.Start()
+				prometheus.ShutDown()
+				prometheus = metrics.NewPrometheusService(cfgnew.ApplicationConfiguration.Prometheus, log)
+				go prometheus.Start()
 			}
 			cfg = cfgnew
 		case <-grace.Done():

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -538,6 +538,10 @@ Main:
 				log.Warn("ProtocolConfiguration changed, signal ignored")
 				break // Continue working.
 			}
+			if !cfg.ApplicationConfiguration.EqualsButServices(&cfgnew.ApplicationConfiguration) {
+				log.Warn("ApplicationConfiguration changed in incompatible way, signal ignored")
+				break // Continue working.
+			}
 			switch sig {
 			case syscall.SIGHUP:
 				rpcServer.Shutdown()

--- a/cli/server/signals_unix.go
+++ b/cli/server/signals_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+// +build !windows
+
+package server
+
+import "syscall"
+
+const (
+	sighup  = syscall.SIGHUP
+	sigusr1 = syscall.SIGUSR1
+	sigusr2 = syscall.SIGUSR2
+)

--- a/cli/server/signals_windows.go
+++ b/cli/server/signals_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+// +build windows
+
+package server
+
+import "syscall"
+
+const (
+	// Doesn't really matter, Windows can't do it.
+	sighup  = syscall.SIGHUP
+	sigusr1 = syscall.Signal(0xa)
+	sigusr2 = syscall.Signal(0xc)
+)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,12 +68,26 @@ current height of the node.
 
 ### Restarting node services
 
-To restart some node services without full node restart, send the SIGHUP 
-signal. List of the services to be restarted on SIGHUP receiving:
+On Unix-like platforms HUP, USR1 and USR2 signals can be used to control node
+services. Upon receiving any of these signals node rereads the configuration
+file, checks for its compatibility (ProtocolConfiguration can't be changed and
+ApplicationConfiguration can only be changed for services) and then
+stops/starts services according to the old and new configurations. Services
+are broadly split into three main categories:
+ * client-oriented
+   These provide some service to clients: RPC, Pprof and Prometheus
+   servers. They're controlled with the HUP signal.
+ * network-oriented
+   These provide some service to the network: Oracle, State validation and P2P
+   Notary. They're controlled with the USR1 signal.
+ * consensus
+   That's dBFT, it's a special one and it's controlled with USR2.
 
-| Service | Action |
-| --- | --- |
-| RPC server | Restarting with the old configuration and updated TLS certificates |
+Typical scenarios when this can be useful (without full node restart):
+ * enabling some service
+ * changing RPC configuration
+ * updating TLS certificates for the RPC server
+ * resolving operational issues
 
 ### DB import/exports
 

--- a/pkg/config/application_config.go
+++ b/pkg/config/application_config.go
@@ -29,3 +29,25 @@ type ApplicationConfiguration struct {
 	// ExtensiblePoolSize is the maximum amount of the extensible payloads from a single sender.
 	ExtensiblePoolSize int `yaml:"ExtensiblePoolSize"`
 }
+
+// EqualsButServices returns true when the o is the same as a except for services
+// (Oracle, P2PNotary, Pprof, Prometheus, RPC, StateRoot and UnlockWallet sections).
+func (a *ApplicationConfiguration) EqualsButServices(o *ApplicationConfiguration) bool {
+	if a.Address != o.Address ||
+		a.AnnouncedNodePort != o.AnnouncedNodePort ||
+		a.AttemptConnPeers != o.AttemptConnPeers ||
+		a.DBConfiguration != o.DBConfiguration ||
+		a.DialTimeout != o.DialTimeout ||
+		a.ExtensiblePoolSize != o.ExtensiblePoolSize ||
+		a.LogPath != o.LogPath ||
+		a.MaxPeers != o.MaxPeers ||
+		a.MinPeers != o.MinPeers ||
+		a.NodePort != o.NodePort ||
+		a.PingInterval != o.PingInterval ||
+		a.PingTimeout != o.PingTimeout ||
+		a.ProtoTickInterval != o.ProtoTickInterval ||
+		a.Relay != o.Relay {
+		return false
+	}
+	return true
+}

--- a/pkg/config/application_config_test.go
+++ b/pkg/config/application_config_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplicationConfigurationEquals(t *testing.T) {
+	a := &ApplicationConfiguration{}
+	o := &ApplicationConfiguration{}
+	require.True(t, a.EqualsButServices(o))
+	require.True(t, o.EqualsButServices(a))
+	require.True(t, a.EqualsButServices(a))
+
+	cfg1, err := LoadFile(filepath.Join("..", "..", "config", "protocol.mainnet.yml"))
+	require.NoError(t, err)
+	cfg2, err := LoadFile(filepath.Join("..", "..", "config", "protocol.testnet.yml"))
+	require.NoError(t, err)
+	require.False(t, cfg1.ApplicationConfiguration.EqualsButServices(&cfg2.ApplicationConfiguration))
+}

--- a/pkg/config/protocol_config.go
+++ b/pkg/config/protocol_config.go
@@ -196,3 +196,78 @@ func (p *ProtocolConfiguration) GetNumOfCNs(height uint32) int {
 func (p *ProtocolConfiguration) ShouldUpdateCommitteeAt(height uint32) bool {
 	return height%uint32(p.GetCommitteeSize(height)) == 0
 }
+
+// Equals allows to compare two ProtocolConfiguration instances, returns true if
+// they're equal.
+func (p *ProtocolConfiguration) Equals(o *ProtocolConfiguration) bool {
+	if p.GarbageCollectionPeriod != o.GarbageCollectionPeriod ||
+		p.InitialGASSupply != o.InitialGASSupply ||
+		p.KeepOnlyLatestState != o.KeepOnlyLatestState ||
+		p.Magic != o.Magic ||
+		p.MaxBlockSize != o.MaxBlockSize ||
+		p.MaxBlockSystemFee != o.MaxBlockSystemFee ||
+		p.MaxTraceableBlocks != o.MaxTraceableBlocks ||
+		p.MaxTransactionsPerBlock != o.MaxTransactionsPerBlock ||
+		p.MaxValidUntilBlockIncrement != o.MaxValidUntilBlockIncrement ||
+		p.MemPoolSize != o.MemPoolSize ||
+		p.P2PNotaryRequestPayloadPoolSize != o.P2PNotaryRequestPayloadPoolSize ||
+		p.P2PSigExtensions != o.P2PSigExtensions ||
+		p.P2PStateExchangeExtensions != o.P2PStateExchangeExtensions ||
+		p.RemoveUntraceableBlocks != o.RemoveUntraceableBlocks ||
+		p.ReservedAttributes != o.ReservedAttributes ||
+		p.SaveStorageBatch != o.SaveStorageBatch ||
+		p.SecondsPerBlock != o.SecondsPerBlock ||
+		p.StateRootInHeader != o.StateRootInHeader ||
+		p.StateSyncInterval != o.StateSyncInterval ||
+		p.ValidatorsCount != o.ValidatorsCount ||
+		p.VerifyBlocks != o.VerifyBlocks ||
+		p.VerifyTransactions != o.VerifyTransactions ||
+		len(p.CommitteeHistory) != len(o.CommitteeHistory) ||
+		len(p.Hardforks) != len(o.Hardforks) ||
+		len(p.NativeUpdateHistories) != len(o.NativeUpdateHistories) ||
+		len(p.SeedList) != len(o.SeedList) ||
+		len(p.StandbyCommittee) != len(o.StandbyCommittee) ||
+		len(p.ValidatorsHistory) != len(o.ValidatorsHistory) {
+		return false
+	}
+	for k, v := range p.CommitteeHistory {
+		vo, ok := o.CommitteeHistory[k]
+		if !ok || v != vo {
+			return false
+		}
+	}
+	for k, v := range p.Hardforks {
+		vo, ok := o.Hardforks[k]
+		if !ok || v != vo {
+			return false
+		}
+	}
+	for k, v := range p.NativeUpdateHistories {
+		vo := o.NativeUpdateHistories[k]
+		if len(v) != len(vo) {
+			return false
+		}
+		for i := range v {
+			if v[i] != vo[i] {
+				return false
+			}
+		}
+	}
+	for i := range p.SeedList {
+		if p.SeedList[i] != o.SeedList[i] {
+			return false
+		}
+	}
+	for i := range p.StandbyCommittee {
+		if p.StandbyCommittee[i] != o.StandbyCommittee[i] {
+			return false
+		}
+	}
+	for k, v := range p.ValidatorsHistory {
+		vo, ok := o.ValidatorsHistory[k]
+		if !ok || v != vo {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -40,9 +40,6 @@ const defaultTimePerBlock = 15 * time.Second
 // Number of nanoseconds in millisecond.
 const nsInMs = 1000000
 
-// Category is a message category for extensible payloads.
-const Category = "dBFT"
-
 // Ledger is the interface to Blockchain sufficient for Service.
 type Ledger interface {
 	AddBlock(block *coreb.Block) error
@@ -218,7 +215,7 @@ var (
 func NewPayload(m netmode.Magic, stateRootEnabled bool) *Payload {
 	return &Payload{
 		Extensible: npayload.Extensible{
-			Category: Category,
+			Category: npayload.ConsensusCategory,
 		},
 		message: message{
 			stateRootEnabled: stateRootEnabled,

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -276,6 +276,7 @@ func (s *service) Start() {
 // Shutdown implements the Service interface.
 func (s *service) Shutdown() {
 	if s.started.CAS(true, false) {
+		s.log.Info("stopping consensus service")
 		close(s.quit)
 		<-s.finished
 	}

--- a/pkg/consensus/recovery_message.go
+++ b/pkg/consensus/recovery_message.go
@@ -297,7 +297,7 @@ func getVerificationScript(i uint8, validators []crypto.PublicKey) []byte {
 func fromPayload(t messageType, recovery *Payload, p io.Serializable) *Payload {
 	return &Payload{
 		Extensible: npayload.Extensible{
-			Category:      Category,
+			Category:      npayload.ConsensusCategory,
 			ValidBlockEnd: recovery.BlockIndex,
 		},
 		message: message{

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -303,14 +303,28 @@ func NewBlockchain(s storage.Store, cfg config.ProtocolConfiguration, log *zap.L
 // must be called before `bc.Run()` to avoid data race.
 func (bc *Blockchain) SetOracle(mod native.OracleService) {
 	orc := bc.contracts.Oracle
-	md, ok := orc.GetMethod(manifest.MethodVerify, -1)
-	if !ok {
-		panic(fmt.Errorf("%s method not found", manifest.MethodVerify))
+	if mod != nil {
+		md, ok := orc.GetMethod(manifest.MethodVerify, -1)
+		if !ok {
+			panic(fmt.Errorf("%s method not found", manifest.MethodVerify))
+		}
+		mod.UpdateNativeContract(orc.NEF.Script, orc.GetOracleResponseScript(),
+			orc.Hash, md.MD.Offset)
+		keys, _, err := bc.contracts.Designate.GetDesignatedByRole(bc.dao, noderoles.Oracle, bc.BlockHeight())
+		if err != nil {
+			bc.log.Error("failed to get oracle key list")
+			return
+		}
+		mod.UpdateOracleNodes(keys)
+		reqs, err := bc.contracts.Oracle.GetRequests(bc.dao)
+		if err != nil {
+			bc.log.Error("failed to get current oracle request list")
+			return
+		}
+		mod.AddRequests(reqs)
 	}
-	mod.UpdateNativeContract(orc.NEF.Script, orc.GetOracleResponseScript(),
-		orc.Hash, md.MD.Offset)
-	orc.Module.Store(mod)
-	bc.contracts.Designate.OracleService.Store(mod)
+	orc.Module.Store(&mod)
+	bc.contracts.Designate.OracleService.Store(&mod)
 }
 
 // SetNotary sets notary module. It doesn't protected by mutex and

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -330,7 +330,15 @@ func (bc *Blockchain) SetOracle(mod native.OracleService) {
 // SetNotary sets notary module. It doesn't protected by mutex and
 // must be called before `bc.Run()` to avoid data race.
 func (bc *Blockchain) SetNotary(mod native.NotaryService) {
-	bc.contracts.Designate.NotaryService.Store(mod)
+	if mod != nil {
+		keys, _, err := bc.contracts.Designate.GetDesignatedByRole(bc.dao, noderoles.P2PNotary, bc.BlockHeight())
+		if err != nil {
+			bc.log.Error("failed to get notary key list")
+			return
+		}
+		mod.UpdateNotaryNodes(keys)
+	}
+	bc.contracts.Designate.NotaryService.Store(&mod)
 }
 
 func (bc *Blockchain) init() error {

--- a/pkg/core/native/designate.go
+++ b/pkg/core/native/designate.go
@@ -238,8 +238,8 @@ func (s *Designate) updateCachedRoleData(cache *DesignationCache, d *dao.Simple,
 func (s *Designate) notifyRoleChanged(v *roleData, r noderoles.Role) {
 	switch r {
 	case noderoles.Oracle:
-		if orc, _ := s.OracleService.Load().(OracleService); orc != nil {
-			orc.UpdateOracleNodes(v.nodes.Copy())
+		if orc, _ := s.OracleService.Load().(*OracleService); orc != nil && *orc != nil {
+			(*orc).UpdateOracleNodes(v.nodes.Copy())
 		}
 	case noderoles.P2PNotary:
 		if ntr, _ := s.NotaryService.Load().(NotaryService); ntr != nil {

--- a/pkg/core/native/designate.go
+++ b/pkg/core/native/designate.go
@@ -242,8 +242,8 @@ func (s *Designate) notifyRoleChanged(v *roleData, r noderoles.Role) {
 			(*orc).UpdateOracleNodes(v.nodes.Copy())
 		}
 	case noderoles.P2PNotary:
-		if ntr, _ := s.NotaryService.Load().(NotaryService); ntr != nil {
-			ntr.UpdateNotaryNodes(v.nodes.Copy())
+		if ntr, _ := s.NotaryService.Load().(*NotaryService); ntr != nil && *ntr != nil {
+			(*ntr).UpdateNotaryNodes(v.nodes.Copy())
 		}
 	case noderoles.StateValidator:
 		if s.StateRootService != nil {

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -196,10 +196,6 @@ func newTestServerWithCustomCfg(t *testing.T, serverConfig ServerConfig, protoco
 	s, err := newServerFromConstructors(serverConfig, fakechain.NewFakeChainWithCustomCfg(protocolCfg), new(fakechain.FakeStateSync), zaptest.NewLogger(t),
 		newFakeTransp, newTestDiscovery)
 	require.NoError(t, err)
-	if serverConfig.Wallet != nil {
-		cons := new(fakeConsensus)
-		s.AddExtensibleHPService(cons, consensus.Category, cons.OnPayload, cons.OnTransaction)
-	}
 	t.Cleanup(s.discovery.Close)
 	return s
 }

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/nspcc-dev/neo-go/internal/fakechain"
 	"github.com/nspcc-dev/neo-go/pkg/config"
-	"github.com/nspcc-dev/neo-go/pkg/consensus"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/network/capability"
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"

--- a/pkg/network/payload/extensible.go
+++ b/pkg/network/payload/extensible.go
@@ -11,6 +11,10 @@ import (
 
 const maxExtensibleCategorySize = 32
 
+// ConsensusCategory is a message category for consensus-related extensible
+// payloads.
+const ConsensusCategory = "dBFT"
+
 // Extensible represents a payload containing arbitrary data.
 type Extensible struct {
 	// Category is the payload type.

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -101,10 +101,12 @@ type (
 		notaryRequestPool *mempool.Pool
 		extensiblePool    *extpool.Pool
 		notaryFeer        NotaryFeer
-		services          map[string]Service
-		extensHandlers    map[string]func(*payload.Extensible) error
-		extensHighPrio    string
-		txCallback        func(*transaction.Transaction)
+
+		serviceLock    sync.RWMutex
+		services       map[string]Service
+		extensHandlers map[string]func(*payload.Extensible) error
+		extensHighPrio string
+		txCallback     func(*transaction.Transaction)
 
 		txInLock sync.Mutex
 		txInMap  map[util.Uint256]struct{}
@@ -263,9 +265,11 @@ func (s *Server) Shutdown() {
 	}
 	s.bQueue.discard()
 	s.bSyncQueue.discard()
+	s.serviceLock.RLock()
 	for _, svc := range s.services {
 		svc.Shutdown()
 	}
+	s.serviceLock.RUnlock()
 	if s.chain.P2PSigExtensionsEnabled() {
 		s.notaryRequestPool.StopSubscriptions()
 	}
@@ -274,20 +278,72 @@ func (s *Server) Shutdown() {
 
 // AddService allows to add a service to be started/stopped by Server.
 func (s *Server) AddService(svc Service) {
+	s.serviceLock.Lock()
+	defer s.serviceLock.Unlock()
+	s.addService(svc)
+}
+
+// addService is an unlocked version of AddService.
+func (s *Server) addService(svc Service) {
 	s.services[svc.Name()] = svc
 }
 
 // AddExtensibleService register a service that handles an extensible payload of some kind.
 func (s *Server) AddExtensibleService(svc Service, category string, handler func(*payload.Extensible) error) {
+	s.serviceLock.Lock()
+	defer s.serviceLock.Unlock()
+	s.addExtensibleService(svc, category, handler)
+}
+
+// addExtensibleService is an unlocked version of AddExtensibleService.
+func (s *Server) addExtensibleService(svc Service, category string, handler func(*payload.Extensible) error) {
 	s.extensHandlers[category] = handler
-	s.AddService(svc)
+	s.addService(svc)
 }
 
 // AddExtensibleHPService registers a high-priority service that handles an extensible payload of some kind.
 func (s *Server) AddExtensibleHPService(svc Service, category string, handler func(*payload.Extensible) error, txCallback func(*transaction.Transaction)) {
+	s.serviceLock.Lock()
+	defer s.serviceLock.Unlock()
 	s.txCallback = txCallback
 	s.extensHighPrio = category
-	s.AddExtensibleService(svc, category, handler)
+	s.addExtensibleService(svc, category, handler)
+}
+
+// DelService drops a service from the list, use it when the service is stopped
+// outside of the Server.
+func (s *Server) DelService(svc Service) {
+	s.serviceLock.Lock()
+	defer s.serviceLock.Unlock()
+	s.delService(svc)
+}
+
+// delService is an unlocked version of DelService.
+func (s *Server) delService(svc Service) {
+	delete(s.services, svc.Name())
+}
+
+// DelExtensibleService drops a service that handler extensible payloads from the
+// list, use it when the service is stopped outside of the Server.
+func (s *Server) DelExtensibleService(svc Service, category string) {
+	s.serviceLock.Lock()
+	defer s.serviceLock.Unlock()
+	s.delExtensibleService(svc, category)
+}
+
+// delExtensibleService is an unlocked version of DelExtensibleService.
+func (s *Server) delExtensibleService(svc Service, category string) {
+	delete(s.extensHandlers, category)
+	s.delService(svc)
+}
+
+// DelExtensibleHPService unregisters a high-priority service that handles an extensible payload of some kind.
+func (s *Server) DelExtensibleHPService(svc Service, category string) {
+	s.serviceLock.Lock()
+	defer s.serviceLock.Unlock()
+	s.txCallback = nil
+	s.extensHighPrio = ""
+	s.delExtensibleService(svc, category)
 }
 
 // GetNotaryPool allows to retrieve notary pool, if it's configured.
@@ -428,9 +484,11 @@ func (s *Server) tryStartServices() {
 		if s.chain.P2PSigExtensionsEnabled() {
 			s.notaryRequestPool.RunSubscriptions() // WSClient is also a subscriber.
 		}
+		s.serviceLock.RLock()
 		for _, svc := range s.services {
 			svc.Start()
 		}
+		s.serviceLock.RUnlock()
 	}
 }
 
@@ -931,7 +989,9 @@ func (s *Server) handleExtensibleCmd(e *payload.Extensible) error {
 	if !ok { // payload is already in cache
 		return nil
 	}
+	s.serviceLock.RLock()
 	handler := s.extensHandlers[e.Category]
+	s.serviceLock.RUnlock()
 	if handler != nil {
 		err = handler(e)
 		if err != nil {
@@ -944,7 +1004,10 @@ func (s *Server) handleExtensibleCmd(e *payload.Extensible) error {
 
 func (s *Server) advertiseExtensible(e *payload.Extensible) {
 	msg := NewMessage(CMDInv, payload.NewInventory(payload.ExtensibleType, []util.Uint256{e.Hash()}))
-	if e.Category == s.extensHighPrio {
+	s.serviceLock.RLock()
+	hp := s.extensHighPrio
+	s.serviceLock.RUnlock()
+	if e.Category == hp {
 		// It's high priority because it directly affects consensus process,
 		// even though it's just an inv.
 		s.broadcastHPMessage(msg)
@@ -966,8 +1029,11 @@ func (s *Server) handleTxCmd(tx *transaction.Transaction) error {
 	}
 	s.txInMap[tx.Hash()] = struct{}{}
 	s.txInLock.Unlock()
-	if s.txCallback != nil {
-		s.txCallback(tx)
+	s.serviceLock.RLock()
+	txCallback := s.txCallback
+	s.serviceLock.RUnlock()
+	if txCallback != nil {
+		txCallback(tx)
 	}
 	if s.verifyAndPoolTX(tx) == nil {
 		s.broadcastTX(tx, nil)

--- a/pkg/network/server_config.go
+++ b/pkg/network/server_config.go
@@ -64,9 +64,6 @@ type (
 		// Level of the internal logger.
 		LogLevel zapcore.Level
 
-		// Wallet is a wallet configuration.
-		Wallet *config.Wallet
-
 		// TimePerBlock is an interval which should pass between two successive blocks.
 		TimePerBlock time.Duration
 
@@ -90,11 +87,6 @@ func NewServerConfig(cfg config.Config) ServerConfig {
 	appConfig := cfg.ApplicationConfiguration
 	protoConfig := cfg.ProtocolConfiguration
 
-	var wc *config.Wallet
-	if appConfig.UnlockWallet.Path != "" {
-		wc = &appConfig.UnlockWallet
-	}
-
 	return ServerConfig{
 		UserAgent:          cfg.GenerateUserAgent(),
 		Address:            appConfig.Address,
@@ -110,7 +102,6 @@ func NewServerConfig(cfg config.Config) ServerConfig {
 		MaxPeers:           appConfig.MaxPeers,
 		AttemptConnPeers:   appConfig.AttemptConnPeers,
 		MinPeers:           appConfig.MinPeers,
-		Wallet:             wc,
 		TimePerBlock:       time.Duration(protoConfig.SecondsPerBlock) * time.Second,
 		OracleCfg:          appConfig.Oracle,
 		P2PNotaryCfg:       appConfig.P2PNotary,

--- a/pkg/network/server_test.go
+++ b/pkg/network/server_test.go
@@ -109,7 +109,9 @@ func TestServerStartAndShutdown(t *testing.T) {
 		require.True(t, errors.Is(err, errServerShutdown))
 	})
 	t.Run("with consensus", func(t *testing.T) {
-		s := newTestServer(t, ServerConfig{Wallet: new(config.Wallet)})
+		s := newTestServer(t, ServerConfig{})
+		cons := new(fakeConsensus)
+		s.AddExtensibleHPService(cons, consensus.Category, cons.OnPayload, cons.OnTransaction)
 
 		ch := startWithChannel(s)
 		p := newLocalPeer(t, s)
@@ -409,7 +411,9 @@ func TestBlock(t *testing.T) {
 }
 
 func TestConsensus(t *testing.T) {
-	s := newTestServer(t, ServerConfig{Wallet: new(config.Wallet)})
+	s := newTestServer(t, ServerConfig{})
+	cons := new(fakeConsensus)
+	s.AddExtensibleHPService(cons, consensus.Category, cons.OnPayload, cons.OnTransaction)
 	startWithCleanup(t, s)
 
 	atomic2.StoreUint32(&s.chain.(*fakechain.FakeChain).Blockheight, 4)
@@ -452,7 +456,9 @@ func TestConsensus(t *testing.T) {
 }
 
 func TestTransaction(t *testing.T) {
-	s := newTestServer(t, ServerConfig{Wallet: new(config.Wallet)})
+	s := newTestServer(t, ServerConfig{})
+	cons := new(fakeConsensus)
+	s.AddExtensibleHPService(cons, consensus.Category, cons.OnPayload, cons.OnTransaction)
 	startWithCleanup(t, s)
 
 	t.Run("good", func(t *testing.T) {

--- a/pkg/network/server_test.go
+++ b/pkg/network/server_test.go
@@ -111,7 +111,7 @@ func TestServerStartAndShutdown(t *testing.T) {
 	t.Run("with consensus", func(t *testing.T) {
 		s := newTestServer(t, ServerConfig{})
 		cons := new(fakeConsensus)
-		s.AddExtensibleHPService(cons, consensus.Category, cons.OnPayload, cons.OnTransaction)
+		s.AddConsensusService(cons, cons.OnPayload, cons.OnTransaction)
 
 		ch := startWithChannel(s)
 		p := newLocalPeer(t, s)
@@ -413,7 +413,7 @@ func TestBlock(t *testing.T) {
 func TestConsensus(t *testing.T) {
 	s := newTestServer(t, ServerConfig{})
 	cons := new(fakeConsensus)
-	s.AddExtensibleHPService(cons, consensus.Category, cons.OnPayload, cons.OnTransaction)
+	s.AddConsensusService(cons, cons.OnPayload, cons.OnTransaction)
 	startWithCleanup(t, s)
 
 	atomic2.StoreUint32(&s.chain.(*fakechain.FakeChain).Blockheight, 4)
@@ -424,7 +424,7 @@ func TestConsensus(t *testing.T) {
 
 	newConsensusMessage := func(start, end uint32) *Message {
 		pl := payload.NewExtensible()
-		pl.Category = consensus.Category
+		pl.Category = payload.ConsensusCategory
 		pl.ValidBlockStart = start
 		pl.ValidBlockEnd = end
 		return NewMessage(CMDExtensible, pl)
@@ -458,7 +458,7 @@ func TestConsensus(t *testing.T) {
 func TestTransaction(t *testing.T) {
 	s := newTestServer(t, ServerConfig{})
 	cons := new(fakeConsensus)
-	s.AddExtensibleHPService(cons, consensus.Category, cons.OnPayload, cons.OnTransaction)
+	s.AddConsensusService(cons, cons.OnPayload, cons.OnTransaction)
 	startWithCleanup(t, s)
 
 	t.Run("good", func(t *testing.T) {

--- a/pkg/services/metrics/metrics.go
+++ b/pkg/services/metrics/metrics.go
@@ -31,6 +31,9 @@ func (ms *Service) Start() {
 
 // ShutDown stops the service.
 func (ms *Service) ShutDown() {
+	if !ms.config.Enabled {
+		return
+	}
 	ms.log.Info("shutting down service", zap.String("endpoint", ms.Addr))
 	err := ms.Shutdown(context.Background())
 	if err != nil {

--- a/pkg/services/metrics/metrics.go
+++ b/pkg/services/metrics/metrics.go
@@ -37,6 +37,6 @@ func (ms *Service) ShutDown() {
 	ms.log.Info("shutting down service", zap.String("endpoint", ms.Addr))
 	err := ms.Shutdown(context.Background())
 	if err != nil {
-		ms.log.Panic("can't shut down service")
+		ms.log.Error("can't shut service down", zap.Error(err))
 	}
 }

--- a/pkg/services/notary/notary.go
+++ b/pkg/services/notary/notary.go
@@ -219,6 +219,7 @@ func (n *Notary) Shutdown() {
 	if !n.started.CAS(true, false) {
 		return
 	}
+	n.Config.Log.Info("stopping notary service")
 	close(n.stopCh)
 	<-n.done
 }

--- a/pkg/services/oracle/broadcaster/oracle.go
+++ b/pkg/services/oracle/broadcaster/oracle.go
@@ -10,7 +10,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient"
 	"github.com/nspcc-dev/neo-go/pkg/services/helpers/rpcbroadcaster"
-	"github.com/nspcc-dev/neo-go/pkg/services/oracle"
 	"go.uber.org/zap"
 )
 
@@ -20,16 +19,17 @@ const (
 	defaultChanCapacity = 16
 )
 
-type oracleBroadcaster struct {
+// OracleBroadcaster is an oracle broadcaster implementation.
+type OracleBroadcaster struct {
 	rpcbroadcaster.RPCBroadcaster
 }
 
 // New returns a new struct capable of broadcasting oracle responses.
-func New(cfg config.OracleConfiguration, log *zap.Logger) oracle.Broadcaster {
+func New(cfg config.OracleConfiguration, log *zap.Logger) *OracleBroadcaster {
 	if cfg.ResponseTimeout == 0 {
 		cfg.ResponseTimeout = defaultSendTimeout
 	}
-	r := &oracleBroadcaster{
+	r := &OracleBroadcaster{
 		RPCBroadcaster: *rpcbroadcaster.NewRPCBroadcaster(log, cfg.ResponseTimeout),
 	}
 	for i := range cfg.Nodes {
@@ -40,7 +40,7 @@ func New(cfg config.OracleConfiguration, log *zap.Logger) oracle.Broadcaster {
 }
 
 // SendResponse implements interfaces.Broadcaster.
-func (r *oracleBroadcaster) SendResponse(priv *keys.PrivateKey, resp *transaction.OracleResponse, txSig []byte) {
+func (r *OracleBroadcaster) SendResponse(priv *keys.PrivateKey, resp *transaction.OracleResponse, txSig []byte) {
 	pub := priv.PublicKey()
 	data := GetMessage(pub.Bytes(), resp.ID, txSig)
 	msgSig := priv.Sign(data)

--- a/pkg/services/oracle/oracle.go
+++ b/pkg/services/oracle/oracle.go
@@ -186,6 +186,7 @@ func (o *Oracle) Shutdown() {
 	if !o.running {
 		return
 	}
+	o.Log.Info("stopping oracle service")
 	o.running = false
 	close(o.close)
 	o.ResponseHandler.Shutdown()

--- a/pkg/services/oracle/oracle_test.go
+++ b/pkg/services/oracle/oracle_test.go
@@ -121,8 +121,8 @@ func TestCreateResponseTx(t *testing.T) {
 		Result: []byte{0},
 	}
 	cInvoker.Invoke(t, stackitem.Null{}, "requestURL", req.URL, *req.Filter, req.CallbackMethod, req.UserData, int64(req.GasForResponse))
-	orc.UpdateOracleNodes(keys.PublicKeys{acc.PrivateKey().PublicKey()})
 	bc.SetOracle(orc)
+	orc.UpdateOracleNodes(keys.PublicKeys{acc.PrivateKey().PublicKey()})
 	tx, err = orc.CreateResponseTx(int64(req.GasForResponse), 1, resp)
 	require.NoError(t, err)
 	assert.Equal(t, 166, tx.Size())

--- a/pkg/services/oracle/request.go
+++ b/pkg/services/oracle/request.go
@@ -234,7 +234,7 @@ func (o *Oracle) processRequest(priv *keys.PrivateKey, req request) error {
 	incTx.attempts++
 	incTx.Unlock()
 
-	o.getBroadcaster().SendResponse(priv, resp, txSig)
+	o.ResponseHandler.SendResponse(priv, resp, txSig)
 	if ready {
 		o.sendTx(readyTx)
 	}
@@ -265,7 +265,7 @@ func (o *Oracle) processFailedRequest(priv *keys.PrivateKey, req request) {
 	txSig := incTx.backupSigs[string(priv.PublicKey().Bytes())].sig
 	incTx.Unlock()
 
-	o.getBroadcaster().SendResponse(priv, getFailedResponse(req.ID), txSig)
+	o.ResponseHandler.SendResponse(priv, getFailedResponse(req.ID), txSig)
 	if ready {
 		o.sendTx(readyTx)
 	}

--- a/pkg/services/stateroot/validators.go
+++ b/pkg/services/stateroot/validators.go
@@ -71,6 +71,7 @@ func (s *service) Shutdown() {
 	if !s.started.CAS(true, false) {
 		return
 	}
+	s.log.Info("stopping state validation service")
 	close(s.stopCh)
 	<-s.done
 }


### PR DESCRIPTION
This fixes #1949. It works like this:

No config changes:

```
2022-07-27T11:32:46.376+0300    INFO    signal received {"name": "hangup"}
2022-07-27T11:32:46.378+0300    INFO    shutting down RPC server        {"endpoint": "[::]:10332"}
2022-07-27T11:32:46.379+0300    INFO    starting rpc-server     {"endpoint": ":10332"}
2022-07-27T11:32:46.379+0300    INFO    shutting down service   {"service": "Prometheus", "endpoint": ":2112"}
2022-07-27T11:32:46.380+0300    INFO    service hasn't started since it's disabled      {"service": "Pprof"}
2022-07-27T11:32:46.381+0300    INFO    service is running      {"service": "Prometheus", "endpoint": ":2112"}
```
Enabled/disabled services:
```
2022-07-27T11:33:18.936+0300    INFO    signal received {"name": "hangup"}
2022-07-27T11:33:18.938+0300    INFO    shutting down RPC server        {"endpoint": "[::]:10332"}
2022-07-27T11:33:18.940+0300    INFO    RPC server is not enabled
2022-07-27T11:33:18.940+0300    INFO    shutting down service   {"service": "Prometheus", "endpoint": ":2112"}
2022-07-27T11:33:18.940+0300    INFO    service is running      {"service": "Pprof", "endpoint": ":2113"}
2022-07-27T11:33:18.941+0300    INFO    service is running      {"service": "Prometheus", "endpoint": ":2112"}

2022-07-27T11:36:39.794+0300    INFO    signal received {"name": "user defined signal 1"}
2022-07-27T11:36:45.840+0300    INFO    starting oracle service
2022-07-27T11:36:45.840+0300    INFO    stopping state validation service
2022-07-27T11:36:50.678+0300    INFO    persisted to disk       {"blocks": 1, "keys": 261, "headerHeight": 1926393, "blockHeight": 1926393, "took": "95.264089ms"}
2022-07-27T11:36:51.232+0300    INFO    starting state validation service

2022-07-27T11:46:26.781+0300    INFO    signal received {"name": "user defined signal 2"}
2022-07-27T11:46:27.109+0300    INFO    starting consensus service
2022-07-27T11:46:27.109+0300    INFO    initializing dbft       {"height": 1926428, "view": 0, "index": -1, "role": "WatchOnly"}
2022-07-27T11:46:33.106+0300    INFO    received PrepareRequest {"validator": 0, "tx": 0}
2022-07-27T11:46:33.158+0300    INFO    received PrepareResponse        {"validator": 2}
2022-07-27T11:46:33.179+0300    INFO    received PrepareResponse        {"validator": 4}
2022-07-27T11:46:33.203+0300    INFO    received PrepareResponse        {"validator": 1}
2022-07-27T11:46:33.222+0300    INFO    received PrepareResponse        {"validator": 6}
2022-07-27T11:46:33.230+0300    INFO    received PrepareResponse        {"validator": 3}
2022-07-27T11:46:33.250+0300    INFO    received Commit {"validator": 4}
2022-07-27T11:46:33.334+0300    INFO    received Commit {"validator": 2}
2022-07-27T11:46:33.342+0300    INFO    received Commit {"validator": 3}
2022-07-27T11:46:33.363+0300    INFO    received Commit {"validator": 6}
2022-07-27T11:46:34.835+0300    INFO    received PrepareResponse        {"validator": 5}
2022-07-27T11:46:34.929+0300    INFO    received Commit {"validator": 5}
2022-07-27T11:46:34.929+0300    INFO    approving block {"height": 1926428, "hash": "56e51d1399f7e784b697e51623ee0f16e0b0c21c46da7d2a9d01025758f2e9ce", "tx_count": 0, "merkle": "0000000000000000000000000000000000000000000000000000000000000000", "prev": "4ce420b948da9de482d9bb12dd86b54387c53bad013bfc0739b3d54f6ffe0791"}
2022-07-27T11:46:34.932+0300    INFO    initializing dbft       {"height": 1926429, "view": 0, "index": -1, "role": "WatchOnly"}

2022-07-27T11:47:08.517+0300    INFO    signal received {"name": "user defined signal 2"}
2022-07-27T11:47:08.518+0300    INFO    stopping consensus service
2022-07-27T11:47:08.662+0300    INFO    persisted to disk       {"blocks": 1, "keys": 23, "headerHeight": 1926430, "blockHeight": 1926430, "took": "9.627537ms"}
2022-07-27T11:47:08.871+0300    INFO    starting consensus service
2022-07-27T11:47:08.871+0300    INFO    initializing dbft       {"height": 1926431, "view": 0, "index": -1, "role": "WatchOnly"}
```