### PR TITLE
native: trigger committee update on candidate registration

### DIFF
--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -759,6 +759,8 @@ func (n *NEO) RegisterCandidateInternal(ic *interop.Context, pub *keys.PublicKey
 	}
 	err := putConvertibleToDAO(n.ID, ic.DAO, key, c)
 	if emitEvent {
+		cache := ic.DAO.GetRWCache(n.ID).(*NeoCache)
+		cache.votesChanged = true
 		ic.AddNotification(n.Hash, "CandidateStateChanged", stackitem.NewArray([]stackitem.Item{
 			stackitem.NewByteArray(pub.Bytes()),
 			stackitem.NewBool(c.Registered),


### PR DESCRIPTION
It can change the committee even if noone voted. Fixes state diff at block
390726 of T5 testnet where there are no transactions, but committee changes
because there were some registrations in previous 21 blocks.
