### PR TITLE
.github: adjust image builder job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,6 @@ jobs:
           fetch-depth: 0
 
       - name: Set up QEMU
-        if: runner.os != 'Windows'
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Nitpicking. Don't need to check runner OS, because it's ubuntu-20.04. Remnant from
b8b85ce911af65699a5a90dca8748ff8a1b7c171.