### PR TITLE
compiler: avoid panic on empty package list

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -2185,6 +2185,9 @@ func newCodegen(info *buildInfo, pkg *packages.Package) *codegen {
 
 // codeGen compiles the program to bytecode.
 func codeGen(info *buildInfo) (*nef.File, *DebugInfo, error) {
+	if len(info.program) == 0 {
+		return nil, nil, errors.New("empty package")
+	}
 	pkg := info.program[0]
 	c := newCodegen(info, pkg)
 


### PR DESCRIPTION
An attempt to compile unexisting file via neo-go-vm CLI leads to the following
panic:
```
NEO-GO-VM > loadgo ./1-print.go
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/nspcc-dev/neo-go/pkg/compiler.codeGen(0xc000047300)
	github.com/nspcc-dev/neo-go/pkg/compiler/codegen.go:2188 +0x60c
github.com/nspcc-dev/neo-go/pkg/compiler.CompileWithOptions({0xc000047300, 0xf66c92}, {0x0, 0x0}, 0xc0003a0000)
	github.com/nspcc-dev/neo-go/pkg/compiler/compiler.go:218 +0x65
github.com/nspcc-dev/neo-go/pkg/vm/cli.handleLoadGo(0xc0000f5340)
	github.com/nspcc-dev/neo-go/pkg/vm/cli/cli.go:480 +0x1a5
github.com/urfave/cli.HandleAction({0xde74a0, 0x10d61d0}, 0x6)
	github.com/urfave/cli@v1.22.5/app.go:524 +0xa8
github.com/urfave/cli.Command.Run({{0xf632f0, 0x6}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0xf9915b, 0x38}, {0xf6a57b, ...}, ...}, ...)
	github.com/urfave/cli@v1.22.5/command.go:173 +0x652
github.com/urfave/cli.(*App).Run(0xc0002c2000, {0xc00036c330, 0x3, 0x3})
	github.com/urfave/cli@v1.22.5/app.go:277 +0x705
github.com/nspcc-dev/neo-go/pkg/vm/cli.(*VMCLI).Run(0xc000290890)
	github.com/nspcc-dev/neo-go/pkg/vm/cli/cli.go:694 +0x317
github.com/nspcc-dev/neo-go/cli/vm.startVMPrompt(0xc0001b9e40)
	github.com/nspcc-dev/neo-go/cli/vm/vm.go:29 +0x92
github.com/urfave/cli.HandleAction({0xde74a0, 0x10d5d10}, 0x2)
	github.com/urfave/cli@v1.22.5/app.go:524 +0xa8
github.com/urfave/cli.Command.Run({{0xf60a2f, 0x2}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0xf7880b, 0x19}, {0x0, ...}, ...}, ...)
	github.com/urfave/cli@v1.22.5/command.go:173 +0x652
github.com/urfave/cli.(*App).Run(0xc0001c8fc0, {0xc000116020, 0x2, 0x2})
	github.com/urfave/cli@v1.22.5/app.go:277 +0x705
main.main()
	./main.go:21 +0x33
```