### PR TITLE
vm: optimize refcount

### DIFF
--- a/pkg/vm/fuzz_test.go
+++ b/pkg/vm/fuzz_test.go
@@ -16,6 +16,12 @@ var fuzzSeedValidScripts = [][]byte{
 	makeProgram(opcode.PUSH2, opcode.NEWARRAY, opcode.DUP, opcode.PUSH0, opcode.PUSH1, opcode.SETITEM, opcode.VALUES),
 	append([]byte{byte(opcode.PUSHDATA1), 10}, randomBytes(10)...),
 	append([]byte{byte(opcode.PUSHDATA1), 100}, randomBytes(100)...),
+	// Simplified version of fuzzer output from #2659.
+	{byte(opcode.CALL), 3, byte(opcode.ASSERT),
+		byte(opcode.CALL), 3, byte(opcode.ASSERT),
+		byte(opcode.DEPTH), byte(opcode.PACKSTRUCT), byte(opcode.DUP),
+		byte(opcode.UNPACK), byte(opcode.PACKSTRUCT), byte(opcode.POPITEM),
+		byte(opcode.DEPTH)},
 }
 
 func FuzzIsScriptCorrect(f *testing.F) {

--- a/pkg/vm/ref_counter_test.go
+++ b/pkg/vm/ref_counter_test.go
@@ -55,3 +55,14 @@ func BenchmarkRefCounter_Add(b *testing.B) {
 		rc.Add(a)
 	}
 }
+
+func BenchmarkRefCounter_AddRemove(b *testing.B) {
+	a := stackitem.NewArray([]stackitem.Item{})
+	rc := newRefCounter()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rc.Add(a)
+		rc.Remove(a)
+	}
+}


### PR DESCRIPTION
Found by `TestFuzzVMDontPanic`.

1. Add new benchmark for refcount.
2. Split `Array` and `Struct` cases in `switch`.
3. Remove interface cast,