### PR TITLE
rpcclient: add enough of NNS into nns to deprecate NNS methods

### DIFF
--- a/pkg/rpcclient/native.go
+++ b/pkg/rpcclient/native.go
@@ -31,6 +31,8 @@ func (c *Client) GetOraclePrice() (int64, error) {
 }
 
 // GetNNSPrice invokes `getPrice` method on a NeoNameService contract with the specified hash.
+//
+// Deprecated: please use nns subpackage. This method will be removed in future versions.
 func (c *Client) GetNNSPrice(nnsHash util.Uint160) (int64, error) {
 	return c.invokeNativeGetMethod(nnsHash, "getPrice")
 }
@@ -84,6 +86,8 @@ func (c *Client) GetDesignatedByRole(role noderoles.Role, index uint32) (keys.Pu
 }
 
 // NNSResolve invokes `resolve` method on a NameService contract with the specified hash.
+//
+// Deprecated: please use nns subpackage. This method will be removed in future versions.
 func (c *Client) NNSResolve(nnsHash util.Uint160, name string, typ nns.RecordType) (string, error) {
 	if typ == nns.CNAME {
 		return "", errors.New("can't resolve CNAME record type")
@@ -92,6 +96,8 @@ func (c *Client) NNSResolve(nnsHash util.Uint160, name string, typ nns.RecordTyp
 }
 
 // NNSIsAvailable invokes `isAvailable` method on a NeoNameService contract with the specified hash.
+//
+// Deprecated: please use nns subpackage. This method will be removed in future versions.
 func (c *Client) NNSIsAvailable(nnsHash util.Uint160, name string) (bool, error) {
 	return unwrap.Bool(c.reader.Call(nnsHash, "isAvailable", name))
 }
@@ -101,6 +107,8 @@ func (c *Client) NNSIsAvailable(nnsHash util.Uint160, name string) (bool, error)
 // third one is an error. Use TraverseIterator method to traverse iterator values or
 // TerminateSession to terminate opened iterator session. See TraverseIterator and
 // TerminateSession documentation for more details.
+//
+// Deprecated: please use nns subpackage. This method will be removed in future versions.
 func (c *Client) NNSGetAllRecords(nnsHash util.Uint160, name string) (uuid.UUID, result.Iterator, error) {
 	return unwrap.SessionIterator(c.reader.Call(nnsHash, "getAllRecords", name))
 }
@@ -109,6 +117,8 @@ func (c *Client) NNSGetAllRecords(nnsHash util.Uint160, name string) (uuid.UUID,
 // (config.DefaultMaxIteratorResultItems at max). It differs from NNSGetAllRecords in
 // that no iterator session is used to retrieve values from iterator. Instead, unpacking
 // VM script is created and invoked via `invokescript` JSON-RPC call.
+//
+// Deprecated: please use nns subpackage. This method will be removed in future versions.
 func (c *Client) NNSUnpackedGetAllRecords(nnsHash util.Uint160, name string) ([]nns.RecordState, error) {
 	arr, err := unwrap.Array(c.reader.CallAndExpandIterator(nnsHash, "getAllRecords", config.DefaultMaxIteratorResultItems, name))
 	if err != nil {

--- a/pkg/rpcclient/nns/contract.go
+++ b/pkg/rpcclient/nns/contract.go
@@ -1,0 +1,122 @@
+/*
+Package nns provide some RPC wrappers for the non-native NNS contract.
+
+It's not yet a complete interface because there are different NNS versions
+available, yet it provides the most widely used ones that were available from
+the old RPC client API.
+*/
+package nns
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/nspcc-dev/neo-go/pkg/neorpc/result"
+	"github.com/nspcc-dev/neo-go/pkg/rpcclient/unwrap"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+)
+
+// Invoker is used by ContractReader to call various methods.
+type Invoker interface {
+	Call(contract util.Uint160, operation string, params ...interface{}) (*result.Invoke, error)
+	CallAndExpandIterator(contract util.Uint160, method string, maxItems int, params ...interface{}) (*result.Invoke, error)
+	TerminateSession(sessionID uuid.UUID) error
+	TraverseIterator(sessionID uuid.UUID, iterator *result.Iterator, num int) ([]stackitem.Item, error)
+}
+
+// ContractReader provides an interface to call read-only NNS contract methods.
+type ContractReader struct {
+	invoker Invoker
+	hash    util.Uint160
+}
+
+// RecordIterator is used for iterating over GetAllRecords results.
+type RecordIterator struct {
+	client   Invoker
+	session  uuid.UUID
+	iterator result.Iterator
+}
+
+// NewReader creates an instance of ContractReader that can be used to read
+// data from the contract.
+func NewReader(invoker Invoker, hash util.Uint160) *ContractReader {
+	return &ContractReader{invoker, hash}
+}
+
+// GetPrice returns current domain registration price in GAS.
+func (c *ContractReader) GetPrice() (int64, error) {
+	return unwrap.Int64(c.invoker.Call(c.hash, "getPrice"))
+}
+
+// IsAvailable checks whether the domain given is available for registration.
+func (c *ContractReader) IsAvailable(name string) (bool, error) {
+	return unwrap.Bool(c.invoker.Call(c.hash, "isAvailable", name))
+}
+
+// Resolve resolves the given record type for the given domain (with no more
+// than three redirects).
+func (c *ContractReader) Resolve(name string, typ RecordType) (string, error) {
+	return unwrap.UTF8String(c.invoker.Call(c.hash, "resolve", name, int64(typ)))
+}
+
+// GetAllRecords returns an iterator that allows to retrieve all RecordState
+// items for the given domain name. It depends on the server to provide proper
+// session-based iterator, but can also work with expanded one.
+func (c *ContractReader) GetAllRecords(name string) (*RecordIterator, error) {
+	sess, iter, err := unwrap.SessionIterator(c.invoker.Call(c.hash, "getAllRecords", name))
+	if err != nil {
+		return nil, err
+	}
+
+	return &RecordIterator{
+		client:   c.invoker,
+		iterator: iter,
+		session:  sess,
+	}, nil
+}
+
+// Next returns the next set of elements from the iterator (up to num of them).
+// It can return less than num elements in case iterator doesn't have that many
+// or zero elements if the iterator has no more elements or the session is
+// expired.
+func (r *RecordIterator) Next(num int) ([]RecordState, error) {
+	items, err := r.client.TraverseIterator(r.session, &r.iterator, num)
+	if err != nil {
+		return nil, err
+	}
+	return itemsToRecords(items)
+}
+
+// Terminate closes the iterator session used by RecordIterator (if it's
+// session-based).
+func (r *RecordIterator) Terminate() error {
+	if r.iterator.ID == nil {
+		return nil
+	}
+	return r.client.TerminateSession(r.session)
+}
+
+// GetAllRecordsExpanded is similar to GetAllRecords (uses the same NNS
+// method), but can be useful if the server used doesn't support sessions and
+// doesn't expand iterators. It creates a script that will get num of result
+// items from the iterator right in the VM and return them to you. It's only
+// limited by VM stack and GAS available for RPC invocations.
+func (c *ContractReader) GetAllRecordsExpanded(name string, num int) ([]RecordState, error) {
+	arr, err := unwrap.Array(c.invoker.CallAndExpandIterator(c.hash, "getAllRecords", num, name))
+	if err != nil {
+		return nil, err
+	}
+	return itemsToRecords(arr)
+}
+
+func itemsToRecords(arr []stackitem.Item) ([]RecordState, error) {
+	res := make([]RecordState, len(arr))
+	for i := range arr {
+		err := res[i].FromStackItem(arr[i])
+		if err != nil {
+			return nil, fmt.Errorf("item #%d: %w", i, err)
+		}
+	}
+	return res, nil
+}

--- a/pkg/rpcclient/nns/contract_test.go
+++ b/pkg/rpcclient/nns/contract_test.go
@@ -1,0 +1,197 @@
+package nns
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nspcc-dev/neo-go/pkg/neorpc/result"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/stretchr/testify/require"
+)
+
+type testAct struct {
+	err error
+	res *result.Invoke
+}
+
+func (t *testAct) Call(contract util.Uint160, operation string, params ...interface{}) (*result.Invoke, error) {
+	return t.res, t.err
+}
+func (t *testAct) CallAndExpandIterator(contract util.Uint160, method string, maxItems int, params ...interface{}) (*result.Invoke, error) {
+	return t.res, t.err
+}
+func (t *testAct) TerminateSession(sessionID uuid.UUID) error {
+	return t.err
+}
+func (t *testAct) TraverseIterator(sessionID uuid.UUID, iterator *result.Iterator, num int) ([]stackitem.Item, error) {
+	return t.res.Stack, t.err
+}
+
+func TestSimpleGetters(t *testing.T) {
+	ta := &testAct{}
+	nns := NewReader(ta, util.Uint160{1, 2, 3})
+
+	ta.err = errors.New("")
+	_, err := nns.GetPrice()
+	require.Error(t, err)
+	_, err = nns.IsAvailable("nspcc.neo")
+	require.Error(t, err)
+	_, err = nns.Resolve("nspcc.neo", A)
+	require.Error(t, err)
+
+	ta.err = nil
+	ta.res = &result.Invoke{
+		State: "HALT",
+		Stack: []stackitem.Item{
+			stackitem.Make(100500),
+		},
+	}
+	price, err := nns.GetPrice()
+	require.NoError(t, err)
+	require.Equal(t, int64(100500), price)
+
+	ta.res = &result.Invoke{
+		State: "HALT",
+		Stack: []stackitem.Item{
+			stackitem.Make(true),
+		},
+	}
+	ava, err := nns.IsAvailable("nspcc.neo")
+	require.NoError(t, err)
+	require.Equal(t, true, ava)
+
+	ta.res = &result.Invoke{
+		State: "HALT",
+		Stack: []stackitem.Item{
+			stackitem.Make("some text"),
+		},
+	}
+	txt, err := nns.Resolve("nspcc.neo", TXT)
+	require.NoError(t, err)
+	require.Equal(t, "some text", txt)
+}
+
+func TestGetAllRecords(t *testing.T) {
+	ta := &testAct{}
+	nns := NewReader(ta, util.Uint160{1, 2, 3})
+
+	ta.err = errors.New("")
+	_, err := nns.GetAllRecords("nspcc.neo")
+	require.Error(t, err)
+
+	ta.err = nil
+	iid := uuid.New()
+	ta.res = &result.Invoke{
+		State: "HALT",
+		Stack: []stackitem.Item{
+			stackitem.NewInterop(result.Iterator{
+				ID: &iid,
+			}),
+		},
+	}
+	_, err = nns.GetAllRecords("nspcc.neo")
+	require.Error(t, err)
+
+	// Session-based iterator.
+	sid := uuid.New()
+	ta.res = &result.Invoke{
+		Session: sid,
+		State:   "HALT",
+		Stack: []stackitem.Item{
+			stackitem.NewInterop(result.Iterator{
+				ID: &iid,
+			}),
+		},
+	}
+	iter, err := nns.GetAllRecords("nspcc.neo")
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+	ta.res = &result.Invoke{
+		Stack: []stackitem.Item{
+			stackitem.Make([]stackitem.Item{
+				stackitem.Make("n3"),
+				stackitem.Make(16),
+				stackitem.Make("cool"),
+			}),
+		},
+	}
+	vals, err := iter.Next(10)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(vals))
+	require.Equal(t, RecordState{
+		Name: "n3",
+		Type: TXT,
+		Data: "cool",
+	}, vals[0])
+
+	ta.err = errors.New("")
+	_, err = iter.Next(1)
+	require.Error(t, err)
+
+	err = iter.Terminate()
+	require.Error(t, err)
+
+	// Value-based iterator.
+	ta.err = nil
+	ta.res = &result.Invoke{
+		State: "HALT",
+		Stack: []stackitem.Item{
+			stackitem.NewInterop(result.Iterator{
+				Values: []stackitem.Item{
+					stackitem.Make("n3"),
+					stackitem.Make(16),
+					stackitem.Make("cool"),
+				},
+			}),
+		},
+	}
+	iter, err = nns.GetAllRecords("nspcc.neo")
+	require.NoError(t, err)
+
+	ta.err = errors.New("")
+	err = iter.Terminate()
+	require.NoError(t, err)
+}
+
+func TestGetAllRecordsExpanded(t *testing.T) {
+	ta := &testAct{}
+	nns := NewReader(ta, util.Uint160{1, 2, 3})
+
+	ta.err = errors.New("")
+	_, err := nns.GetAllRecordsExpanded("nspcc.neo", 8)
+	require.Error(t, err)
+
+	ta.err = nil
+	ta.res = &result.Invoke{
+		State: "HALT",
+		Stack: []stackitem.Item{
+			stackitem.Make(42),
+		},
+	}
+	_, err = nns.GetAllRecordsExpanded("nspcc.neo", 8)
+	require.Error(t, err)
+
+	ta.res = &result.Invoke{
+		State: "HALT",
+		Stack: []stackitem.Item{
+			stackitem.Make([]stackitem.Item{
+				stackitem.Make([]stackitem.Item{
+					stackitem.Make("n3"),
+					stackitem.Make(16),
+					stackitem.Make("cool"),
+				}),
+			}),
+		},
+	}
+	vals, err := nns.GetAllRecordsExpanded("nspcc.neo", 8)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(vals))
+	require.Equal(t, RecordState{
+		Name: "n3",
+		Type: TXT,
+		Data: "cool",
+	}, vals[0])
+}

--- a/pkg/rpcclient/nns/record_test.go
+++ b/pkg/rpcclient/nns/record_test.go
@@ -1,0 +1,39 @@
+package nns
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordStateFromStackItem(t *testing.T) {
+	r := &RecordState{}
+	require.Error(t, r.FromStackItem(stackitem.Make(42)))
+	require.Error(t, r.FromStackItem(stackitem.Make([]stackitem.Item{})))
+	require.Error(t, r.FromStackItem(stackitem.Make([]stackitem.Item{
+		stackitem.Make([]stackitem.Item{}),
+		stackitem.Make(16),
+		stackitem.Make("cool"),
+	})))
+	require.Error(t, r.FromStackItem(stackitem.Make([]stackitem.Item{
+		stackitem.Make("n3"),
+		stackitem.Make([]stackitem.Item{}),
+		stackitem.Make("cool"),
+	})))
+	require.Error(t, r.FromStackItem(stackitem.Make([]stackitem.Item{
+		stackitem.Make("n3"),
+		stackitem.Make(16),
+		stackitem.Make([]stackitem.Item{}),
+	})))
+	require.Error(t, r.FromStackItem(stackitem.Make([]stackitem.Item{
+		stackitem.Make("n3"),
+		stackitem.Make(100500),
+		stackitem.Make("cool"),
+	})))
+	require.NoError(t, r.FromStackItem(stackitem.Make([]stackitem.Item{
+		stackitem.Make("n3"),
+		stackitem.Make(16),
+		stackitem.Make("cool"),
+	})))
+}


### PR DESCRIPTION
We need to move these methods out even if we can't provide complete NNS support yet.