### PR TITLE
Dynamic semver from git describe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DC_FILE ?= ".docker/docker-compose.yml" # Single docker-compose for Ubuntu/WSC, 
 ENV_IMAGE_TAG="env_neo_go_image"
 
 REPO ?= "$(shell go list -m)"
-VERSION ?= "$(shell git describe --tags --match "v*" 2>/dev/null | sed 's/^v//')"
+VERSION ?= "$(shell git describe --tags --match "v*" 2>/dev/null | sed -r 's,^v([0-9]+\.[0-9]+)\.([0-9]+)(-.*)?$$,\1 \2 \3,' | while read mm patch suffix; do if [ -z "$$suffix" ]; then echo $$mm.$$patch; else patch=`expr $$patch + 1`; echo $$mm.$${patch}-pre$$suffix; fi; done)"
 MODVERSION ?= "$(shell cat go.mod | cat go.mod | sed -r -n -e 's|.*pkg/interop (.*)|\1|p')"
 BUILD_FLAGS = "-X '$(REPO)/pkg/config.Version=$(VERSION)' -X '$(REPO)/cli/smartcontract.ModVersion=$(MODVERSION)'"
 


### PR DESCRIPTION
@AnnaShaleva, what do you think? We can make it the first commit after v0.99.3 (hopefully it works from Windows) and then leverage it in many ways. It looks bad, I know. But maybe worth doing. Then we could even drop *-pre tags completely after some time.