### PR TITLE
rpcclient: simplify historic API

### DIFF
--- a/pkg/rpcclient/invoker/invoker_test.go
+++ b/pkg/rpcclient/invoker/invoker_test.go
@@ -29,25 +29,16 @@ func (r *rpcInv) InvokeFunction(contract util.Uint160, operation string, params 
 func (r *rpcInv) InvokeScript(script []byte, signers []transaction.Signer) (*result.Invoke, error) {
 	return r.resInv, r.err
 }
-func (r *rpcInv) InvokeContractVerifyAtBlock(blockHash util.Uint256, contract util.Uint160, params []smartcontract.Parameter, signers []transaction.Signer, witnesses ...transaction.Witness) (*result.Invoke, error) {
-	return r.resInv, r.err
-}
 func (r *rpcInv) InvokeContractVerifyAtHeight(height uint32, contract util.Uint160, params []smartcontract.Parameter, signers []transaction.Signer, witnesses ...transaction.Witness) (*result.Invoke, error) {
 	return r.resInv, r.err
 }
 func (r *rpcInv) InvokeContractVerifyWithState(stateroot util.Uint256, contract util.Uint160, params []smartcontract.Parameter, signers []transaction.Signer, witnesses ...transaction.Witness) (*result.Invoke, error) {
 	return r.resInv, r.err
 }
-func (r *rpcInv) InvokeFunctionAtBlock(blockHash util.Uint256, contract util.Uint160, operation string, params []smartcontract.Parameter, signers []transaction.Signer) (*result.Invoke, error) {
-	return r.resInv, r.err
-}
 func (r *rpcInv) InvokeFunctionAtHeight(height uint32, contract util.Uint160, operation string, params []smartcontract.Parameter, signers []transaction.Signer) (*result.Invoke, error) {
 	return r.resInv, r.err
 }
 func (r *rpcInv) InvokeFunctionWithState(stateroot util.Uint256, contract util.Uint160, operation string, params []smartcontract.Parameter, signers []transaction.Signer) (*result.Invoke, error) {
-	return r.resInv, r.err
-}
-func (r *rpcInv) InvokeScriptAtBlock(blockHash util.Uint256, script []byte, signers []transaction.Signer) (*result.Invoke, error) {
 	return r.resInv, r.err
 }
 func (r *rpcInv) InvokeScriptAtHeight(height uint32, script []byte, signers []transaction.Signer) (*result.Invoke, error) {
@@ -108,9 +99,6 @@ func TestInvoker(t *testing.T) {
 	t.Run("standard", func(t *testing.T) {
 		testInv(t, New(ri, nil))
 	})
-	t.Run("historic, block", func(t *testing.T) {
-		testInv(t, NewHistoricAtBlock(util.Uint256{}, ri, nil))
-	})
 	t.Run("historic, height", func(t *testing.T) {
 		testInv(t, NewHistoricAtHeight(100500, ri, nil))
 	})
@@ -124,7 +112,7 @@ func TestInvoker(t *testing.T) {
 		require.Panics(t, func() { _, _ = inv.Run([]byte{1}) })
 	})
 	t.Run("terminate session", func(t *testing.T) {
-		for _, inv := range []*Invoker{New(ri, nil), NewHistoricAtBlock(util.Uint256{}, ri, nil)} {
+		for _, inv := range []*Invoker{New(ri, nil), NewHistoricWithState(util.Uint256{}, ri, nil)} {
 			ri.err = errors.New("")
 			require.Error(t, inv.TerminateSession(uuid.UUID{}))
 			ri.err = nil
@@ -135,7 +123,7 @@ func TestInvoker(t *testing.T) {
 		}
 	})
 	t.Run("traverse iterator", func(t *testing.T) {
-		for _, inv := range []*Invoker{New(ri, nil), NewHistoricAtBlock(util.Uint256{}, ri, nil)} {
+		for _, inv := range []*Invoker{New(ri, nil), NewHistoricWithState(util.Uint256{}, ri, nil)} {
 			res, err := inv.TraverseIterator(uuid.UUID{}, &result.Iterator{
 				Values: []stackitem.Item{stackitem.Make(42)},
 			}, 0)

--- a/pkg/rpcclient/rpc.go
+++ b/pkg/rpcclient/rpc.go
@@ -605,21 +605,12 @@ func (c *Client) InvokeScriptAtHeight(height uint32, script []byte, signers []tr
 	return c.invokeSomething("invokescripthistoric", p, signers)
 }
 
-// InvokeScriptAtBlock returns the result of the given script after running it
-// true the VM using the provided chain state retrieved from the specified block
-// hash.
-// NOTE: This is a test invoke and will not affect the blockchain.
-func (c *Client) InvokeScriptAtBlock(blockHash util.Uint256, script []byte, signers []transaction.Signer) (*result.Invoke, error) {
-	var p = []interface{}{blockHash.StringLE(), script}
-	return c.invokeSomething("invokescripthistoric", p, signers)
-}
-
 // InvokeScriptWithState returns the result of the given script after running it
 // true the VM using the provided chain state retrieved from the specified
-// stateroot hash.
+// state root or block hash.
 // NOTE: This is a test invoke and will not affect the blockchain.
-func (c *Client) InvokeScriptWithState(stateroot util.Uint256, script []byte, signers []transaction.Signer) (*result.Invoke, error) {
-	var p = []interface{}{stateroot.StringLE(), script}
+func (c *Client) InvokeScriptWithState(stateOrBlock util.Uint256, script []byte, signers []transaction.Signer) (*result.Invoke, error) {
+	var p = []interface{}{stateOrBlock.StringLE(), script}
 	return c.invokeSomething("invokescripthistoric", p, signers)
 }
 
@@ -640,21 +631,12 @@ func (c *Client) InvokeFunctionAtHeight(height uint32, contract util.Uint160, op
 	return c.invokeSomething("invokefunctionhistoric", p, signers)
 }
 
-// InvokeFunctionAtBlock returns the results after calling the smart contract
-// with the given operation and parameters at given the blockchain state
-// specified by the block hash.
-// NOTE: this is test invoke and will not affect the blockchain.
-func (c *Client) InvokeFunctionAtBlock(blockHash util.Uint256, contract util.Uint160, operation string, params []smartcontract.Parameter, signers []transaction.Signer) (*result.Invoke, error) {
-	var p = []interface{}{blockHash.StringLE(), contract.StringLE(), operation, params}
-	return c.invokeSomething("invokefunctionhistoric", p, signers)
-}
-
 // InvokeFunctionWithState returns the results after calling the smart contract
 // with the given operation and parameters at the given blockchain state defined
-// by the specified stateroot hash.
+// by the specified state root or block hash.
 // NOTE: this is test invoke and will not affect the blockchain.
-func (c *Client) InvokeFunctionWithState(stateroot util.Uint256, contract util.Uint160, operation string, params []smartcontract.Parameter, signers []transaction.Signer) (*result.Invoke, error) {
-	var p = []interface{}{stateroot.StringLE(), contract.StringLE(), operation, params}
+func (c *Client) InvokeFunctionWithState(stateOrBlock util.Uint256, contract util.Uint160, operation string, params []smartcontract.Parameter, signers []transaction.Signer) (*result.Invoke, error) {
+	var p = []interface{}{stateOrBlock.StringLE(), contract.StringLE(), operation, params}
 	return c.invokeSomething("invokefunctionhistoric", p, signers)
 }
 
@@ -675,21 +657,12 @@ func (c *Client) InvokeContractVerifyAtHeight(height uint32, contract util.Uint1
 	return c.invokeSomething("invokecontractverifyhistoric", p, signers, witnesses...)
 }
 
-// InvokeContractVerifyAtBlock returns the results after calling `verify` method
-// of the smart contract with the given parameters under verification trigger type
-// at the blockchain state specified by the block hash.
-// NOTE: this is test invoke and will not affect the blockchain.
-func (c *Client) InvokeContractVerifyAtBlock(blockHash util.Uint256, contract util.Uint160, params []smartcontract.Parameter, signers []transaction.Signer, witnesses ...transaction.Witness) (*result.Invoke, error) {
-	var p = []interface{}{blockHash.StringLE(), contract.StringLE(), params}
-	return c.invokeSomething("invokecontractverifyhistoric", p, signers, witnesses...)
-}
-
 // InvokeContractVerifyWithState returns the results after calling `verify` method
 // of the smart contract with the given parameters under verification trigger type
-// at the blockchain state specified by the stateroot hash.
+// at the blockchain state specified by the state root or block hash.
 // NOTE: this is test invoke and will not affect the blockchain.
-func (c *Client) InvokeContractVerifyWithState(stateroot util.Uint256, contract util.Uint160, params []smartcontract.Parameter, signers []transaction.Signer, witnesses ...transaction.Witness) (*result.Invoke, error) {
-	var p = []interface{}{stateroot.StringLE(), contract.StringLE(), params}
+func (c *Client) InvokeContractVerifyWithState(stateOrBlock util.Uint256, contract util.Uint160, params []smartcontract.Parameter, signers []transaction.Signer, witnesses ...transaction.Witness) (*result.Invoke, error) {
+	var p = []interface{}{stateOrBlock.StringLE(), contract.StringLE(), params}
 	return c.invokeSomething("invokecontractverifyhistoric", p, signers, witnesses...)
 }
 

--- a/pkg/services/rpcsrv/client_test.go
+++ b/pkg/services/rpcsrv/client_test.go
@@ -1264,7 +1264,7 @@ func TestInvokeVerify(t *testing.T) {
 	})
 
 	t.Run("positive, historic, by block, with signer", func(t *testing.T) {
-		res, err := c.InvokeContractVerifyAtBlock(chain.GetHeaderHash(int(chain.BlockHeight())-1), contract, []smartcontract.Parameter{}, []transaction.Signer{{Account: testchain.PrivateKeyByID(0).PublicKey().GetScriptHash()}})
+		res, err := c.InvokeContractVerifyWithState(chain.GetHeaderHash(int(chain.BlockHeight())-1), contract, []smartcontract.Parameter{}, []transaction.Signer{{Account: testchain.PrivateKeyByID(0).PublicKey().GetScriptHash()}})
 		require.NoError(t, err)
 		require.Equal(t, "HALT", res.State)
 		require.Equal(t, 1, len(res.Stack))
@@ -1290,7 +1290,7 @@ func TestInvokeVerify(t *testing.T) {
 	})
 
 	t.Run("bad, historic, by block: contract not found", func(t *testing.T) {
-		_, err = c.InvokeContractVerifyAtBlock(chain.GetHeaderHash(1), contract, []smartcontract.Parameter{}, []transaction.Signer{{Account: testchain.PrivateKeyByID(0).PublicKey().GetScriptHash()}})
+		_, err = c.InvokeContractVerifyWithState(chain.GetHeaderHash(1), contract, []smartcontract.Parameter{}, []transaction.Signer{{Account: testchain.PrivateKeyByID(0).PublicKey().GetScriptHash()}})
 		require.Error(t, err)
 		require.True(t, strings.Contains(err.Error(), core.ErrUnknownVerificationContract.Error())) // contract wasn't deployed at block #1 yet
 	})


### PR DESCRIPTION
util.Uint256 is util.Uint256 and it's same RPC behind the scenes, so we can make it a bit easier to digest. See #2545 also.

Probably will need a rebase after #2683.