### PR TITLE
stateroot: fix panic on shutdown

### DIFF
--- a/pkg/services/stateroot/validators.go
+++ b/pkg/services/stateroot/validators.go
@@ -74,7 +74,9 @@ func (s *service) Shutdown() {
 	s.log.Info("stopping state validation service")
 	close(s.stopCh)
 	<-s.done
-	s.wallet.Close()
+	if s.wallet != nil {
+		s.wallet.Close()
+	}
 }
 
 func (s *service) signAndSend(r *state.MPTRoot) error {


### PR DESCRIPTION
Stateroot service is always active, but it might have no wallet.

panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xc57d41]

goroutine 1 [running]:
github.com/nspcc-dev/neo-go/pkg/wallet.(*Wallet).Close(...)
        github.com/nspcc-dev/neo-go/pkg/wallet/wallet.go:175
github.com/nspcc-dev/neo-go/pkg/services/stateroot.(*service).Shutdown(0xc000105880?)
        github.com/nspcc-dev/neo-go/pkg/services/stateroot/validators.go:77 +0x81
github.com/nspcc-dev/neo-go/pkg/network.(*Server).Shutdown(0xc000105880)
        github.com/nspcc-dev/neo-go/pkg/network/server.go:271 +0x205
github.com/nspcc-dev/neo-go/cli/server.startServer(0xc0002702c0)
        github.com/nspcc-dev/neo-go/cli/server/server.go:641 +0x2675
github.com/urfave/cli.HandleAction({0xe456e0?, 0x1155f20?}, 0x4?)
        github.com/urfave/cli@v1.22.5/app.go:524 +0x50
github.com/urfave/cli.Command.Run({{0xfca38b, 0x4}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0xfd6a46, 0x10}, {0xffebe3, ...}, ...}, ...)
        github.com/urfave/cli@v1.22.5/command.go:173 +0x65b
github.com/urfave/cli.(*App).Run(0xc000272000, {0xc00003e180, 0x3, 0x3})
        github.com/urfave/cli@v1.22.5/app.go:277 +0x8a7
main.main()
        ./main.go:21 +0x33
