### PR TITLE
interop: adjust Iterator documentation

### DIFF
--- a/pkg/interop/iterator/iterator.go
+++ b/pkg/interop/iterator/iterator.go
@@ -6,8 +6,8 @@ package iterator
 import "github.com/nspcc-dev/neo-go/pkg/interop/neogointernal"
 
 // Iterator represents a Neo iterator, it's an opaque data structure that can
-// be properly created by Create or storage.Find. Iterators range over key-value
-// pairs, so it's convenient to use them for maps. This structure is similar in
+// be properly created by storage.Find. Iterators range over key-value pairs,
+// so it's convenient to use them for maps. This structure is similar in
 // function to Neo .net framework's Iterator.
 type Iterator struct{}
 
@@ -22,7 +22,7 @@ func Next(it Iterator) bool {
 // Value returns iterator's current value. It's only valid to call after
 // a successful Next call. This function uses `System.Iterator.Value` syscall.
 // For slices, the result is just value.
-// For maps, the result can be casted to a slice of 2 elements: a key and a value.
+// For maps, the result can be cast to a slice of 2 elements: a key and a value.
 // For storage iterators, refer to `storage.FindFlags` documentation.
 func Value(it Iterator) interface{} {
 	return neogointernal.Syscall1("System.Iterator.Value", it)


### PR DESCRIPTION
The only way to get Iterator is as a result of storage.Find.