### PR TITLE
core: add example to VUB comment

### DIFF
--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -47,7 +47,8 @@ type Transaction struct {
 	NetworkFee int64
 
 	// Maximum blockchain height exceeding which
-	// transaction should fail verification.
+	// transaction should fail verification. E.g. if VUB=N, then transaction
+	// can be accepted to block with index N, but not to block with index N+1.
 	ValidUntilBlock uint32
 
 	// Code to run in NeoVM for this transaction.


### PR DESCRIPTION
### Problem

~VUB documentation doesn't match the behaviour.~ Thanks to @KirillovDenis.

It matches perfectly, my bad.