### PR TITLE
network: don't wait indefinitely for packet to be sent

### DIFF
--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -1385,7 +1385,7 @@ func (s *Server) iteratePeersWithSendMsg(msg *Message, send func(Peer, bool, []b
 					peer.AddGetAddrSent()
 				}
 				sentN++
-			} else if errors.Is(err, errBusy) {
+			} else if !blocking && errors.Is(err, errBusy) {
 				// Can be retried.
 				continue
 			} else {


### PR DESCRIPTION
Peers can be slow, very slow, slow enough to affect node's regular operation. We can't wait for them indefinitely, there has to be a timeout for send operations.

This patch uses TimePerBlock as a reference for its timeout. It's relatively big and it doesn't affect tests much, 4+1 scenarios tend to perform a little worse with while 7+2 scenarios work a little better. The difference is in some percents, but all of these tests easily have 10-15% variations from run to run.

It's an important step in making our gossip better because we can't have any behavior where neighbors directly block the node forever, refs. #2678 and #608.

This is set of tests this patch was tried on (4+1/7+2 with no 0 or 200ms delay):
![cpu_four_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/194935511-90c2b616-1b51-4466-9fdd-3523940bee47.png)
![cpu_four_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/194935516-29b5bd9f-135a-48b9-8913-935c2b79330c.png)
![cpu_seven_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/194935517-b8515fa1-7db8-4f98-b683-649604301dad.png)
![cpu_seven_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/194935519-517bef2f-312f-4115-83f8-a42f003c9069.png)
![mem_four_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/194935521-c45cf84b-5675-4555-a81f-62c555071386.png)
![mem_four_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/194935525-66fd3294-f850-4f03-a8ab-119f7c8de28e.png)
![mem_seven_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/194935526-2bddc959-7f04-4ac6-be39-ba95a0f6336a.png)
![mem_seven_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/194935529-ec5234dd-8dfb-4a4e-a463-d8b01e4a4eea.png)
![ms_per_block_four_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/194935530-6e5bfb80-f111-4961-a6b7-e1dd94a9cdac.png)
![ms_per_block_four_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/194935532-53656431-cf41-4867-8b93-fdfe97413cc9.png)
![ms_per_block_seven_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/194935535-d10dc0bc-fe2e-4e72-91f3-aece15e6508b.png)
![ms_per_block_seven_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/194935537-9f80a745-b04d-4c18-9418-0a9ea69a07aa.png)
![tpb_four_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/194935539-680c5858-e5dc-411d-b5c3-05365db3e20f.png)
![tpb_four_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/194935540-dc385425-b9f8-47a6-8546-30835c426320.png)
![tpb_seven_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/194935544-f733d0cf-fd6d-4995-8fce-c25a2a8f84f0.png)
![tpb_seven_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/194935547-ecff9409-da1f-42f4-a916-62e3dfa53f86.png)
![tps_four_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/194935549-ba423fe3-e900-4704-8de3-7b21e9b76dd7.png)
![tps_four_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/194935551-0ac3489e-bd28-4ae8-baae-254080381f16.png)
![tps_seven_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/194935553-2223f6f1-1fa9-4141-ba3a-99cb2e623149.png)
![tps_seven_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/194935554-5bc41ed4-82a6-4edb-aada-bb8cca1766e6.png)

One more thing I've tried today is making the timeout adaptive (7f47acecf0653ede6837c13ba59a64eed1e53f94), so it could be lower or higher depending on the network. But turns out that most of the time these timeouts are very low, so the average one tends to go down quickly and when it's already low we have higher chances for packets to be dropped. This can be regulated with some coefficients, but they don't seem to be meaningful/reasonable when tests start to approach normal characteristics (expected "normal" coefficients or 2/4/8 drastically degrade performance).