### PR TITLE
smartcontract: fix underlying PublicKey parameter value

### DIFF
--- a/pkg/smartcontract/parameter.go
+++ b/pkg/smartcontract/parameter.go
@@ -387,8 +387,6 @@ func NewParametersFromValues(values ...interface{}) ([]Parameter, error) {
 func ExpandParameterToEmitable(param Parameter) (interface{}, error) {
 	var err error
 	switch t := param.Type; t {
-	case PublicKeyType:
-		return param.Value.(*keys.PublicKey).Bytes(), nil
 	case ArrayType:
 		arr := param.Value.([]Parameter)
 		res := make([]interface{}, len(arr))

--- a/pkg/smartcontract/parameter_test.go
+++ b/pkg/smartcontract/parameter_test.go
@@ -477,7 +477,7 @@ func TestExpandParameterToEmitable(t *testing.T) {
 			Expected: util.Uint256{1, 2, 3},
 		},
 		{
-			In:       Parameter{Type: PublicKeyType, Value: pk.PublicKey()},
+			In:       Parameter{Type: PublicKeyType, Value: pk.PublicKey().Bytes()},
 			Expected: pk.PublicKey().Bytes(),
 		},
 		{


### PR DESCRIPTION
Value of PublicKey parameter always stores public key bytes, not the deserialized representation. All other code (CLI parameters parsing, RPC-related code, etc.) is based on the idea that value of PublicKey is []byte.