### PR TITLE
Rework broadcast logic

### DIFF
--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -109,18 +110,21 @@ func (p *localPeer) EnqueueMessage(msg *Message) error {
 	if err != nil {
 		return err
 	}
-	return p.EnqueuePacket(true, b)
+	return p.EnqueueHPPacket(b)
 }
-func (p *localPeer) EnqueuePacket(block bool, m []byte) error {
-	return p.EnqueueHPPacket(block, m)
+func (p *localPeer) BroadcastPacket(_ context.Context, m []byte) error {
+	return p.EnqueueHPPacket(m)
 }
 func (p *localPeer) EnqueueP2PMessage(msg *Message) error {
 	return p.EnqueueMessage(msg)
 }
 func (p *localPeer) EnqueueP2PPacket(m []byte) error {
-	return p.EnqueueHPPacket(true, m)
+	return p.EnqueueHPPacket(m)
 }
-func (p *localPeer) EnqueueHPPacket(_ bool, m []byte) error {
+func (p *localPeer) BroadcastHPPacket(_ context.Context, m []byte) error {
+	return p.EnqueueHPPacket(m)
+}
+func (p *localPeer) EnqueueHPPacket(m []byte) error {
 	msg := &Message{}
 	r := io.NewBinReaderFromBuf(m)
 	err := msg.Decode(r)

--- a/pkg/network/peer.go
+++ b/pkg/network/peer.go
@@ -20,8 +20,8 @@ type Peer interface {
 	PeerAddr() net.Addr
 	Disconnect(error)
 
-	// EnqueueMessage is a temporary wrapper that sends a message via
-	// EnqueuePacket if there is no error in serializing it.
+	// EnqueueMessage is a blocking packet enqueuer similar to EnqueueP2PMessage,
+	// but using the lowest priority queue.
 	EnqueueMessage(*Message) error
 
 	// BroadcastPacket is a context-bound packet enqueuer, it either puts the
@@ -43,7 +43,7 @@ type Peer interface {
 	// EnqueueP2PPacket is a blocking packet enqueuer, it doesn't return until
 	// it puts the given packet into the queue. It accepts a slice of bytes that
 	// can be shared with other queues (so that message marshalling can be
-	// done once for all peers). It does nothing if the peer has not yet
+	// done once for all peers). It returns an error if the peer has not yet
 	// completed handshaking. This queue is intended to be used for unicast
 	// peer to peer communication that is more important than broadcasts
 	// (handled by BroadcastPacket) but less important than high-priority

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -1367,11 +1367,11 @@ func (s *Server) iteratePeersWithSendMsg(msg *Message, send func(Peer, context.C
 	var ctx, cancel = context.WithTimeout(context.Background(), s.TimePerBlock/2)
 	for _, peer := range peers {
 		go func(p Peer, ctx context.Context, pkt []byte) {
-			err := send(p, ctx, pkt)
-			if err == nil && msg.Command == CMDGetAddr {
+			// Do this before packet is sent, reader thread can get the reply before this routine wakes up.
+			if msg.Command == CMDGetAddr {
 				p.AddGetAddrSent()
 			}
-			replies <- err
+			replies <- send(p, ctx, pkt)
 		}(peer, ctx, pkt)
 	}
 	for r := range replies {


### PR DESCRIPTION
    We have a number of queues for different purposes:
     * regular broadcast queue
     * direct p2p queue
     * high-priority queue
    
    And two basic egress scenarios:
     * direct p2p messages (replies to requests in Server's handle* methods)
     * broadcasted messages
    
    Low priority broadcasted messages:
     * transaction inventories
     * block inventories
     * notary inventories
     * non-consensus extensibles
    
    High-priority broadcasted messages:
     * consensus extensibles
     * getdata transaction requests from consensus process
     * getaddr requests
    
    P2P messages are a bit more complicated, most of the time they use p2p queue,
    but extensible message requests/replies use HP queue.
    
    Server's handle* code is run from Peer's handleIncoming, every peer has this
    thread that handles incoming messages. When working with the peer it's
    important to reply to requests and blocking this thread until we send (queue)
    a reply is fine, if the peer is slow we just won't get anything new from
    it. The queue used is irrelevant wrt this issue.
    
    Broadcasted messages are radically different, we want them to be delivered to
    many peers, but we don't care about specific ones. If it's delivered to 2/3 of
    the peers we're fine, if it's delivered to more of them --- it's not an
    issue. But doing this fairly is not an easy thing, current code tries performing
    unblocked sends and if this doesn't yield enough results it then blocks (but
    has a timeout, we can't wait indefinitely). But it does so in sequential
    manner, once the peer is chosen the code will wait for it (and only it) until
    timeout happens.
    
    What can be done instead is an attempt to push the message to all of the peers
    simultaneously (or close to that). If they all deliver --- OK, if some block
    and wait then we can wait until _any_ of them pushes the message through (or
    global timeout happens, we still can't wait forever). If we have enough
    deliveries then we can cancel pending ones and it's again not an error if
    these canceled threads still do their job.
    
    This makes the system more dynamic and adds some substantial processing
    overhead, but it's a networking code, any of this overhead is much lower than
    the actual packet delivery time. It also allows to spread the load more
    fairly, if there is any spare queue it'll get the packet and release the
    broadcaster. On the next broadcast iteration another peer is more likely to be
    chosen just because it didn't get a message previously (and had some time to
    deliver already queued messages).
    
    It works perfectly in tests, with optimal networking conditions we have much
    better block times and TPS increases by 5-25%% depending on the scenario.
    
    I'd go as far as to say that it fixes the original problem of #2678, because
    in this particular scenario we have empty queues in ~100% of the cases and
    this new logic will likely lead to 100% fan out in this case (cancelation just
    won't happen fast enough). But when the load grows and there is some waiting
    in the queue it will optimize out the slowest links.

![cpu_four_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/195136338-79fbdee3-1dc9-412b-b4b9-640d168dd202.png)
![cpu_four_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/195136342-d573cb40-0f0c-4294-bd85-3b3087a263d9.png)
![cpu_seven_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/195136347-266cd8b0-5cf3-4981-af96-070ef72ebd7d.png)
![cpu_seven_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/195136349-65e8bbd6-0994-47e6-939f-0ff444b1bf88.png)
![mem_four_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/195136352-51f37d5d-c1cf-44b5-b6b6-08c48295b54b.png)
![mem_four_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/195136353-34e7d82f-c32f-4f1f-a548-13b81bb1275c.png)
![mem_seven_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/195136354-e374f8f6-529c-4124-936a-9b60874c4f0b.png)
![mem_seven_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/195136361-e1334dcd-c1fc-44d7-afbc-589d36f30b63.png)
![ms_per_block_four_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/195136368-0fe70a86-ff0b-4c37-9357-ad4003b3ef5e.png)
![ms_per_block_four_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/195136370-34e12dae-b664-490e-b8ba-c73f79156dea.png)
![ms_per_block_seven_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/195136371-3ea75b3e-d1ca-411a-8377-2155325d7c1c.png)
![ms_per_block_seven_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/195136375-78da0621-3f85-4275-89e2-6831db0b30b1.png)
![tpb_four_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/195136378-fc22d170-c621-41ec-bb98-e7c03cc22bb5.png)
![tpb_four_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/195136384-cde20180-2467-4e5e-9350-7567b59c4af2.png)
![tpb_seven_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/195136388-f7b72269-785a-4be1-80e7-0cbfe570f9bc.png)
![tpb_seven_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/195136394-d6336801-7902-426b-98d1-7871a3b85446.png)
![tps_four_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/195136397-72484646-c667-4544-96df-df29fb05116c.png)
![tps_four_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/195136406-b98cff1e-2172-4724-ad38-c5b1ad6f5245.png)
![tps_seven_(30_wrk,_50K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/195136409-b848878e-9bf4-454e-890d-99acaac80cf4.png)
![tps_seven_(30_wrk,_50K_pool)](https://user-images.githubusercontent.com/22092804/195136414-c7fd43fe-8496-4f0e-96ca-13472455e473.png)
