### PR TITLE
Logarithmic gossip fan out

### DIFF
--- a/config/protocol.mainnet.yml
+++ b/config/protocol.mainnet.yml
@@ -69,7 +69,7 @@ ApplicationConfiguration:
   PingTimeout: 90
   MaxPeers: 100
   AttemptConnPeers: 20
-  MinPeers: 5
+  MinPeers: 10
   Oracle:
     Enabled: false
     AllowedContentTypes:

--- a/config/protocol.testnet.yml
+++ b/config/protocol.testnet.yml
@@ -72,7 +72,7 @@ ApplicationConfiguration:
   PingTimeout: 90
   MaxPeers: 100
   AttemptConnPeers: 20
-  MinPeers: 5
+  MinPeers: 10
   Oracle:
     Enabled: false
     AllowedContentTypes:

--- a/docs/node-configuration.md
+++ b/docs/node-configuration.md
@@ -19,6 +19,7 @@ node-related settings described in the table below.
 | Address | `string` | `0.0.0.0` | Node address that P2P protocol handler binds to. |
 | AnnouncedPort | `uint16` | Same as `NodePort` | Node port which should be used to announce node's port on P2P layer, it can differ from the `NodePort` the node is bound to (for example, if your node is behind NAT). |
 | AttemptConnPeers | `int` | `20` | Number of connection to try to establish when the connection count drops below the `MinPeers` value.|
+| BroadcastFactor | `int` | `0` | Multiplier that is used to determine the number of optimal gossip fan-out peer number for broadcasted messages (0-100). By default it's zero, node uses the most optimized value depending on the estimated network size (`2.5×log(size)`), so the node may have 20 peers and calculate that it needs to broadcast messages to just 10 of them. With BroadcastFactor set to 100 it will always send messages to all peers, any value in-between 0 and 100 is used for weighted calculation, for example if it's 30 then 13 neighbors will be used in the previous case. |
 | DBConfiguration | [DB Configuration](#DB-Configuration) |  | Describes configuration for database. See the [DB Configuration](#DB-Configuration) section for details. |
 | DialTimeout | `int64` | `0` | Maximum duration a single dial may take in seconds. |
 | ExtensiblePoolSize | `int` | `20` | Maximum amount of the extensible payloads from a single sender stored in a local pool. |

--- a/pkg/config/application_config.go
+++ b/pkg/config/application_config.go
@@ -6,9 +6,11 @@ import (
 
 // ApplicationConfiguration config specific to the node.
 type ApplicationConfiguration struct {
-	Address           string                   `yaml:"Address"`
-	AnnouncedNodePort uint16                   `yaml:"AnnouncedPort"`
-	AttemptConnPeers  int                      `yaml:"AttemptConnPeers"`
+	Address           string `yaml:"Address"`
+	AnnouncedNodePort uint16 `yaml:"AnnouncedPort"`
+	AttemptConnPeers  int    `yaml:"AttemptConnPeers"`
+	// BroadcastFactor is the factor (0-100) controlling gossip fan-out number optimization.
+	BroadcastFactor   int                      `yaml:"BroadcastFactor"`
 	DBConfiguration   dbconfig.DBConfiguration `yaml:"DBConfiguration"`
 	DialTimeout       int64                    `yaml:"DialTimeout"`
 	LogPath           string                   `yaml:"LogPath"`
@@ -36,6 +38,7 @@ func (a *ApplicationConfiguration) EqualsButServices(o *ApplicationConfiguration
 	if a.Address != o.Address ||
 		a.AnnouncedNodePort != o.AnnouncedNodePort ||
 		a.AttemptConnPeers != o.AttemptConnPeers ||
+		a.BroadcastFactor != o.BroadcastFactor ||
 		a.DBConfiguration != o.DBConfiguration ||
 		a.DialTimeout != o.DialTimeout ||
 		a.ExtensiblePoolSize != o.ExtensiblePoolSize ||

--- a/pkg/network/discovery.go
+++ b/pkg/network/discovery.go
@@ -83,6 +83,11 @@ func newDefaultDiscovery(addrs []string, dt time.Duration, ts Transporter) Disco
 // the pool with the given addresses.
 func (d *DefaultDiscovery) BackFill(addrs ...string) {
 	d.lock.Lock()
+	d.backfill(addrs...)
+	d.lock.Unlock()
+}
+
+func (d *DefaultDiscovery) backfill(addrs ...string) {
 	for _, addr := range addrs {
 		if d.badAddrs[addr] || d.connectedAddrs[addr] ||
 			d.unconnectedAddrs[addr] > 0 {
@@ -92,7 +97,6 @@ func (d *DefaultDiscovery) BackFill(addrs ...string) {
 		d.pushToPoolOrDrop(addr)
 	}
 	d.updateNetSize()
-	d.lock.Unlock()
 }
 
 // PoolCount returns the number of the available node addresses.
@@ -187,7 +191,7 @@ func (d *DefaultDiscovery) RegisterGoodAddr(s string, c capability.Capabilities)
 func (d *DefaultDiscovery) UnregisterConnectedAddr(s string) {
 	d.lock.Lock()
 	delete(d.connectedAddrs, s)
-	d.updateNetSize()
+	d.backfill(s)
 	d.lock.Unlock()
 }
 

--- a/pkg/network/discovery.go
+++ b/pkg/network/discovery.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	maxPoolSize = 200
+	maxPoolSize = 10000
 	connRetries = 3
 )
 
@@ -18,7 +18,6 @@ const (
 // a healthy connection pool.
 type Discoverer interface {
 	BackFill(...string)
-	Close()
 	GetFanOut() int
 	PoolCount() int
 	RequestRemote(int)
@@ -42,7 +41,6 @@ type DefaultDiscovery struct {
 	seeds            []string
 	transport        Transporter
 	lock             sync.RWMutex
-	closeMtx         sync.RWMutex
 	dialTimeout      time.Duration
 	badAddrs         map[string]bool
 	connectedAddrs   map[string]bool
@@ -50,10 +48,7 @@ type DefaultDiscovery struct {
 	unconnectedAddrs map[string]int
 	attempted        map[string]bool
 	optimalFanOut    int32
-	isDead           bool
 	requestCh        chan int
-	pool             chan string
-	runExit          chan struct{}
 }
 
 // NewDefaultDiscovery returns a new DefaultDiscovery.
@@ -68,10 +63,7 @@ func NewDefaultDiscovery(addrs []string, dt time.Duration, ts Transporter) *Defa
 		unconnectedAddrs: make(map[string]int),
 		attempted:        make(map[string]bool),
 		requestCh:        make(chan int),
-		pool:             make(chan string, maxPoolSize),
-		runExit:          make(chan struct{}),
 	}
-	go d.run()
 	return d
 }
 
@@ -93,7 +85,6 @@ func (d *DefaultDiscovery) backfill(addrs ...string) {
 			d.unconnectedAddrs[addr] > 0 {
 			continue
 		}
-		d.unconnectedAddrs[addr] = connRetries
 		d.pushToPoolOrDrop(addr)
 	}
 	d.updateNetSize()
@@ -101,40 +92,73 @@ func (d *DefaultDiscovery) backfill(addrs ...string) {
 
 // PoolCount returns the number of the available node addresses.
 func (d *DefaultDiscovery) PoolCount() int {
-	return len(d.pool)
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+	return d.poolCount()
+}
+
+func (d *DefaultDiscovery) poolCount() int {
+	return len(d.unconnectedAddrs)
 }
 
 // pushToPoolOrDrop tries to push the address given into the pool, but if the pool
 // is already full, it just drops it.
 func (d *DefaultDiscovery) pushToPoolOrDrop(addr string) {
-	select {
-	case d.pool <- addr:
-		updatePoolCountMetric(d.PoolCount())
-		// ok, queued
-	default:
-		// whatever
+	if len(d.unconnectedAddrs) < maxPoolSize {
+		d.unconnectedAddrs[addr] = connRetries
 	}
 }
 
 // RequestRemote tries to establish a connection with n nodes.
-func (d *DefaultDiscovery) RequestRemote(n int) {
-	d.closeMtx.RLock()
-	if !d.isDead {
-		d.requestCh <- n
+func (d *DefaultDiscovery) RequestRemote(requested int) {
+	for ; requested > 0; requested-- {
+		var nextAddr string
+		d.lock.Lock()
+		for addr := range d.unconnectedAddrs {
+			if !d.connectedAddrs[addr] && !d.attempted[addr] {
+				nextAddr = addr
+				break
+			}
+		}
+
+		if nextAddr == "" {
+			// Empty pool, try seeds.
+			for _, addr := range d.seeds {
+				if !d.connectedAddrs[addr] && !d.attempted[addr] {
+					nextAddr = addr
+					break
+				}
+			}
+		}
+		if nextAddr == "" {
+			d.lock.Unlock()
+			// The pool is empty, but all seed nodes are already connected (or attempted),
+			// we can end up in an infinite loop here, so drop the request.
+			break
+		}
+		d.attempted[nextAddr] = true
+		d.lock.Unlock()
+		go d.tryAddress(nextAddr)
 	}
-	d.closeMtx.RUnlock()
 }
 
 // RegisterBadAddr registers the given address as a bad address.
 func (d *DefaultDiscovery) RegisterBadAddr(addr string) {
+	var isSeed bool
 	d.lock.Lock()
-	d.unconnectedAddrs[addr]--
-	if d.unconnectedAddrs[addr] > 0 {
-		d.pushToPoolOrDrop(addr)
-	} else {
-		d.badAddrs[addr] = true
-		delete(d.unconnectedAddrs, addr)
-		delete(d.goodAddrs, addr)
+	for _, seed := range d.seeds {
+		if addr == seed {
+			isSeed = true
+			break
+		}
+	}
+	if !isSeed {
+		d.unconnectedAddrs[addr]--
+		if d.unconnectedAddrs[addr] <= 0 {
+			d.badAddrs[addr] = true
+			delete(d.unconnectedAddrs, addr)
+			delete(d.goodAddrs, addr)
+		}
 	}
 	d.updateNetSize()
 	d.lock.Unlock()
@@ -219,6 +243,7 @@ func (d *DefaultDiscovery) updateNetSize() {
 
 	atomic.StoreInt32(&d.optimalFanOut, int32(fanOut+0.5)) // Truncating conversion, hence +0.5.
 	updateNetworkSizeMetric(netsize)
+	updatePoolCountMetric(d.poolCount())
 }
 
 func (d *DefaultDiscovery) tryAddress(addr string) {
@@ -230,77 +255,4 @@ func (d *DefaultDiscovery) tryAddress(addr string) {
 		d.RegisterBadAddr(addr)
 		d.RequestRemote(1)
 	}
-}
-
-// Close stops discoverer pool processing, which makes the discoverer almost useless.
-func (d *DefaultDiscovery) Close() {
-	d.closeMtx.Lock()
-	d.isDead = true
-	d.closeMtx.Unlock()
-	select {
-	case <-d.requestCh: // Drain the channel if there is anything there.
-	default:
-	}
-	close(d.requestCh)
-	<-d.runExit
-}
-
-// run is a goroutine that makes DefaultDiscovery process its queue to connect
-// to other nodes.
-func (d *DefaultDiscovery) run() {
-	var requested, oldRequest, r int
-	var ok bool
-
-	for {
-		if requested == 0 {
-			requested, ok = <-d.requestCh
-		}
-		oldRequest = requested
-		for ok && requested > 0 {
-			select {
-			case r, ok = <-d.requestCh:
-				if requested <= r {
-					requested = r
-				}
-			case addr := <-d.pool:
-				updatePoolCountMetric(d.PoolCount())
-				d.lock.Lock()
-				if !d.connectedAddrs[addr] && !d.attempted[addr] {
-					d.attempted[addr] = true
-					go d.tryAddress(addr)
-					requested--
-				}
-				d.lock.Unlock()
-			default: // Empty pool
-				var added int
-				d.lock.Lock()
-				for _, addr := range d.seeds {
-					if !d.connectedAddrs[addr] {
-						delete(d.badAddrs, addr)
-						d.unconnectedAddrs[addr] = connRetries
-						d.pushToPoolOrDrop(addr)
-						added++
-					}
-				}
-				d.lock.Unlock()
-				// The pool is empty, but all seed nodes are already connected,
-				// we can end up in an infinite loop here, so drop the request.
-				if added == 0 {
-					requested = 0
-				}
-			}
-		}
-		if !ok {
-			break
-		}
-		// Special case, no connections after all attempts.
-		d.lock.RLock()
-		connected := len(d.connectedAddrs)
-		d.lock.RUnlock()
-		if connected == 0 {
-			time.Sleep(d.dialTimeout)
-			requested = oldRequest
-		}
-	}
-	close(d.runExit)
 }

--- a/pkg/network/discovery_test.go
+++ b/pkg/network/discovery_test.go
@@ -157,7 +157,7 @@ func TestDefaultDiscoverer(t *testing.T) {
 			}
 		}
 	}
-	require.Equal(t, 0, d.PoolCount())
+	require.Eventually(t, func() bool { return d.PoolCount() == 0 }, 2*time.Second, 50*time.Millisecond)
 	sort.Strings(dialledBad)
 	for i := 0; i < len(set1); i++ {
 		for j := 0; j < connRetries; j++ {
@@ -174,10 +174,6 @@ func TestDefaultDiscoverer(t *testing.T) {
 	assert.Equal(t, len(set1), len(d.BadPeers()))
 	assert.Equal(t, 0, len(d.GoodPeers()))
 	require.Equal(t, 0, d.PoolCount())
-
-	// Close should work and subsequent RequestRemote is a no-op.
-	d.Close()
-	d.RequestRemote(42)
 }
 
 func TestSeedDiscovery(t *testing.T) {

--- a/pkg/network/discovery_test.go
+++ b/pkg/network/discovery_test.go
@@ -74,6 +74,7 @@ func TestDefaultDiscoverer(t *testing.T) {
 		assert.Equal(t, 0, len(d.BadPeers()))
 		require.Equal(t, set1, set1D)
 	}
+	require.Equal(t, 2, d.GetFanOut())
 
 	// Request should make goroutines dial our addresses draining the pool.
 	d.RequestRemote(len(set1))

--- a/pkg/network/discovery_test.go
+++ b/pkg/network/discovery_test.go
@@ -132,14 +132,13 @@ func TestDefaultDiscoverer(t *testing.T) {
 	for _, addr := range set1 {
 		d.UnregisterConnectedAddr(addr)
 	}
-	assert.Equal(t, 0, len(d.UnconnectedPeers()))
+	assert.Equal(t, 2, len(d.UnconnectedPeers())) // They're re-added automatically.
 	assert.Equal(t, 0, len(d.BadPeers()))
 	assert.Equal(t, len(set1), len(d.GoodPeers()))
-	require.Equal(t, 0, d.PoolCount())
+	require.Equal(t, 2, d.PoolCount())
 
 	// Now make Dial() fail and wait to see addresses in the bad list.
 	atomic.StoreInt32(&ts.retFalse, 1)
-	d.BackFill(set1...)
 	assert.Equal(t, len(set1), d.PoolCount())
 	set1D := d.UnconnectedPeers()
 	sort.Strings(set1D)

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -40,6 +40,11 @@ func (d *testDiscovery) RegisterBadAddr(addr string) {
 	defer d.Unlock()
 	d.bad = append(d.bad, addr)
 }
+func (d *testDiscovery) GetFanOut() int {
+	d.Lock()
+	defer d.Unlock()
+	return len(d.connected) + len(d.backfill)
+}
 func (d *testDiscovery) RegisterGoodAddr(string, capability.Capabilities) {}
 func (d *testDiscovery) RegisterConnectedAddr(addr string) {
 	d.Lock()

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -42,6 +42,11 @@ func (d *testDiscovery) RegisterBadAddr(addr string) {
 func (d *testDiscovery) GetFanOut() int {
 	d.Lock()
 	defer d.Unlock()
+	return (len(d.connected) + len(d.backfill)) * 2 / 3
+}
+func (d *testDiscovery) NetworkSize() int {
+	d.Lock()
+	defer d.Unlock()
 	return len(d.connected) + len(d.backfill)
 }
 func (d *testDiscovery) RegisterGoodAddr(string, capability.Capabilities) {}

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -33,7 +33,6 @@ func (d *testDiscovery) BackFill(addrs ...string) {
 	defer d.Unlock()
 	d.backfill = append(d.backfill, addrs...)
 }
-func (d *testDiscovery) Close()         {}
 func (d *testDiscovery) PoolCount() int { return 0 }
 func (d *testDiscovery) RegisterBadAddr(addr string) {
 	d.Lock()
@@ -204,6 +203,5 @@ func newTestServerWithCustomCfg(t *testing.T, serverConfig ServerConfig, protoco
 	s, err := newServerFromConstructors(serverConfig, fakechain.NewFakeChainWithCustomCfg(protocolCfg), new(fakechain.FakeStateSync), zaptest.NewLogger(t),
 		newFakeTransp, newTestDiscovery)
 	require.NoError(t, err)
-	t.Cleanup(s.discovery.Close)
 	return s
 }

--- a/pkg/network/prometheus.go
+++ b/pkg/network/prometheus.go
@@ -6,6 +6,14 @@ import (
 
 // Metric used in monitoring service.
 var (
+	estimatedNetworkSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Help:      "Estimated network size",
+			Name:      "network_size",
+			Namespace: "neogo",
+		},
+	)
+
 	peersConnected = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Help:      "Number of connected peers",
@@ -42,11 +50,16 @@ var (
 
 func init() {
 	prometheus.MustRegister(
+		estimatedNetworkSize,
 		peersConnected,
 		servAndNodeVersion,
 		poolCount,
 		blockQueueLength,
 	)
+}
+
+func updateNetworkSizeMetric(sz int) {
+	estimatedNetworkSize.Set(float64(sz))
 }
 
 func updateBlockQueueLenMetric(bqLen int) {

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -670,7 +670,6 @@ func (s *Server) handleVersionCmd(p Peer, version *payload.Version) error {
 		return errInvalidNetwork
 	}
 	peerAddr := p.PeerAddr().String()
-	s.discovery.RegisterConnectedAddr(peerAddr)
 	s.lock.RLock()
 	for peer := range s.peers {
 		if p == peer {
@@ -684,6 +683,7 @@ func (s *Server) handleVersionCmd(p Peer, version *payload.Version) error {
 		}
 	}
 	s.lock.RUnlock()
+	s.discovery.RegisterConnectedAddr(peerAddr)
 	return p.SendVersionAck(NewMessage(CMDVerack, payload.NewNullPayload()))
 }
 

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -439,11 +439,9 @@ func (s *Server) run() {
 					s.lock.RUnlock()
 					if !stillConnected {
 						s.discovery.UnregisterConnectedAddr(addr)
-						s.discovery.BackFill(addr)
 					}
 				} else {
 					s.discovery.UnregisterConnectedAddr(addr)
-					s.discovery.BackFill(addr)
 				}
 				updatePeersConnectedMetric(s.PeerCount())
 			} else {

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -261,7 +261,6 @@ func (s *Server) Start(errChan chan error) {
 func (s *Server) Shutdown() {
 	s.log.Info("shutting down server", zap.Int("peers", s.PeerCount()))
 	s.transport.Close()
-	s.discovery.Close()
 	for _, p := range s.getPeers(nil) {
 		p.Disconnect(errServerShutdown)
 	}

--- a/pkg/network/server_config.go
+++ b/pkg/network/server_config.go
@@ -78,6 +78,9 @@ type (
 
 		// ExtensiblePoolSize is the size of the pool for extensible payloads from a single sender.
 		ExtensiblePoolSize int
+
+		// BroadcastFactor is the factor (0-100) for fan-out optimization.
+		BroadcastFactor int
 	}
 )
 
@@ -107,5 +110,6 @@ func NewServerConfig(cfg config.Config) ServerConfig {
 		P2PNotaryCfg:       appConfig.P2PNotary,
 		StateRootCfg:       appConfig.StateRoot,
 		ExtensiblePoolSize: appConfig.ExtensiblePoolSize,
+		BroadcastFactor:    appConfig.BroadcastFactor,
 	}
 }


### PR DESCRIPTION
Fixes #608, #2678. A new configuration option is added, `BroadcastFactor` that allows to configure the number of fan-out node between optimal (log-dependent on the size of the network, default) and all available peers.