### PR TITLE
network/consensus: use new dbft StopTxFlow callback

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -332,6 +332,7 @@ func mkConsensus(config config.Wallet, tpb time.Duration, chain *core.Blockchain
 		Chain:                 chain,
 		ProtocolConfiguration: chain.GetConfig(),
 		RequestTx:             serv.RequestTx,
+		StopTxFlow:            serv.StopTxFlow,
 		Wallet:                &config,
 		TimePerBlock:          tpb,
 	})

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/holiman/uint256 v1.2.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mr-tron/base58 v1.2.0
-	github.com/nspcc-dev/dbft v0.0.0-20220902113116-58a5e763e647
+	github.com/nspcc-dev/dbft v0.0.0-20221018080254-c7e1bf49ccd7
 	github.com/nspcc-dev/go-ordered-json v0.0.0-20220111165707-25110be27d22
 	github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220927123257-24c107e3a262
 	github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/nspcc-dev/dbft v0.0.0-20191209120240-0d6b7568d9ae/go.mod h1:3FjXOoHmA
 github.com/nspcc-dev/dbft v0.0.0-20200117124306-478e5cfbf03a/go.mod h1:/YFK+XOxxg0Bfm6P92lY5eDSLYfp06XOdL8KAVgXjVk=
 github.com/nspcc-dev/dbft v0.0.0-20200219114139-199d286ed6c1/go.mod h1:O0qtn62prQSqizzoagHmuuKoz8QMkU3SzBoKdEvm3aQ=
 github.com/nspcc-dev/dbft v0.0.0-20210721160347-1b03241391ac/go.mod h1:U8MSnEShH+o5hexfWJdze6uMFJteP0ko7J2frO7Yu1Y=
-github.com/nspcc-dev/dbft v0.0.0-20220902113116-58a5e763e647 h1:handGBjqVzRx7HD6152zsP8ZRxw083zCMbN0IlUaPQk=
-github.com/nspcc-dev/dbft v0.0.0-20220902113116-58a5e763e647/go.mod h1:g9xisXmX9NP9MjioaTe862n9SlZTrP+6PVUWLBYOr98=
+github.com/nspcc-dev/dbft v0.0.0-20221018080254-c7e1bf49ccd7 h1:RxVI9RFiHmpUvbuYIM5siLMiOvVt8P651BdmTstGi3Q=
+github.com/nspcc-dev/dbft v0.0.0-20221018080254-c7e1bf49ccd7/go.mod h1:g9xisXmX9NP9MjioaTe862n9SlZTrP+6PVUWLBYOr98=
 github.com/nspcc-dev/go-ordered-json v0.0.0-20210915112629-e1b6cce73d02/go.mod h1:79bEUDEviBHJMFV6Iq6in57FEOCMcRhfQnfaf0ETA5U=
 github.com/nspcc-dev/go-ordered-json v0.0.0-20220111165707-25110be27d22 h1:n4ZaFCKt1pQJd7PXoMJabZWK9ejjbLOVrkl/lOUmshg=
 github.com/nspcc-dev/go-ordered-json v0.0.0-20220111165707-25110be27d22/go.mod h1:79bEUDEviBHJMFV6Iq6in57FEOCMcRhfQnfaf0ETA5U=

--- a/internal/testcli/executor.go
+++ b/internal/testcli/executor.go
@@ -156,6 +156,7 @@ func NewTestChain(t *testing.T, f func(*config.Config), run bool) (*core.Blockch
 		Chain:                 chain,
 		ProtocolConfiguration: chain.GetConfig(),
 		RequestTx:             netSrv.RequestTx,
+		StopTxFlow:            netSrv.StopTxFlow,
 		Wallet:                &cfg.ApplicationConfiguration.UnlockWallet,
 		TimePerBlock:          serverConfig.TimePerBlock,
 	})

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -119,6 +119,9 @@ type Config struct {
 	// RequestTx is a callback to which will be called
 	// when a node lacks transactions present in the block.
 	RequestTx func(h ...util.Uint256)
+	// StopTxFlow is a callback that is called after the consensus
+	// process stops accepting incoming transactions.
+	StopTxFlow func()
 	// TimePerBlock is minimal time that should pass before the next block is accepted.
 	TimePerBlock time.Duration
 	// Wallet is a local-node wallet configuration.
@@ -173,6 +176,7 @@ func NewService(cfg Config) (Service, error) {
 		dbft.WithSecondsPerBlock(cfg.TimePerBlock),
 		dbft.WithGetKeyPair(srv.getKeyPair),
 		dbft.WithRequestTx(cfg.RequestTx),
+		dbft.WithStopTxFlow(cfg.StopTxFlow),
 		dbft.WithGetTx(srv.getTx),
 		dbft.WithGetVerified(srv.getVerifiedTx),
 		dbft.WithBroadcast(srv.broadcast),

--- a/pkg/consensus/consensus_test.go
+++ b/pkg/consensus/consensus_test.go
@@ -479,6 +479,7 @@ func newTestServiceWithChain(t *testing.T, bc *core.Blockchain) *service {
 		Chain:                 bc,
 		ProtocolConfiguration: bc.GetConfig(),
 		RequestTx:             func(...util.Uint256) {},
+		StopTxFlow:            func() {},
 		TimePerBlock:          time.Duration(bc.GetConfig().SecondsPerBlock) * time.Second,
 		Wallet: &config.Wallet{
 			Path:     "./testdata/wallet1.json",

--- a/pkg/network/server_test.go
+++ b/pkg/network/server_test.go
@@ -461,6 +461,7 @@ func TestTransaction(t *testing.T) {
 	cons := new(fakeConsensus)
 	s.AddConsensusService(cons, cons.OnPayload, cons.OnTransaction)
 	startWithCleanup(t, s)
+	s.RequestTx(util.Uint256{1})
 
 	t.Run("good", func(t *testing.T) {
 		tx := newDummyTx()


### PR DESCRIPTION
It makes sense in general (further narrowing down the time window when transactions are processed by consensus thread) and it improves block times a little too, especially in the 7+2 scenario.

Related to #2744.
![cpu_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/196152637-d9251ff1-e4a4-43af-a66b-e6703a49353c.png)
![cpu_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/196152642-6b4c4ed3-64d8-405b-82d7-e7f1f59419e8.png)
![cpu_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/196152645-3eb009fa-ab64-4841-8028-a31f5616ba84.png)
![cpu_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/196152646-a74e315f-39b5-4f84-992b-5eb6ea1d8c1c.png)
![mem_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/196152647-657e9529-16fa-4608-ba39-19966f6e5cab.png)
![mem_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/196152648-03a0d7d5-d2bd-43b2-8114-84e85ee17a90.png)
![mem_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/196152650-0db7998b-12de-4513-8a44-a8433287477e.png)
![mem_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/196152652-13817d4c-330f-46cf-b976-dc2dcaedbfe6.png)
![ms_per_block_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/196152654-3b8d22c7-f166-453e-ace4-e2ff7698d308.png)
![ms_per_block_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/196152657-caf1c101-fdb6-4b19-8be3-1e3d2c95b290.png)
![ms_per_block_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/196152660-8459d29d-c89b-44ec-babd-4f1f8beaf499.png)
![ms_per_block_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/196152661-f02bf462-10de-43a8-87ec-5088c16c81f7.png)
![tpb_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/196152664-64c33eb0-0e70-4445-8645-424c3406a0c3.png)
![tpb_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/196152667-31f8ed71-a164-4ce0-b56e-0fd63b72e7f6.png)
![tpb_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/196152671-d0244268-07bd-4452-893c-559e0273bef5.png)
![tpb_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/196152675-5d90a4c9-86cd-43ec-9947-0bc870a01d13.png)
![tps_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/196152677-a68fcb5b-4ef8-4670-b046-76a0eea188f5.png)
![tps_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/196152683-9c2369f6-237f-4e67-b2fc-d213431770b1.png)
![tps_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/196152685-bd14ba98-7ef1-4d25-b3fa-d509f22e877f.png)
![tps_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/196152687-e5bb2e92-6d4c-421c-b561-559e048a98e3.png)
