### PR TITLE
config: reschedule Aspidochelone fork block for NeoFS mainnet

### DIFF
--- a/config/protocol.mainnet.neofs.yml
+++ b/config/protocol.mainnet.neofs.yml
@@ -25,7 +25,7 @@ ProtocolConfiguration:
   VerifyTransactions: true
   P2PSigExtensions: false
   Hardforks:
-    Aspidochelone: 2550000
+    Aspidochelone: 2600000
   NativeActivations:
     ContractManagement: [0]
     StdLib: [0]


### PR DESCRIPTION
We can't make it before 2550000, so move to 2600000. @anatoly-bogatyrev, please ensure you're using this new height for mainnet NeoFS configurations next week.
