### PR TITLE
network: batch getdata replies

### DIFF
--- a/pkg/network/peer.go
+++ b/pkg/network/peer.go
@@ -39,10 +39,16 @@ type Peer interface {
 	// (handled by BroadcastPacket) but less important than high-priority
 	// messages (handled by EnqueueHPMessage).
 	EnqueueP2PMessage(*Message) error
+	// EnqueueP2PPacket is similar to EnqueueP2PMessage, but accepts a slice of
+	// message(s) bytes.
+	EnqueueP2PPacket([]byte) error
 
 	// EnqueueHPMessage is similar to EnqueueP2PMessage, but uses a high-priority
 	// queue.
 	EnqueueHPMessage(*Message) error
+	// EnqueueHPPacket is similar to EnqueueHPMessage, but accepts a slice of
+	// message(s) bytes.
+	EnqueueHPPacket([]byte) error
 	Version() *payload.Version
 	LastBlockIndex() uint32
 	Handshaked() bool

--- a/pkg/network/tcp_peer.go
+++ b/pkg/network/tcp_peer.go
@@ -128,6 +128,16 @@ func (p *TCPPeer) EnqueueHPMessage(msg *Message) error {
 	return p.putMsgIntoQueue(p.hpSendQ, msg)
 }
 
+// EnqueueP2PPacket implements the Peer interface.
+func (p *TCPPeer) EnqueueP2PPacket(b []byte) error {
+	return p.putPacketIntoQueue(context.Background(), p.p2pSendQ, b)
+}
+
+// EnqueueHPPacket implements the Peer interface.
+func (p *TCPPeer) EnqueueHPPacket(b []byte) error {
+	return p.putPacketIntoQueue(context.Background(), p.hpSendQ, b)
+}
+
 func (p *TCPPeer) writeMsg(msg *Message) error {
 	b, err := msg.Bytes()
 	if err != nil {


### PR DESCRIPTION
This is not exactly the protocol-level batching as was tried in #1770 and proposed by neo-project/neo#2365, but it's a TCP-level change in that we now Write() a set of messages and given that Go sets up TCP sockets with TCP_NODELAY by default this is a substantial change, we have less packets generated with the same amount of data. It doesn't change anything on properly connected networks, but the ones with delays benefit from it a lot.

This also improves queueing because we no longer generate 32 messages to deliver on transaction's GetData, it's just one stream of bytes with 32 messages inside.

Do the same with GetBlocksByIndex, we can have a lot of messages there too.

But don't forget about potential peer DoS attacks, if a peer is to request a lot of big blocks we need to flush them before we process the whole set.

![cpu_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197216894-94cba9f7-afd2-46c1-8bc1-343849e607ff.png)
![cpu_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197216903-9e2eb53f-1f2b-46aa-b6ab-48992766f3d3.png)
![cpu_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197216906-4506c7e0-1478-4b75-9cb0-a4a4dfb0b472.png)
![cpu_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197216908-0bdf2cad-bd4b-4790-ac71-3f50cecc0534.png)
![mem_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197216911-bd802dda-16c0-4780-9ff3-390bbaa84cea.png)
![mem_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197216919-d42df4d0-e6e9-4e55-a7a7-86e5852f5810.png)
![mem_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197216920-3bb91cf7-277a-4fa7-8f8b-c719127cc342.png)
![mem_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197216922-845ea09d-f2c1-4ec0-bf22-c65dbf2ae94b.png)
![ms_per_block_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197216925-3e7667ce-7cf4-4320-ad3b-9989891ef4ff.png)
![ms_per_block_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197216927-c5f34aa5-1750-4ac0-a9b8-031cd42172b0.png)
![ms_per_block_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197216929-c52ac9c2-36c0-4882-b042-166e11cd77d6.png)
![ms_per_block_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197216932-51131a39-066f-420e-aae6-ae65f96d9df4.png)
![tpb_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197216936-3b856bf6-5d90-4495-8d88-662dbee8d1f3.png)
![tpb_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197216938-48c452fd-e7c8-4ff1-9cf7-a9c7850e9b7d.png)
![tpb_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197216941-c04befc5-d4b5-4590-b69a-ad4372159d93.png)
![tpb_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197216944-f600c8b2-98f0-4762-be55-065b71dcf295.png)
![tps_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197216947-65117183-218d-4ac3-95a0-304d88704191.png)
![tps_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197216948-0798749e-5c9f-4556-a483-a939dfe5dbc0.png)
![tps_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197216950-c4373933-a03c-48aa-8ad0-1ef7124d2bb3.png)
![tps_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197216952-7febbc2e-b9ed-4266-8b30-230ad0b1576d.png)
