### PR TITLE
core: optimize HasBlock check for recent blocks

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1714,6 +1714,16 @@ func (bc *Blockchain) HasTransaction(hash util.Uint256) bool {
 // HasBlock returns true if the blockchain contains the given
 // block hash.
 func (bc *Blockchain) HasBlock(hash util.Uint256) bool {
+	var height = bc.BlockHeight()
+	bc.headerHashesLock.RLock()
+	for i := int(height); i >= int(height)-4 && i >= 0; i-- {
+		if hash.Equals(bc.headerHashes[i]) {
+			bc.headerHashesLock.RUnlock()
+			return true
+		}
+	}
+	bc.headerHashesLock.RUnlock()
+
 	if header, err := bc.GetHeader(hash); err == nil {
 		return header.Index <= bc.BlockHeight()
 	}


### PR DESCRIPTION
When block is being spread through the network we can get a lot of invs with the same hash. Some more stale nodes may also announce previous or some earlier block. We can avoid full DB lookup for them and minimize inv handling time (timeouts in inv handler had happened in #2744).

It doesn't affect tests, just makes node a little less likely to spend some considerable amount of time in the inv handler.
