### PR TITLE
network: it is 42

### DIFF
--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -1580,7 +1580,7 @@ func (s *Server) initStaleMemPools() {
 func (s *Server) broadcastTxLoop() {
 	const (
 		batchTime = time.Millisecond * 50
-		batchSize = 32
+		batchSize = 42
 	)
 
 	txs := make([]util.Uint256, 0, batchSize)


### PR DESCRIPTION
32 is a very good number, but we all know 42 is a better one. And it can even be proven by tests with higher peaking TPS values.

You may wonder why is it so good? Because we're using packet-switching networks mostly and a packet is a packet almost irrespectively of how big it is. Yet a packet has some maximum possible size (hi, MTU) and this size most of the time is 1500 (or a little less than that, hi VPN). Subtract IP header (20 for IPv4 or 40 for IPv6 not counting options), TCP header (another 20) and Neo message/payload headers (~8 for this case) and we have just a little more than 1400 bytes for our dear hashes. Which means that in a single packet most of the time we can have 42-44 of them, maybe 45. Choosing between these numbers is not hard then.

Inspired by #2757. (invcheck is in fact net42 of pictures below)

![cpu_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197520675-c4c40756-8258-45cf-887d-f6028a4dca39.png)
![cpu_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197520679-709b7a1c-ba65-4008-a3cf-1c5e7c82b4cd.png)
![cpu_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197520682-2a7dbffc-d912-4891-9b12-db3768fe24f9.png)
![cpu_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197520683-ffad06b3-1ef2-48c1-b134-c4b7a20eec54.png)
![mem_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197520685-6a04de9a-aa15-4948-8666-b194d958473a.png)
![mem_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197520687-d862a524-c05e-4fd7-ac96-cd5120ce5ecf.png)
![mem_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197520689-1a8d7060-bb4e-4d88-bfc1-2508f5c75fbc.png)
![mem_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197520691-4ea74aa7-b156-45e9-a114-80aadd00ca2d.png)
![ms_per_block_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197520692-1e1ebca2-4e26-4a04-8ec7-7d2ddd99c57e.png)
![ms_per_block_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197520694-e4e580c7-a19c-4185-97a9-76449b7f799b.png)
![ms_per_block_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197520698-5988c54b-0ae7-4269-b4fc-bd467adb27d7.png)
![ms_per_block_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197520701-b507e487-8ca3-4bee-b7c0-e479d2e1e991.png)
![tpb_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197520702-3da1d736-12c7-438b-9a3c-e7c43008cf52.png)
![tpb_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197520707-405294f9-a535-41ac-8ea3-31439feef3a1.png)
![tpb_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197520709-33002057-eee2-4c7b-9f69-a183bc372613.png)
![tpb_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197520713-6498dd95-9f1f-45a3-b35e-3977874af7f2.png)
![tps_four_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197520715-7cc47fc6-4c10-4a24-8679-02ac6358bccc.png)
![tps_four_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197520717-6adb38e1-5a38-48e4-b60e-e82566b0dc73.png)
![tps_seven_(30_wrk,_64K_pool,_200ms)](https://user-images.githubusercontent.com/22092804/197520720-aff3e20f-647b-4bd1-a492-01cab9c311d5.png)
![tps_seven_(30_wrk,_64K_pool)](https://user-images.githubusercontent.com/22092804/197520723-4322fe94-a026-40e6-bd5d-26f857114b46.png)
