### PR TITLE
cli: fix race in TestQueryTx

### DIFF
--- a/cli/query/query_test.go
+++ b/cli/query/query_test.go
@@ -54,15 +54,14 @@ func TestQueryTx(t *testing.T) {
 	e.CheckNextLine(t, `ValidUntil:\s+`+strconv.FormatUint(uint64(tx.ValidUntilBlock), 10))
 	e.CheckEOF(t)
 
-	height := e.Chain.BlockHeight()
 	go e.Chain.Run()
-	require.Eventually(t, func() bool { return e.Chain.BlockHeight() > height }, time.Second*2, time.Millisecond*50)
+	require.Eventually(t, func() bool { _, aerErr := e.Chain.GetAppExecResults(txHash, trigger.Application); return aerErr == nil }, time.Second*2, time.Millisecond*50)
 
 	e.Run(t, append(args, txHash.StringLE())...)
 	e.CheckNextLine(t, `Hash:\s+`+txHash.StringLE())
 	e.CheckNextLine(t, `OnChain:\s+true`)
 
-	_, height, err = e.Chain.GetTransaction(txHash)
+	_, height, err := e.Chain.GetTransaction(txHash)
 	require.NoError(t, err)
 	e.CheckNextLine(t, `BlockHash:\s+`+e.Chain.GetHeaderHash(int(height)).StringLE())
 	e.CheckNextLine(t, `Success:\s+true`)
@@ -88,8 +87,7 @@ func TestQueryTx(t *testing.T) {
 			txHash, err := util.Uint256DecodeStringLE(line)
 			require.NoError(t, err)
 
-			height := e.Chain.BlockHeight()
-			require.Eventually(t, func() bool { return e.Chain.BlockHeight() > height }, time.Second*2, time.Millisecond*50)
+			require.Eventually(t, func() bool { _, aerErr := e.Chain.GetAppExecResults(txHash, trigger.Application); return aerErr == nil }, time.Second*2, time.Millisecond*50)
 
 			tx, _, err := e.Chain.GetTransaction(txHash)
 			require.NoError(t, err)


### PR DESCRIPTION
Problem - failing TestQueryTx test (see https://app.circleci.com/pipelines/github/nspcc-dev/neo-go/9623/workflows/5bdf01d9-c5e2-41da-9cf9-e5e945e9f4d5/jobs/64191):
```
=== RUN   TestQueryTx/verbose/FAULT
=== CONT  TestQueryTx
    logger.go:130: 2022-10-26T10:47:51.414Z	DEBUG	processing rpc request	{"method": "getversion", "params": "[]"}
    logger.go:130: 2022-10-26T10:47:51.415Z	DEBUG	processing rpc request	{"method": "getnativecontracts", "params": "[]"}
    logger.go:130: 2022-10-26T10:47:51.612Z	DEBUG	processing rpc request	{"method": "getversion", "params": "[]"}
    logger.go:130: 2022-10-26T10:47:51.615Z	DEBUG	processing rpc request	{"method": "invokefunction", "params": "[11fdb7bc30a306a60dac874711a2b37b7da402c4 randomMethod  ]"}
    logger.go:130: 2022-10-26T10:47:51.617Z	DEBUG	processing rpc request	{"method": "getblockcount", "params": "[]"}
    logger.go:130: 2022-10-26T10:47:51.617Z	INFO	persisted to disk	{"blocks": 2, "keys": 154, "headerHeight": 2, "blockHeight": 2, "took": "260.704µs"}
    logger.go:130: 2022-10-26T10:47:51.618Z	DEBUG	processing rpc request	{"method": "calculatenetworkfee", "params": "[AIpp7dreAw8AAAAAAAAAAAAAAAAABQAAAAHYzFqQTVJvyabKtVugLJpv54nJVgAAK8IfDAxyYW5kb21NZXRob2QMFMQCpH17s6IRR4esDaYGozC8t/0RQWJ9W1IBACoRDCECs2Ir9AF73+MXxYrtX0x1PyBrfbiWBG+n13S7xL9/jcIRQZ7Q3Do=]"}
    logger.go:130: 2022-10-26T10:47:51.712Z	DEBUG	processing rpc request	{"method": "sendrawtransaction", "params": "[AIpp7dreAw8AAAAAABQbEgAAAAAABQAAAAHYzFqQTVJvyabKtVugLJpv54nJVgAAK8IfDAxyYW5kb21NZXRob2QMFMQCpH17s6IRR4esDaYGozC8t/0RQWJ9W1IBQgxAO2nxSMSRNFqBD5lOA37E9Px+nYDGMy6IqZromHXFtVTYD1c1hdUK4vTccoOr2AksdGwDsdQ8qIGJhXdEDxv8NSoRDCECs2Ir9AF73+MXxYrtX0x1PyBrfbiWBG+n13S7xL9/jcIRQZ7Q3Do=]"}
    logger.go:130: 2022-10-26T10:47:51.713Z	DEBUG	done processing headers	{"headerIndex": 3, "blockHeight": 2, "took": "228.756µs"}
    logger.go:130: 2022-10-26T10:47:51.813Z	DEBUG	processing rpc request	{"method": "getversion", "params": "[]"}
    logger.go:130: 2022-10-26T10:47:51.815Z	DEBUG	processing rpc request	{"method": "getnativecontracts", "params": "[]"}
    logger.go:130: 2022-10-26T10:47:51.923Z	DEBUG	processing rpc request	{"method": "getrawtransaction", "params": "[22bbb08d3f4b9e601a05c1bb1f7ac456d44bfad013287599bf3f843a75b30076 1]"}
=== CONT  TestQueryTx/verbose/FAULT
    executor.go:238:
        	Error Trace:	executor.go:238
        	            				executor.go:234
        	            				query_test.go:119
        	            				query_test.go:97
        	Error:      	Expect "OnChain:		false" to match "OnChain:\s+true"
        	Test:       	TestQueryTx/verbose/FAULT
```

chain.GetTransaction is looking for the mempool also.