### PR TITLE
rpcsrv: bypass any origin on websocket upgrade

### DIFF
--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -251,9 +251,10 @@ var invalidBlockHeightError = func(index int, height int) *neorpc.Error {
 
 // upgrader is a no-op websocket.Upgrader that reuses HTTP server buffers and
 // doesn't set any Error function.
-var upgrader = websocket.Upgrader {
-    // allow & bypass any origin header
-    CheckOrigin: func(r *http.Request) bool { return true },
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
 }
 
 // New creates a new Server struct.

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -251,7 +251,10 @@ var invalidBlockHeightError = func(index int, height int) *neorpc.Error {
 
 // upgrader is a no-op websocket.Upgrader that reuses HTTP server buffers and
 // doesn't set any Error function.
-var upgrader = websocket.Upgrader{}
+var upgrader = websocket.Upgrader {
+    // allow & bypass any origin header
+    CheckOrigin: func(r *http.Request) bool { return true },
+}
 
 // New creates a new Server struct.
 func New(chain Ledger, conf config.RPC, coreServer *network.Server,


### PR DESCRIPTION
- Browser client can't establish websocket connection with neo-go node, receiving 403
- Issue is caused by `Origin` in header, which browser ws client will send in any case
`gorilla/websocket` package is used in project to handle ws connections
`websocket.Upgrader.Upgrade()` fails to upgrade connection if request contains Origin header & u not configure behavior
See [gorilla/websocket #367](https://github.com/gorilla/websocket/issues/367) 

### Possible improvements
This PR just hardcode upgrader to pass all origins, so `Upgrader.CheckOrigin` setting to allow-all can be configured as feature-flag in configs