### PR TITLE
config: move NeoFS mainnet Aspidochelone fork again

### DIFF
--- a/config/protocol.mainnet.neofs.yml
+++ b/config/protocol.mainnet.neofs.yml
@@ -25,7 +25,7 @@ ProtocolConfiguration:
   VerifyTransactions: true
   P2PSigExtensions: false
   Hardforks:
-    Aspidochelone: 2600000
+    Aspidochelone: 2700000
   NativeActivations:
     ContractManagement: [0]
     StdLib: [0]


### PR DESCRIPTION
We're still 0.98.5 on this network.
