### PR TITLE
rpcsrv: provide Prometheus histograms for calls

### DIFF
--- a/pkg/services/rpcsrv/prometheus.go
+++ b/pkg/services/rpcsrv/prometheus.go
@@ -2,14 +2,23 @@ package rpcsrv
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Metrics used in monitoring service.
-var rpcCounter = map[string]prometheus.Counter{}
+var (
+	rpcCounter = map[string]prometheus.Counter{}
+	rpcTimes   = map[string]prometheus.Histogram{}
+)
 
-func incCounter(name string) {
+func addReqTimeMetric(name string, t time.Duration) {
+	hist, ok := rpcTimes[name]
+	if ok {
+		hist.Observe(t.Seconds())
+	}
 	ctr, ok := rpcCounter[name]
 	if ok {
 		ctr.Inc()
@@ -19,13 +28,21 @@ func incCounter(name string) {
 func regCounter(call string) {
 	ctr := prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Help:      fmt.Sprintf("Number of calls to %s rpc endpoint", call),
+			Help:      fmt.Sprintf("Number of calls to %s rpc endpoint (obsolete, to be removed)", call),
 			Name:      fmt.Sprintf("%s_called", call),
 			Namespace: "neogo",
 		},
 	)
 	prometheus.MustRegister(ctr)
 	rpcCounter[call] = ctr
+	rpcTimes[call] = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Help:      "RPC " + call + " call handling time",
+			Name:      "rpc_" + strings.ToLower(call) + "_time",
+			Namespace: "neogo",
+		},
+	)
+	prometheus.MustRegister(rpcTimes[call])
 }
 
 func init() {

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -501,7 +501,8 @@ func (s *Server) handleIn(req *params.In, sub *subscriber) abstract {
 		zap.String("method", req.Method),
 		zap.Stringer("params", reqParams))
 
-	incCounter(req.Method)
+	start := time.Now()
+	defer func() { addReqTimeMetric(req.Method, time.Since(start)) }()
 
 	resErr = neorpc.NewMethodNotFoundError(fmt.Sprintf("method %q not supported", req.Method))
 	handler, ok := rpcHandlers[req.Method]


### PR DESCRIPTION
They're a bit more useful and they're naturally grouped under rpc prefix. Simple counters will be removed eventually to avoid duplication.
