### PR TITLE
cli: properly close storage on `db reset`

### DIFF
--- a/cli/server/server_test.go
+++ b/cli/server/server_test.go
@@ -336,12 +336,12 @@ func TestConfigureAddresses(t *testing.T) {
 
 func TestInitBlockChain(t *testing.T) {
 	t.Run("bad storage", func(t *testing.T) {
-		_, err := initBlockChain(config.Config{}, nil)
+		_, _, err := initBlockChain(config.Config{}, nil)
 		require.Error(t, err)
 	})
 
 	t.Run("empty logger", func(t *testing.T) {
-		_, err := initBlockChain(config.Config{
+		_, _, err := initBlockChain(config.Config{
 			ApplicationConfiguration: config.ApplicationConfiguration{
 				DBConfiguration: dbconfig.DBConfiguration{
 					Type: dbconfig.InMemoryDB,


### PR DESCRIPTION
And fix failing test along the way:
```
2022-11-11T12:37:47.0413934Z === RUN   TestResetDB
2022-11-11T12:37:47.0414557Z 2022-11-11T12:36:54.510Z	INFO	initial gas supply is not set or wrong, setting default value	{"InitialGASSupply": "52000000"}
2022-11-11T12:37:47.0415288Z 2022-11-11T12:36:54.510Z	INFO	MaxBlockSize is not set or wrong, setting default value	{"MaxBlockSize": 262144}
2022-11-11T12:37:47.0416020Z 2022-11-11T12:36:54.510Z	INFO	MaxBlockSystemFee is not set or wrong, setting default value	{"MaxBlockSystemFee": 900000000000}
2022-11-11T12:37:47.0416786Z 2022-11-11T12:36:54.510Z	INFO	MaxTransactionsPerBlock is not set or wrong, using default value	{"MaxTransactionsPerBlock": 512}
2022-11-11T12:37:47.0417725Z 2022-11-11T12:36:54.510Z	INFO	MaxValidUntilBlockIncrement is not set or wrong, using default value	{"MaxValidUntilBlockIncrement": 5760}
2022-11-11T12:37:47.0418415Z 2022-11-11T12:36:54.510Z	INFO	Hardforks are not set, using default value
2022-11-11T12:37:47.0419272Z 2022-11-11T12:36:54.523Z	INFO	no storage version found! creating genesis block
2022-11-11T12:37:47.0419997Z 2022-11-11T12:36:54.529Z	INFO	chain is already at the proper state	{"height": 0}
2022-11-11T12:37:47.0420974Z     testing.go:1097: TempDir RemoveAll cleanup: remove C:\Users\RUNNER~1\AppData\Local\Temp\TestResetDB671187463\001\chains\privnet\000001.log: The process cannot access the file because it is being used by another process.
2022-11-11T12:37:47.0421606Z --- FAIL: TestResetDB (1.99s)
```