### PR TITLE
core, vm: improve script invocation errors

### DIFF
--- a/cli/vm/cli_test.go
+++ b/cli/vm/cli_test.go
@@ -924,7 +924,7 @@ func TestRunWithHistoricState(t *testing.T) {
 	e.checkNextLine(t, "READY: loaded 36 instructions")
 	e.checkStack(t, []byte{1})
 	e.checkNextLine(t, "READY: loaded 36 instructions")
-	e.checkNextLineExact(t, "Error: at instruction 31 (SYSCALL): failed to invoke syscall 1381727586: called contract cd583ac7a1a4faef70d6e9f513bc988dde22f672 not found: key not found\n")
+	e.checkNextLineExact(t, "Error: at instruction 31 (SYSCALL): System.Contract.Call failed: called contract cd583ac7a1a4faef70d6e9f513bc988dde22f672 not found: key not found\n")
 }
 
 func TestEvents(t *testing.T) {
@@ -1178,7 +1178,7 @@ func TestLoaddeployed(t *testing.T) {
 	e.checkNextLine(t, "READY: loaded \\d+ instructions")
 	e.checkStack(t, []byte{2})
 	e.checkNextLine(t, "READY: loaded \\d+ instructions")
-	e.checkError(t, errors.New("at instruction 63 (SYSCALL): failed to invoke syscall 837311890: insufficient amount of gas"))
+	e.checkError(t, errors.New("at instruction 63 (SYSCALL): System.Storage.Get failed: insufficient amount of gas"))
 	e.checkNextLine(t, "READY: loaded \\d+ instructions")
 	e.checkStack(t, []byte{2})
 	e.checkNextLine(t, "READY: loaded \\d+ instructions")

--- a/pkg/core/interop/storage/basic.go
+++ b/pkg/core/interop/storage/basic.go
@@ -70,7 +70,7 @@ func GetReadOnlyContext(ic *interop.Context) error {
 func getContextInternal(ic *interop.Context, isReadOnly bool) error {
 	contract, err := ic.GetContract(ic.VM.GetCurrentScriptHash())
 	if err != nil {
-		return err
+		return fmt.Errorf("storage context can not be retrieved in dynamic scripts: %w", err)
 	}
 	sc := &Context{
 		ID:       contract.ID,

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1462,7 +1462,11 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 		}
 		err := v.SyscallHandler(v, interopID)
 		if err != nil {
-			panic(fmt.Sprintf("failed to invoke syscall %d: %s", interopID, err))
+			iName, iErr := interopnames.FromID(interopID)
+			if iErr == nil {
+				panic(fmt.Sprintf("%s failed: %s", iName, err))
+			}
+			panic(fmt.Sprintf("%d failed: %s", interopID, err))
 		}
 
 	case opcode.RET:


### PR DESCRIPTION
### Problem

~~Contracts loaded with `loadnef` and `loadgo` can't properly work with notifications and contract storages. Strictly, it's not a bug, because they are scripts actually, but as a user, I would expect them to behave like a loaded contracts and properly handle `runtime.Notify` and `storage.GetContext` calls.~~

Invocation errors are not detailed enough.

### Solution

~~A bad cludge, but at least it allows to properly handle these things. Also, documentation is improved a bit.~~

Add some details.