### PR TITLE
core: filter out txes with system fee > MaxBlockSystemFee

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2467,6 +2467,9 @@ func (bc *Blockchain) verifyAndPoolTx(t *transaction.Transaction, pool *mempool.
 		// Only one %w can be used.
 		return fmt.Errorf("%w: %v", ErrPolicy, err)
 	}
+	if t.SystemFee > bc.config.MaxBlockSystemFee {
+		return fmt.Errorf("%w: too big system fee (%d > MaxBlockSystemFee %d)", ErrPolicy, t.SystemFee, bc.config.MaxBlockSystemFee)
+	}
 	size := t.Size()
 	if size > transaction.MaxTransactionSize {
 		return fmt.Errorf("%w: (%d > MaxTransactionSize %d)", ErrTxTooBig, size, transaction.MaxTransactionSize)

--- a/pkg/core/blockchain_neotest_test.go
+++ b/pkg/core/blockchain_neotest_test.go
@@ -1131,6 +1131,12 @@ func TestBlockchain_VerifyTx(t *testing.T) {
 		require.NoError(t, accs[0].SignTx(netmode.UnitTestNet, tx))
 		checkErr(t, core.ErrInsufficientFunds, tx)
 	})
+	t.Run("TooBigSystemFee", func(t *testing.T) {
+		tx := newTestTx(t, h, testScript)
+		tx.SystemFee = bc.GetConfig().MaxBlockSystemFee + 100500
+		require.NoError(t, accs[0].SignTx(netmode.UnitTestNet, tx))
+		checkErr(t, core.ErrPolicy, tx)
+	})
 	t.Run("TooBigTx", func(t *testing.T) {
 		script := make([]byte, transaction.MaxTransactionSize)
 		tx := newTestTx(t, h, script)


### PR DESCRIPTION
They can stay in the memory pool forever because consensus process will never accept these transactions (and maybe even block consensus process at all).