### PR TITLE
config: use string type for Port

### DIFF
--- a/pkg/config/basic_service.go
+++ b/pkg/config/basic_service.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"net"
-	"strconv"
 )
 
 // BasicService is used as a simple base for node services like Pprof, RPC or
@@ -12,7 +11,7 @@ type BasicService struct {
 	// Deprecated: please, use Addresses section instead. This field will be removed later.
 	Address *string `yaml:"Address,omitempty"`
 	// Deprecated: please, use Addresses section instead. This field will be removed later.
-	Port *uint16 `yaml:"Port,omitempty"`
+	Port *string `yaml:"Port,omitempty"`
 	// Addresses holds the list of bind addresses in the form of "address:port".
 	Addresses []string `yaml:"Addresses"`
 }
@@ -25,7 +24,7 @@ func (s BasicService) GetAddresses() []string {
 	if s.Address != nil || s.Port != nil { //nolint:staticcheck // SA1019: s.Address is deprecated
 		var (
 			addr string
-			port uint16
+			port string
 		)
 		if s.Address != nil { //nolint:staticcheck // SA1019: s.Address is deprecated
 			addr = *s.Address //nolint:staticcheck // SA1019: s.Address is deprecated
@@ -33,7 +32,7 @@ func (s BasicService) GetAddresses() []string {
 		if s.Port != nil { //nolint:staticcheck // SA1019: s.Port is deprecated
 			port = *s.Port //nolint:staticcheck // SA1019: s.Port is deprecated
 		}
-		addrs = append(addrs, net.JoinHostPort(addr, strconv.FormatUint(uint64(port), 10)))
+		addrs = append(addrs, net.JoinHostPort(addr, port))
 	}
 	return addrs
 }

--- a/pkg/config/basic_service_test.go
+++ b/pkg/config/basic_service_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestBasicService_GetAddresses(t *testing.T) {
 	addr := "1.2.3.4"
-	port := uint16(1234)
+	port := "1234"
 	s := BasicService{
 		Enabled: false,
 		Address: &addr,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/nspcc-dev/neo-go/pkg/config/netmode"
 	"gopkg.in/yaml.v3"
@@ -66,8 +67,8 @@ func LoadFile(configPath string) (Config, error) {
 	config := Config{
 		ApplicationConfiguration: ApplicationConfiguration{
 			P2P: P2P{
-				PingInterval: 30,
-				PingTimeout:  30,
+				PingInterval: 30 * time.Second,
+				PingTimeout:  90 * time.Second,
 			},
 			RPC: RPC{
 				MaxIteratorResultItems: DefaultMaxIteratorResultItems,

--- a/pkg/config/rpc_config_test.go
+++ b/pkg/config/rpc_config_test.go
@@ -20,5 +20,5 @@ MaxGasInvoke: 15
 	err := yaml.Unmarshal([]byte(data), &cfg)
 	require.NoError(t, err)
 	require.True(t, cfg.Enabled)
-	require.Equal(t, uint16(10332), *cfg.Port)
+	require.Equal(t, "10332", *cfg.Port)
 }


### PR DESCRIPTION
6b4dd5703e3a2255c915406c60c2d91bb83fee06 made it to be a uint16 which was somewhat important for RPC, but now it's irrelevant and the fact that it was a string in some cases may lead to errors like these:

  failed to unmarshal config YAML: yaml: unmarshal errors:
    line 48: cannot unmarshal !!str `20011` into uint16
    line 52: cannot unmarshal !!str `40001` into uint16

So for maximum backwards compatibility we better have string here and eventually it'll be deleted anyway.
