### PR TITLE
*: use zap.Stringer instead of zap.String where it can be used

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -226,7 +226,7 @@ func NewBlockchain(s storage.Store, cfg config.Blockchain, log *zap.Logger) (*Bl
 	// Protocol configuration fixups/checks.
 	if cfg.InitialGASSupply <= 0 {
 		cfg.InitialGASSupply = fixedn.Fixed8(defaultInitialGAS)
-		log.Info("initial gas supply is not set or wrong, setting default value", zap.String("InitialGASSupply", cfg.InitialGASSupply.String()))
+		log.Info("initial gas supply is not set or wrong, setting default value", zap.Stringer("InitialGASSupply", cfg.InitialGASSupply))
 	}
 	if cfg.MemPoolSize <= 0 {
 		cfg.MemPoolSize = defaultMemPoolSize

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -1292,7 +1292,7 @@ func getRequestBlocksPayload(p Peer, currHeight uint32, lastRequestedHeight *ato
 func (s *Server) handleMessage(peer Peer, msg *Message) error {
 	s.log.Debug("got msg",
 		zap.Stringer("addr", peer.RemoteAddr()),
-		zap.String("type", msg.Command.String()))
+		zap.Stringer("type", msg.Command))
 
 	start := time.Now()
 	defer func() { addCmdTimeMetric(msg.Command, time.Since(start)) }()

--- a/pkg/network/tcp_transport.go
+++ b/pkg/network/tcp_transport.go
@@ -83,7 +83,7 @@ func (t *TCPTransport) Accept() {
 			if errors.Is(err, net.ErrClosed) && quit {
 				break
 			}
-			t.log.Warn("TCP accept error", zap.String("address", l.Addr().String()), zap.Error(err))
+			t.log.Warn("TCP accept error", zap.Stringer("address", l.Addr()), zap.Error(err))
 			continue
 		}
 		p := NewTCPPeer(conn, "", t.server)

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -2639,14 +2639,14 @@ chloop:
 						if err != nil {
 							s.log.Error("failed to marshal notification",
 								zap.Error(err),
-								zap.String("type", resp.Event.String()))
+								zap.Stringer("type", resp.Event))
 							break subloop
 						}
 						msg, err = websocket.NewPreparedMessage(websocket.TextMessage, b)
 						if err != nil {
 							s.log.Error("failed to prepare notification message",
 								zap.Error(err),
-								zap.String("type", resp.Event.String()))
+								zap.Stringer("type", resp.Event))
 							break subloop
 						}
 					}


### PR DESCRIPTION
It's a bit more efficient in case we're not logging the message (mostly for debug), makes the code somewhat simpler as well.
