### PR TITLE
network: do not allow to request invalid block count

### DIFF
--- a/pkg/network/blockqueue.go
+++ b/pkg/network/blockqueue.go
@@ -136,10 +136,12 @@ func (bq *blockQueue) putBlock(block *block.Block) error {
 	return nil
 }
 
-func (bq *blockQueue) lastQueued() uint32 {
+// lastQueued returns the index of the last queued block and the queue's capacity
+// left.
+func (bq *blockQueue) lastQueued() (uint32, int) {
 	bq.queueLock.RLock()
 	defer bq.queueLock.RUnlock()
-	return bq.lastQ
+	return bq.lastQ, blockCacheSize - bq.len
 }
 
 func (bq *blockQueue) discard() {

--- a/pkg/network/blockqueue_test.go
+++ b/pkg/network/blockqueue_test.go
@@ -22,7 +22,9 @@ func TestBlockQueue(t *testing.T) {
 	for i := 3; i < 5; i++ {
 		assert.NoError(t, bq.putBlock(blocks[i]))
 	}
-	assert.Equal(t, uint32(0), bq.lastQueued())
+	last, capLeft := bq.lastQueued()
+	assert.Equal(t, uint32(0), last)
+	assert.Equal(t, blockCacheSize-2, capLeft)
 	// nothing should be put into the blockchain
 	assert.Equal(t, uint32(0), chain.BlockHeight())
 	assert.Equal(t, 2, bq.length())
@@ -31,7 +33,9 @@ func TestBlockQueue(t *testing.T) {
 		assert.NoError(t, bq.putBlock(blocks[i]))
 	}
 	// but they're still not put into the blockchain, because bq isn't running
-	assert.Equal(t, uint32(4), bq.lastQueued())
+	last, capLeft = bq.lastQueued()
+	assert.Equal(t, uint32(4), last)
+	assert.Equal(t, blockCacheSize-4, capLeft)
 	assert.Equal(t, uint32(0), chain.BlockHeight())
 	assert.Equal(t, 4, bq.length())
 	// block with too big index is dropped
@@ -40,14 +44,18 @@ func TestBlockQueue(t *testing.T) {
 	go bq.run()
 	// run() is asynchronous, so we need some kind of timeout anyway and this is the simplest one
 	assert.Eventually(t, func() bool { return chain.BlockHeight() == 4 }, 4*time.Second, 100*time.Millisecond)
-	assert.Equal(t, uint32(4), bq.lastQueued())
+	last, capLeft = bq.lastQueued()
+	assert.Equal(t, uint32(4), last)
+	assert.Equal(t, blockCacheSize, capLeft)
 	assert.Equal(t, 0, bq.length())
 	assert.Equal(t, uint32(4), chain.BlockHeight())
 	// put some old blocks
 	for i := 1; i < 5; i++ {
 		assert.NoError(t, bq.putBlock(blocks[i]))
 	}
-	assert.Equal(t, uint32(4), bq.lastQueued())
+	last, capLeft = bq.lastQueued()
+	assert.Equal(t, uint32(4), last)
+	assert.Equal(t, blockCacheSize, capLeft)
 	assert.Equal(t, 0, bq.length())
 	assert.Equal(t, uint32(4), chain.BlockHeight())
 	// unexpected blocks with run() active
@@ -65,7 +73,9 @@ func TestBlockQueue(t *testing.T) {
 	assert.NoError(t, bq.putBlock(blocks[5]))
 	// run() is asynchronous, so we need some kind of timeout anyway and this is the simplest one
 	assert.Eventually(t, func() bool { return chain.BlockHeight() == 8 }, 4*time.Second, 100*time.Millisecond)
-	assert.Equal(t, uint32(8), bq.lastQueued())
+	last, capLeft = bq.lastQueued()
+	assert.Equal(t, uint32(8), last)
+	assert.Equal(t, blockCacheSize-1, capLeft)
 	assert.Equal(t, 1, bq.length())
 	assert.Equal(t, uint32(8), chain.BlockHeight())
 	bq.discard()

--- a/pkg/network/payload/getblockbyindex.go
+++ b/pkg/network/payload/getblockbyindex.go
@@ -1,7 +1,7 @@
 package payload
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/io"
 )
@@ -25,7 +25,7 @@ func (d *GetBlockByIndex) DecodeBinary(br *io.BinReader) {
 	d.IndexStart = br.ReadU32LE()
 	d.Count = int16(br.ReadU16LE())
 	if d.Count < -1 || d.Count == 0 || d.Count > MaxHeadersAllowed {
-		br.Err = errors.New("invalid block count")
+		br.Err = fmt.Errorf("invalid block count: %d", d.Count)
 	}
 }
 

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -1250,7 +1250,7 @@ func (s *Server) requestBlocks(bq Blockqueuer, p Peer) error {
 	h := bq.BlockHeight()
 	pl := getRequestBlocksPayload(p, h, &s.lastRequestedBlock)
 	lq := s.bQueue.lastQueued()
-	if lq > pl.IndexStart {
+	if lq >= pl.IndexStart {
 		c := int16(h + blockCacheSize - lq)
 		if c < payload.MaxHashesCount {
 			pl.Count = c


### PR DESCRIPTION
The problem is in peer disconnection due to invalid GetBlockByIndex payload (the logs are from some patched neo-go version):
```
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.490Z        INFO        new peer connected        {"addr": "10.78.69.115:50846", "peerCount": 3}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.490Z        WARN        peer disconnected        {"addr": "10.78.69.115:50846", "error": "invalid block count", "peerCount": 2}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.490Z        INFO        started protocol        {"addr": "10.78.69.115:50846", "userAgent": "/NEO-GO:1.0.0/", "startHeight": 0, "id": 1339571820}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.491Z        INFO        new peer connected        {"addr": "10.78.69.115:50856", "peerCount": 3}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.492Z        WARN        peer disconnected        {"addr": "10.78.69.115:50856", "error": "invalid block count", "peerCount": 2}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.492Z        INFO        started protocol        {"addr": "10.78.69.115:50856", "userAgent": "/NEO-GO:1.0.0/", "startHeight": 0, "id": 1339571820}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.492Z        INFO        new peer connected        {"addr": "10.78.69.115:50858", "peerCount": 3}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.493Z        INFO        started protocol        {"addr": "10.78.69.115:50858", "userAgent": "/NEO-GO:1.0.0/", "startHeight": 0, "id": 1339571820}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.493Z        WARN        peer disconnected        {"addr": "10.78.69.115:50858", "error": "invalid block count", "peerCount": 2}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.494Z        INFO        new peer connected        {"addr": "10.78.69.115:50874", "peerCount": 3}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.494Z        INFO        started protocol        {"addr": "10.78.69.115:50874", "userAgent": "/NEO-GO:1.0.0/", "startHeight": 0, "id": 1339571820}
дек 15 16:02:39 glagoli neo-go[928530]: 2022-12-15T16:02:39.494Z        WARN        peer disconnected        {"addr": "10.78.69.115:50874", "error": "invalid block count", "peerCount": 2}
```

GetBlockByIndex payload can't be decoded, and the only possible cause is zero (or <-1, but it's probably not the case) block count requested.

Error is improved as far.

UPD: `0` blocks were requested:
```
дек 15 17:44:32 az neo-go[998229]: 2022-12-15T17:44:32.814Z        WARN        peer disconnected        {"addr": "10.78.69.115:55634", "error": "invalid block count: 0", "peerCount": 2}
```