### PR TITLE
rpcclient/actor: Document `RPCActor.CalculateNetworkFee` method

### DIFF
--- a/pkg/rpcclient/actor/actor.go
+++ b/pkg/rpcclient/actor/actor.go
@@ -26,6 +26,10 @@ import (
 type RPCActor interface {
 	invoker.RPCInvoke
 
+	// CalculateNetworkFee calculates network fee for the given transaction.
+	//
+	// CalculateNetworkFee MUST NOT call state-changing methods (like Hash or Size)
+	// of the transaction through the passed pointer: make a copy if necessary.
 	CalculateNetworkFee(tx *transaction.Transaction) (int64, error)
 	GetBlockCount() (uint32, error)
 	GetVersion() (*result.Version, error)


### PR DESCRIPTION
`Actor.MakeUnsignedUncheckedRun` method imposes restriction to `CalculateNetworkFee` method's implementations: `Hash` or `Size` methods must not be called on the pointer to the given transaction.

Add docs to adjust described requirement.
