### PR TITLE
services/rpcsrv: Strengthen `Server` error channel's type

### DIFF
--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -133,7 +133,7 @@ type (
 		log              *zap.Logger
 		shutdown         chan struct{}
 		started          *atomic.Bool
-		errChan          chan error
+		errChan          chan<- error
 
 		sessionsLock sync.Mutex
 		sessions     map[string]*session
@@ -255,7 +255,7 @@ var invalidBlockHeightError = func(index int, height int) *neorpc.Error {
 
 // New creates a new Server struct.
 func New(chain Ledger, conf config.RPC, coreServer *network.Server,
-	orc OracleHandler, log *zap.Logger, errChan chan error) Server {
+	orc OracleHandler, log *zap.Logger, errChan chan<- error) Server {
 	addrs := conf.GetAddresses()
 	httpServers := make([]*http.Server, len(addrs))
 	for i, addr := range addrs {


### PR DESCRIPTION
## Motivation
I'm trying to use `rpcsrv.Server` type in the developing application. I have global error channel which is used to sync app's error signals. In current implementation `New` contstructor accepts parameter of type `chan error`. Thus, I can't be sure that `Server` errors won't "disappear" from my application's view.

According to docs (and, accordingly, implementation), `Server` only writes errors to the channel. It seems that it is enough to accept a write-only channel.

## P.S.
Similar work can be made for cases like https://pkg.go.dev/github.com/nspcc-dev/neo-go@v0.100.1/pkg/core#Blockchain.SubscribeForTransactions.