### PR TITLE
rpcclient: expose endpoint (fixes #2912)

### DIFF
--- a/pkg/rpcclient/client.go
+++ b/pkg/rpcclient/client.go
@@ -255,3 +255,8 @@ func (c *Client) Ping() error {
 func (c *Client) Context() context.Context {
 	return c.ctx
 }
+
+// Endpoint returns the client endpoint.
+func (c *Client) Endpoint() string {
+	return c.endpoint.String()
+}

--- a/pkg/rpcclient/client_test.go
+++ b/pkg/rpcclient/client_test.go
@@ -1,0 +1,18 @@
+package rpcclient
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetEndpoint(t *testing.T) {
+	host := "http://localhost:1234"
+	u, err := url.Parse(host)
+	require.NoError(t, err)
+	client := Client{
+		endpoint: u,
+	}
+	require.Equal(t, host, client.Endpoint())
+}


### PR DESCRIPTION
### Problem

Endpoint data not accessible

### Solution

expose with method as string as per https://github.com/nspcc-dev/neo-go/issues/2912#issuecomment-1427110975
