### PR TITLE
network: drain send queues on peer disconnection

### DIFF
--- a/pkg/network/tcp_peer.go
+++ b/pkg/network/tcp_peer.go
@@ -250,6 +250,16 @@ func (p *TCPPeer) handleQueues() {
 		p2pSkipCounter++
 	}
 	p.Disconnect(err)
+drainloop:
+	for {
+		select {
+		case <-p.hpSendQ:
+		case <-p.p2pSendQ:
+		case <-p.sendQ:
+		default:
+			break drainloop
+		}
+	}
 }
 
 // StartProtocol starts a long running background loop that interacts


### PR DESCRIPTION
Fix potential memory leak with a lot of connected clients that keep requesting things from node and then disconnect.
