### PR TITLE
*: add nolint comments to multiple errors wrapping

### DIFF
--- a/cli/vm/cli.go
+++ b/cli/vm/cli.go
@@ -607,7 +607,7 @@ func getInstructionParameter(c *cli.Context) (int, error) {
 	}
 	n, err := strconv.Atoi(args[0])
 	if err != nil {
-		return 0, fmt.Errorf("%w: %s", ErrInvalidParameter, err)
+		return 0, fmt.Errorf("%w: %s", ErrInvalidParameter, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 	}
 	return n, nil
 }
@@ -690,7 +690,7 @@ func handleLoadNEF(c *cli.Context) error {
 	if len(args) > 2 {
 		signers, err = cmdargs.ParseSigners(c.Args()[2:])
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidParameter, err)
+			return fmt.Errorf("%w: %v", ErrInvalidParameter, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 	}
 	err = prepareVM(c, createFakeTransaction(nef.Script, signers))
@@ -711,13 +711,13 @@ func handleLoadBase64(c *cli.Context) error {
 	}
 	b, err := base64.StdEncoding.DecodeString(args[0])
 	if err != nil {
-		return fmt.Errorf("%w: %s", ErrInvalidParameter, err)
+		return fmt.Errorf("%w: %s", ErrInvalidParameter, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 	}
 	var signers []transaction.Signer
 	if len(args) > 1 {
 		signers, err = cmdargs.ParseSigners(args[1:])
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidParameter, err)
+			return fmt.Errorf("%w: %v", ErrInvalidParameter, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 	}
 	err = prepareVM(c, createFakeTransaction(b, signers))
@@ -745,13 +745,13 @@ func handleLoadHex(c *cli.Context) error {
 	}
 	b, err := hex.DecodeString(args[0])
 	if err != nil {
-		return fmt.Errorf("%w: %s", ErrInvalidParameter, err)
+		return fmt.Errorf("%w: %s", ErrInvalidParameter, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 	}
 	var signers []transaction.Signer
 	if len(args) > 1 {
 		signers, err = cmdargs.ParseSigners(args[1:])
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidParameter, err)
+			return fmt.Errorf("%w: %v", ErrInvalidParameter, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 	}
 	err = prepareVM(c, createFakeTransaction(b, signers))
@@ -785,7 +785,7 @@ func handleLoadGo(c *cli.Context) error {
 	if len(args) > 1 {
 		signers, err = cmdargs.ParseSigners(args[1:])
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidParameter, err)
+			return fmt.Errorf("%w: %v", ErrInvalidParameter, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 	}
 
@@ -871,7 +871,7 @@ func handleLoadDeployed(c *cli.Context) error {
 	if len(c.Args()) > 1 {
 		signers, err = cmdargs.ParseSigners(c.Args()[1:])
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidParameter, err)
+			return fmt.Errorf("%w: %v", ErrInvalidParameter, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 	}
 	err = prepareVM(c, createFakeTransaction(cs.NEF.Script, signers)) // prepare VM one more time for proper IC initialization.
@@ -982,7 +982,7 @@ func handleRun(c *cli.Context) error {
 
 		_, scParams, err := cmdargs.ParseParams(args[1:], true)
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidParameter, err)
+			return fmt.Errorf("%w: %v", ErrInvalidParameter, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 		params = make([]stackitem.Item, len(scParams))
 		for i := range scParams {
@@ -1085,7 +1085,7 @@ func handleStep(c *cli.Context) error {
 	if len(args) > 0 {
 		n, err = strconv.Atoi(args[0])
 		if err != nil {
-			return fmt.Errorf("%w: %s", ErrInvalidParameter, err)
+			return fmt.Errorf("%w: %s", ErrInvalidParameter, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 	}
 	v.AddBreakPointRel(n)

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2339,7 +2339,7 @@ func (bc *Blockchain) verifyAndPoolTx(t *transaction.Transaction, pool *mempool.
 	// really require a chain lock.
 	err := vm.IsScriptCorrect(t.Script, nil)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidScript, err)
+		return fmt.Errorf("%w: %v", ErrInvalidScript, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 	}
 
 	height := bc.BlockHeight()
@@ -2350,7 +2350,7 @@ func (bc *Blockchain) verifyAndPoolTx(t *transaction.Transaction, pool *mempool.
 	// Policying.
 	if err := bc.contracts.Policy.CheckPolicy(bc.dao, t); err != nil {
 		// Only one %w can be used.
-		return fmt.Errorf("%w: %v", ErrPolicy, err)
+		return fmt.Errorf("%w: %v", ErrPolicy, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 	}
 	if t.SystemFee > bc.config.MaxBlockSystemFee {
 		return fmt.Errorf("%w: too big system fee (%d > MaxBlockSystemFee %d)", ErrPolicy, t.SystemFee, bc.config.MaxBlockSystemFee)
@@ -2401,7 +2401,7 @@ func (bc *Blockchain) verifyAndPoolTx(t *transaction.Transaction, pool *mempool.
 		case errors.Is(err, mempool.ErrOOM):
 			return ErrOOM
 		case errors.Is(err, mempool.ErrConflictsAttribute):
-			return fmt.Errorf("mempool: %w: %s", ErrHasConflicts, err)
+			return fmt.Errorf("mempool: %w: %s", ErrHasConflicts, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		default:
 			return err
 		}
@@ -2421,7 +2421,7 @@ func (bc *Blockchain) verifyTxAttributes(d *dao.Simple, tx *transaction.Transact
 		case transaction.OracleResponseT:
 			h, err := bc.contracts.Oracle.GetScriptHash(bc.dao)
 			if err != nil || h.Equals(util.Uint160{}) {
-				return fmt.Errorf("%w: %v", ErrInvalidAttribute, err)
+				return fmt.Errorf("%w: %v", ErrInvalidAttribute, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 			}
 			hasOracle := false
 			for i := range tx.Signers {
@@ -2441,7 +2441,7 @@ func (bc *Blockchain) verifyTxAttributes(d *dao.Simple, tx *transaction.Transact
 			resp := tx.Attributes[i].Value.(*transaction.OracleResponse)
 			req, err := bc.contracts.Oracle.GetRequestInternal(bc.dao, resp.ID)
 			if err != nil {
-				return fmt.Errorf("%w: oracle tx points to invalid request: %v", ErrInvalidAttribute, err)
+				return fmt.Errorf("%w: oracle tx points to invalid request: %v", ErrInvalidAttribute, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 			}
 			if uint64(tx.NetworkFee+tx.SystemFee) < req.GasForResponse {
 				return fmt.Errorf("%w: oracle tx has insufficient gas", ErrInvalidAttribute)
@@ -2675,7 +2675,7 @@ func (bc *Blockchain) InitVerificationContext(ic *interop.Context, hash util.Uin
 		}
 		err := vm.IsScriptCorrect(witness.VerificationScript, nil)
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidVerification, err)
+			return fmt.Errorf("%w: %v", ErrInvalidVerification, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 		ic.VM.LoadScriptWithHash(witness.VerificationScript, hash, callflag.ReadOnly)
 	} else {
@@ -2700,7 +2700,7 @@ func (bc *Blockchain) InitVerificationContext(ic *interop.Context, hash util.Uin
 	if len(witness.InvocationScript) != 0 {
 		err := vm.IsScriptCorrect(witness.InvocationScript, nil)
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidInvocation, err)
+			return fmt.Errorf("%w: %v", ErrInvalidInvocation, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 		ic.VM.LoadScript(witness.InvocationScript)
 	}
@@ -2732,7 +2732,7 @@ func (bc *Blockchain) verifyHashAgainstScript(hash util.Uint160, witness *transa
 	}
 	err := interopCtx.Exec()
 	if vm.HasFailed() {
-		return 0, fmt.Errorf("%w: vm execution has failed: %v", ErrVerificationFailed, err)
+		return 0, fmt.Errorf("%w: vm execution has failed: %v", ErrVerificationFailed, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 	}
 	estack := vm.Estack()
 	if estack.Len() > 0 {

--- a/pkg/core/interop/contract/call.go
+++ b/pkg/core/interop/contract/call.go
@@ -165,7 +165,7 @@ func CallFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contract
 
 	for !ic.VM.HasStopped() && len(ic.VM.Istack()) > startSize {
 		if err := ic.VM.Step(); err != nil {
-			return fmt.Errorf("%w: %v", ErrNativeCall, err)
+			return fmt.Errorf("%w: %v", ErrNativeCall, err) //nolint:errorlint // non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 	}
 	if ic.VM.HasFailed() {

--- a/pkg/core/storage/boltdb_store.go
+++ b/pkg/core/storage/boltdb_store.go
@@ -59,7 +59,7 @@ func NewBoltDBStore(cfg dbconfig.BoltDBOptions) (*BoltDBStore, error) {
 		closeErr := db.Close()
 		err = fmt.Errorf("failed to initialize BoltDB instance: %w", err)
 		if closeErr != nil {
-			err = fmt.Errorf("%w, failed to close BoltDB instance: %v", err, closeErr)
+			err = fmt.Errorf("%w, failed to close BoltDB instance: %v", err, closeErr) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 		return nil, err
 	}

--- a/pkg/rpcclient/actor/waiter.go
+++ b/pkg/rpcclient/actor/waiter.go
@@ -197,9 +197,9 @@ func (w *PollingWaiter) WaitAny(ctx context.Context, vub uint32, hashes ...util.
 				return nil, ErrTxNotAccepted
 			}
 		case <-w.polling.Context().Done():
-			return nil, fmt.Errorf("%w: %v", ErrContextDone, w.polling.Context().Err())
+			return nil, fmt.Errorf("%w: %v", ErrContextDone, w.polling.Context().Err()) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		case <-ctx.Done():
-			return nil, fmt.Errorf("%w: %v", ErrContextDone, ctx.Err())
+			return nil, fmt.Errorf("%w: %v", ErrContextDone, ctx.Err()) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 	}
 }
@@ -302,9 +302,9 @@ func (w *EventWaiter) WaitAny(ctx context.Context, vub uint32, hashes ...util.Ui
 			}
 			res = aer
 		case <-w.ws.Context().Done():
-			waitErr = fmt.Errorf("%w: %v", ErrContextDone, w.ws.Context().Err())
+			waitErr = fmt.Errorf("%w: %v", ErrContextDone, w.ws.Context().Err()) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		case <-ctx.Done():
-			waitErr = fmt.Errorf("%w: %v", ErrContextDone, ctx.Err())
+			waitErr = fmt.Errorf("%w: %v", ErrContextDone, ctx.Err()) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 	}
 	close(exit)
@@ -345,7 +345,7 @@ func (w *EventWaiter) WaitAny(ctx context.Context, vub uint32, hashes ...util.Ui
 		res, waitErr = w.polling.WaitAny(ctx, vub, hashes...)
 		if waitErr != nil {
 			// Wrap the poll-based error, it's more important.
-			waitErr = fmt.Errorf("event-based error: %v; poll-based waiter error: %w", wsWaitErr, waitErr)
+			waitErr = fmt.Errorf("event-based error: %v; poll-based waiter error: %w", wsWaitErr, waitErr) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 		}
 	}
 	return

--- a/pkg/services/oracle/neofs/neofs.go
+++ b/pkg/services/oracle/neofs/neofs.go
@@ -83,12 +83,12 @@ func parseNeoFSURL(u *url.URL) (*object.Address, []string, error) {
 
 	containerID := cid.New()
 	if err := containerID.Parse(ps[0]); err != nil {
-		return nil, nil, fmt.Errorf("%w: %v", ErrInvalidContainer, err)
+		return nil, nil, fmt.Errorf("%w: %v", ErrInvalidContainer, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 	}
 
 	objectID := object.NewID()
 	if err := objectID.Parse(ps[1]); err != nil {
-		return nil, nil, fmt.Errorf("%w: %v", ErrInvalidObject, err)
+		return nil, nil, fmt.Errorf("%w: %v", ErrInvalidObject, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 	}
 
 	objectAddr := object.NewAddress()

--- a/pkg/services/oracle/network.go
+++ b/pkg/services/oracle/network.go
@@ -65,7 +65,7 @@ func getDefaultClient(cfg config.OracleConfiguration) *http.Client {
 		d.Control = func(network, address string, c syscall.RawConn) error {
 			host, _, err := net.SplitHostPort(address)
 			if err != nil {
-				return fmt.Errorf("%w: failed to split address %s: %s", ErrRestrictedRedirect, address, err)
+				return fmt.Errorf("%w: failed to split address %s: %s", ErrRestrictedRedirect, address, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 			}
 			ip := net.ParseIP(host)
 			if ip == nil {

--- a/pkg/vm/stackitem/json.go
+++ b/pkg/vm/stackitem/json.go
@@ -406,7 +406,7 @@ type (
 )
 
 func mkErrValue(err error) error {
-	return fmt.Errorf("%w: %v", ErrInvalidValue, err)
+	return fmt.Errorf("%w: %v", ErrInvalidValue, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 }
 
 // FromJSONWithTypes deserializes an item from typed-json representation.


### PR DESCRIPTION
### Problem

Failing Linter job, see :
```
 Error: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
```

Due to a set of places where multiple errors should be wrapped. However, multiple errors wrapping is a part of go 1.20, thus we can't use it now.

### Solution

Explicitly specify go version (although it should be fetched from environment anyway).
