### PR TITLE
rpc: do not omit value of Null parameter on marshalling

### DIFF
--- a/pkg/services/rpcsrv/params/txBuilder.go
+++ b/pkg/services/rpcsrv/params/txBuilder.go
@@ -84,7 +84,7 @@ func ExpandArrayIntoScript(script *io.BinWriter, slice []Param) error {
 				return err
 			}
 		case smartcontract.AnyType:
-			if fp.Value.IsNull() {
+			if fp.Value.IsNull() || len(fp.Value.RawMessage) == 0 {
 				emit.Opcodes(script, opcode.PUSHNULL)
 			}
 		default:


### PR DESCRIPTION
Thanks to fyrchik for reporting. Need to test it wrt C# node compatibility and (if not compatible) apply another fix.

Otherwise it leads to the following error in the TestActor_CallWithNilParam:
```
=== RUN   TestActor_CallWithNilParam
    logger.go:130: 2023-04-03T15:58:27.672+0300	INFO	initial gas supply is not set or wrong, setting default value	{"InitialGASSupply": "52000000"}
    logger.go:130: 2023-04-03T15:58:27.672+0300	INFO	P2PNotaryRequestPayloadPool size is not set or wrong, setting default value	{"P2PNotaryRequestPayloadPoolSize": 1000}
    logger.go:130: 2023-04-03T15:58:27.672+0300	INFO	MaxBlockSize is not set or wrong, setting default value	{"MaxBlockSize": 262144}
    logger.go:130: 2023-04-03T15:58:27.672+0300	INFO	MaxBlockSystemFee is not set or wrong, setting default value	{"MaxBlockSystemFee": 900000000000}
    logger.go:130: 2023-04-03T15:58:27.672+0300	INFO	MaxTransactionsPerBlock is not set or wrong, using default value	{"MaxTransactionsPerBlock": 512}
    logger.go:130: 2023-04-03T15:58:27.672+0300	INFO	MaxValidUntilBlockIncrement is not set or wrong, using default value	{"MaxValidUntilBlockIncrement": 5760}
    logger.go:130: 2023-04-03T15:58:27.675+0300	INFO	no storage version found! creating genesis block
    logger.go:130: 2023-04-03T15:58:27.675+0300	INFO	ExtensiblePoolSize is not set or wrong, using default value	{"ExtensiblePoolSize": 20}
    logger.go:130: 2023-04-03T15:58:27.675+0300	INFO	SessionPoolSize is not set or wrong, setting default value	{"SessionPoolSize": 20}
    logger.go:130: 2023-04-03T15:58:27.675+0300	INFO	MaxWebSocketClients is not set or wrong, setting default value	{"MaxWebSocketClients": 64}
    logger.go:130: 2023-04-03T15:58:27.675+0300	INFO	starting rpc-server	{"endpoint": "localhost:0"}
    logger.go:130: 2023-04-03T15:58:27.677+0300	DEBUG	done processing headers	{"headerIndex": 1, "blockHeight": 0, "took": "436.313µs"}
    logger.go:130: 2023-04-03T15:58:27.679+0300	DEBUG	done processing headers	{"headerIndex": 2, "blockHeight": 1, "took": "272.891µs"}
    logger.go:130: 2023-04-03T15:58:27.680+0300	DEBUG	done processing headers	{"headerIndex": 3, "blockHeight": 2, "took": "276.949µs"}
    logger.go:130: 2023-04-03T15:58:27.681+0300	DEBUG	done processing headers	{"headerIndex": 4, "blockHeight": 3, "took": "286.028µs"}
    logger.go:130: 2023-04-03T15:58:27.681+0300	DEBUG	done processing headers	{"headerIndex": 5, "blockHeight": 4, "took": "268.673µs"}
    logger.go:130: 2023-04-03T15:58:27.681+0300	INFO	bad notification	{"contract": "565cff9508ebc75aadd7fe59f38dac610ab6093c", "event": "Transfer", "error": "parameter 0 type mismatch: Hash160 vs ByteString"}
    logger.go:130: 2023-04-03T15:58:27.682+0300	DEBUG	done processing headers	{"headerIndex": 6, "blockHeight": 5, "took": "380.988µs"}
    logger.go:130: 2023-04-03T15:58:27.683+0300	DEBUG	done processing headers	{"headerIndex": 7, "blockHeight": 6, "took": "273.543µs"}
    logger.go:130: 2023-04-03T15:58:27.683+0300	DEBUG	done processing headers	{"headerIndex": 8, "blockHeight": 7, "took": "275.163µs"}
    logger.go:130: 2023-04-03T15:58:27.684+0300	DEBUG	done processing headers	{"headerIndex": 9, "blockHeight": 8, "took": "259.578µs"}
    logger.go:130: 2023-04-03T15:58:27.685+0300	DEBUG	done processing headers	{"headerIndex": 10, "blockHeight": 9, "took": "266.882µs"}
    logger.go:130: 2023-04-03T15:58:27.686+0300	DEBUG	done processing headers	{"headerIndex": 11, "blockHeight": 10, "took": "295.3µs"}
    logger.go:130: 2023-04-03T15:58:27.687+0300	DEBUG	done processing headers	{"headerIndex": 12, "blockHeight": 11, "took": "295.568µs"}
    logger.go:130: 2023-04-03T15:58:27.688+0300	DEBUG	done processing headers	{"headerIndex": 13, "blockHeight": 12, "took": "258.197µs"}
    logger.go:130: 2023-04-03T15:58:27.689+0300	DEBUG	done processing headers	{"headerIndex": 14, "blockHeight": 13, "took": "261.602µs"}
    logger.go:130: 2023-04-03T15:58:27.689+0300	DEBUG	done processing headers	{"headerIndex": 15, "blockHeight": 14, "took": "268.922µs"}
    logger.go:130: 2023-04-03T15:58:27.690+0300	DEBUG	done processing headers	{"headerIndex": 16, "blockHeight": 15, "took": "276.176µs"}
    logger.go:130: 2023-04-03T15:58:27.691+0300	DEBUG	done processing headers	{"headerIndex": 17, "blockHeight": 16, "took": "256.068µs"}
    logger.go:130: 2023-04-03T15:58:27.692+0300	DEBUG	done processing headers	{"headerIndex": 18, "blockHeight": 17, "took": "262.303µs"}
    logger.go:130: 2023-04-03T15:58:27.692+0300	DEBUG	done processing headers	{"headerIndex": 19, "blockHeight": 18, "took": "265.087µs"}
    logger.go:130: 2023-04-03T15:58:27.693+0300	DEBUG	done processing headers	{"headerIndex": 20, "blockHeight": 19, "took": "260.758µs"}
    logger.go:130: 2023-04-03T15:58:27.694+0300	DEBUG	done processing headers	{"headerIndex": 21, "blockHeight": 20, "took": "263.482µs"}
    logger.go:130: 2023-04-03T15:58:27.694+0300	DEBUG	done processing headers	{"headerIndex": 22, "blockHeight": 21, "took": "327.812µs"}
    logger.go:130: 2023-04-03T15:58:27.696+0300	DEBUG	done processing headers	{"headerIndex": 23, "blockHeight": 22, "took": "284.104µs"}
    logger.go:130: 2023-04-03T15:58:27.697+0300	WARN	contract invocation failed	{"tx": "82279bfe9bada282ca0f8cb8e0bb124b921af36f00c69a518320322c6f4fef60", "block": 23, "error": "at instruction 0 (ABORT): ABORT"}
    logger.go:130: 2023-04-03T15:58:27.697+0300	DEBUG	processing rpc request	{"method": "getversion", "params": "[]"}
    logger.go:130: 2023-04-03T15:58:27.698+0300	DEBUG	processing rpc request	{"method": "invokefunction", "params": "[565cff9508ebc75aadd7fe59f38dac610ab6093c putValue  ]"}
    client_test.go:2562:
        	Error Trace:	/home/anna/Documents/GitProjects/nspcc-dev/neo-go/pkg/services/rpcsrv/client_test.go:2562
        	Error:      	Should be true
        	Test:       	TestActor_CallWithNilParam
        	Messages:   	at instruction 6 (PACK): OPACK: invalid length
    logger.go:130: 2023-04-03T15:58:27.699+0300	INFO	shutting down RPC server	{"endpoint": "127.0.0.1:46005"}
    logger.go:130: 2023-04-03T15:58:27.700+0300	INFO	persisted to disk	{"blocks": 23, "keys": 1236, "headerHeight": 23, "blockHeight": 23, "took": "908.825µs"}
--- FAIL: TestActor_CallWithNilParam (0.03s)

FAIL
```