### PR TITLE
cli: extend `util` with `ops` command

### DIFF
--- a/cli/util/util_test.go
+++ b/cli/util/util_test.go
@@ -1,10 +1,13 @@
 package util_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/internal/testcli"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUtilConvert(t *testing.T) {
@@ -23,4 +26,40 @@ func TestUtilConvert(t *testing.T) {
 	e.CheckNextLine(t, "30303030303030303030303030303030303030303030303030303030303030303030303330323031") // string to hex
 	e.CheckNextLine(t, "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAzMDIwMQ==")                         // string to base64
 	e.CheckEOF(t)
+}
+
+func TestUtilOps(t *testing.T) {
+	e := testcli.NewExecutor(t, false)
+	base64Str := "EUA="
+	hexStr := "1140"
+
+	check := func(t *testing.T) {
+		e.CheckNextLine(t, "INDEX.*OPCODE.*PARAMETER")
+		e.CheckNextLine(t, "PUSH1")
+		e.CheckNextLine(t, "RET")
+		e.CheckEOF(t)
+	}
+
+	e.Run(t, "neo-go", "util", "ops", base64Str) // base64
+	check(t)
+
+	e.Run(t, "neo-go", "util", "ops", hexStr) // base64 is checked firstly by default, but it's invalid script if decoded from base64
+	e.CheckNextLine(t, "INDEX.*OPCODE.*PARAMETER")
+	e.CheckNextLine(t, ".*ERROR: incorrect opcode")
+	e.CheckEOF(t)
+
+	e.Run(t, "neo-go", "util", "ops", "--hex", hexStr) // explicitly specify hex encoding
+	check(t)
+
+	e.RunWithError(t, "neo-go", "util", "ops", "%&~*") // unknown encoding
+
+	tmp := filepath.Join(t.TempDir(), "script_base64.txt")
+	require.NoError(t, os.WriteFile(tmp, []byte(base64Str), os.ModePerm))
+	e.Run(t, "neo-go", "util", "ops", "--in", tmp) // base64 from file
+	check(t)
+
+	tmp = filepath.Join(t.TempDir(), "script_hex.txt")
+	require.NoError(t, os.WriteFile(tmp, []byte(hexStr), os.ModePerm))
+	e.Run(t, "neo-go", "util", "ops", "--hex", "--in", tmp) // hex from file
+	check(t)
 }


### PR DESCRIPTION
Close #2911.

Works like a magic:
```
anna@kiwi:~/Documents/GitProjects/nspcc-dev/neo-go$ ./bin/neo-go util ops CxAMFHTn5bEoAfIH/wRZ1zATce9uZ6v2DBR05+WxKAHyB/8EWdcwE3Hvbmer9hTAHwwIdHJhbnNmZXIMFPVj6kC8KD1NDgXEjqMFs/Kgc0DvQWJ9W1I=
INDEX    OPCODE       PARAMETER
0        PUSHNULL         <<
1        PUSH0        
2        PUSHDATA1    74e7e5b12801f207ff0459d7301371ef6e67abf6
24       PUSHDATA1    74e7e5b12801f207ff0459d7301371ef6e67abf6
46       PUSH4        
47       PACK         
48       PUSH15       
49       PUSHDATA1    7472616e73666572 ("transfer")
59       PUSHDATA1    f563ea40bc283d4d0e05c48ea305b3f2a07340ef
81       SYSCALL      System.Contract.Call (627d5b52)
```