### PR TITLE
Revert "native: make management compatible with C# node 3.5.0"

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2228,14 +2228,6 @@ func (bc *Blockchain) GetContractState(hash util.Uint160) *state.Contract {
 
 // GetContractScriptHash returns contract script hash by its ID.
 func (bc *Blockchain) GetContractScriptHash(id int32) (util.Uint160, error) {
-	if id < 0 {
-		for _, n := range bc.contracts.Contracts {
-			nc := n.Metadata().NativeContract
-			if nc.ID == id {
-				return nc.Hash, nil
-			}
-		}
-	}
 	return native.GetContractScriptHash(bc.dao, id)
 }
 

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -688,10 +688,8 @@ func putContractState(d *dao.Simple, cs *state.Contract, updateCache bool) error
 	if cs.UpdateCounter != 0 { // Update.
 		return nil
 	}
-	if cs.ID > 0 {
-		key = putHashKey(key, cs.ID)
-		d.PutStorageItem(ManagementContractID, key, cs.Hash.BytesBE())
-	}
+	key = putHashKey(key, cs.ID)
+	d.PutStorageItem(ManagementContractID, key, cs.Hash.BytesBE())
 	return nil
 }
 

--- a/pkg/core/native/native_test/management_test.go
+++ b/pkg/core/native/native_test/management_test.go
@@ -566,7 +566,6 @@ func TestManagement_GetContract(t *testing.T) {
 	t.Run("by ID, positive", func(t *testing.T) {
 		managementInvoker.Invoke(t, si, "getContractById", cs1.ID)
 	})
-	/* C# compatibility
 	t.Run("by ID, native", func(t *testing.T) {
 		csm := managementInvoker.Executor.Chain.GetContractState(managementInvoker.Hash)
 		require.NotNil(t, csm)
@@ -574,7 +573,6 @@ func TestManagement_GetContract(t *testing.T) {
 		require.NoError(t, err)
 		managementInvoker.Invoke(t, sim, "getContractById", -1)
 	})
-	*/
 	t.Run("by ID, empty", func(t *testing.T) {
 		managementInvoker.Invoke(t, stackitem.Null{}, "getContractById", -100)
 	})

--- a/pkg/services/rpcsrv/client_test.go
+++ b/pkg/services/rpcsrv/client_test.go
@@ -261,11 +261,10 @@ func TestClientManagementContract(t *testing.T) {
 	cs2, err := c.GetContractStateByHash(gas.Hash)
 	require.NoError(t, err)
 	require.Equal(t, cs2, cs1)
-	/* C# compat
 	cs1, err = manReader.GetContractByID(-6)
 	require.NoError(t, err)
 	require.Equal(t, cs2, cs1)
-	*/
+
 	ret, err := manReader.HasMethod(gas.Hash, "transfer", 4)
 	require.NoError(t, err)
 	require.True(t, ret)

--- a/pkg/services/rpcsrv/server_test.go
+++ b/pkg/services/rpcsrv/server_test.go
@@ -83,7 +83,7 @@ const (
 	faultedTxHashLE                   = "82279bfe9bada282ca0f8cb8e0bb124b921af36f00c69a518320322c6f4fef60"
 	faultedTxBlock             uint32 = 23
 	invokescriptContractAVM           = "VwIADBQBDAMOBQYMDQIODw0DDgcJAAAAAErZMCQE2zBwaEH4J+yMqiYEEUAMFA0PAwIJAAIBAwcDBAUCAQAOBgwJStkwJATbMHFpQfgn7IyqJgQSQBNA"
-	block20StateRootLE                = "a2841baec40c6b752ba959c2b2cfee20b6beeabb85460224929bc9ff358bf8d2"
+	block20StateRootLE                = "ae445869283f8d7e0debc3f455014c73cde21b9802db99e80248da9f393bce14"
 )
 
 var (


### PR DESCRIPTION
This reverts commit 236e633ee488889a63f59ac9649cbfc10e4783d3.

Close #2859.