### PR TITLE
*: adjust Prometheus metrics initialisation on node start

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -503,6 +503,10 @@ func (bc *Blockchain) init() error {
 		}
 	}
 
+	updateBlockHeightMetric(bHeight)
+	updatePersistedHeightMetric(bHeight)
+	updateHeaderHeightMetric(bc.HeaderHeight())
+
 	return bc.updateExtensibleWhitelist(bHeight)
 }
 
@@ -632,6 +636,8 @@ func (bc *Blockchain) resetRAMState(height uint32, resetHeaders bool) error {
 	}
 
 	updateBlockHeightMetric(height)
+	updatePersistedHeightMetric(height)
+	updateHeaderHeightMetric(bc.HeaderHeight())
 	return nil
 }
 

--- a/pkg/core/stateroot/module.go
+++ b/pkg/core/stateroot/module.go
@@ -152,7 +152,9 @@ func (s *Module) CurrentValidatedHeight() uint32 {
 func (s *Module) Init(height uint32) error {
 	data, err := s.Store.Get([]byte{byte(storage.DataMPTAux), prefixValidated})
 	if err == nil {
-		s.validatedHeight.Store(binary.LittleEndian.Uint32(data))
+		h := binary.LittleEndian.Uint32(data)
+		s.validatedHeight.Store(h)
+		updateStateHeightMetric(h)
 	}
 
 	if height == 0 {


### PR DESCRIPTION
Initialize Prometheus metrics on node start where appropriate and review the usage of the following metrics:
```
anna@kiwi:~/Documents/GitProjects/nspcc-dev/neo-go$ find | grep prometheus.go
./pkg/network/prometheus.go
./pkg/core/stateroot/prometheus.go
./pkg/core/prometheus.go
./pkg/services/rpcsrv/prometheus.go
./pkg/services/metrics/prometheus.go
```

Close #2970.