### PR TITLE
core: add nolint comment for deprecated error format style

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2569,7 +2569,7 @@ func (bc *Blockchain) verifyTxAttributes(d *dao.Simple, tx *transaction.Transact
 			if isPartialTx {
 				maxNVBDelta, err := bc.GetMaxNotValidBeforeDelta()
 				if err != nil {
-					return fmt.Errorf("%w: failed to retrieve MaxNotValidBeforeDelta value from native Notary contract: %v", ErrInvalidAttribute, err)
+					return fmt.Errorf("%w: failed to retrieve MaxNotValidBeforeDelta value from native Notary contract: %v", ErrInvalidAttribute, err) //nolint:errorlint // errorlint: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
 				}
 				if curHeight+maxNVBDelta < nvb {
 					return fmt.Errorf("%w: NotValidBefore (%d) bigger than MaxNVBDelta (%d) allows at height %d", ErrInvalidAttribute, nvb, maxNVBDelta, curHeight)


### PR DESCRIPTION
Should be a part of 67d4d891ef847a8979fce36a37073ff4d74316b6.