### PR TITLE
github: use minimum supported go version for Linter job

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.18'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
It should be this way because we can't provide some features golangci-lint require us to do due to the need to support not only the latest Go version, but also two versions below.