### PR TITLE
rpcclient: provide some exported error for disconnected WSClient

### DIFF
--- a/pkg/rpcclient/wsclient_test.go
+++ b/pkg/rpcclient/wsclient_test.go
@@ -3,6 +3,7 @@ package rpcclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -752,7 +753,7 @@ func TestWS_RequestAfterClose(t *testing.T) {
 		_, err = c.GetBlockCount()
 	})
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "connection lost before registering response channel"))
+	require.True(t, errors.Is(err, ErrWSConnLost))
 }
 
 func TestWSClient_ConnClosedError(t *testing.T) {


### PR DESCRIPTION
Regular Client doesn't care much about connections, because HTTP client's Do method can reuse old ones or create additional ones on the fly. So one request can fail and the next one easily succeed. WSClient is different, it works via a single connection and if it breaks, it breaks forever for this client. Callers will get some error on every request afterwards and it'd be nice for this error to be the same so that API users could detect disconnection this way too.

Related to nspcc-dev/neofs-node#2325.