### PR TITLE
network: add `neogo_version` metric, deprecate `serv_node_version`

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -129,4 +129,13 @@ Removal of Peer unmarshalling with string based ports is scheduled for ~Septembe
 We check struct items count before convert LastGasPerVote to let RPC client be compatible with
 old versions.
 
-Removal of this compatiblility code is scheduled for Sep-Oct 2023. 
+Removal of this compatiblility code is scheduled for Sep-Oct 2023.
+
+## `serv_node_version` Prometheus gauge metric
+
+This metric is replaced by the new `neogo_version` and `server_id` Prometheus gauge
+metrics with proper version formatting. `neogo_version` contains NeoGo version
+hidden under `version` label and `server_id` contains network server ID hidden
+under `server_id` label.
+
+Removal of `serv_node_version` is scheduled for Sep-Oct 2023 (~0.105.0 release).

--- a/pkg/network/prometheus.go
+++ b/pkg/network/prometheus.go
@@ -25,6 +25,7 @@ var (
 		},
 	)
 
+	// Deprecated: please, use neogoVersion and serverID instead.
 	servAndNodeVersion = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Help:      "Server and Node versions",
@@ -33,6 +34,22 @@ var (
 		},
 		[]string{"description", "value"},
 	)
+
+	neogoVersion = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Help:      "NeoGo version",
+			Name:      "version",
+			Namespace: "neogo",
+		},
+		[]string{"version"})
+
+	serverID = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Help:      "network server ID",
+			Name:      "server_id",
+			Namespace: "neogo",
+		},
+		[]string{"server_id"})
 
 	poolCount = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -66,6 +83,8 @@ func init() {
 		estimatedNetworkSize,
 		peersConnected,
 		servAndNodeVersion,
+		neogoVersion,
+		serverID,
 		poolCount,
 		blockQueueLength,
 		notarypoolUnsortedTx,
@@ -102,10 +121,21 @@ func updatePoolCountMetric(pCount int) {
 func updatePeersConnectedMetric(pConnected int) {
 	peersConnected.Set(float64(pConnected))
 }
+
+// Deprecated: please, use setNeoGoVersion and setSeverID instead.
 func setServerAndNodeVersions(nodeVer string, serverID string) {
 	servAndNodeVersion.WithLabelValues("Node version: ", nodeVer).Add(0)
 	servAndNodeVersion.WithLabelValues("Server id: ", serverID).Add(0)
 }
+
+func setNeoGoVersion(nodeVer string) {
+	neogoVersion.WithLabelValues(nodeVer).Add(1)
+}
+
+func setSeverID(id string) {
+	serverID.WithLabelValues(id).Add(1)
+}
+
 func addCmdTimeMetric(cmd CommandType, t time.Duration) {
 	// Shouldn't happen, message decoder checks the type, but better safe than sorry.
 	if p2pCmds[cmd] == nil {

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -285,6 +285,8 @@ func (s *Server) Start() {
 		go tr.Accept()
 	}
 	setServerAndNodeVersions(s.UserAgent, strconv.FormatUint(uint64(s.id), 10))
+	setNeoGoVersion(config.Version)
+	setSeverID(strconv.FormatUint(uint64(s.id), 10))
 	s.run()
 }
 


### PR DESCRIPTION
Close #2999.