### PR TITLE
github: automatically attach binaries to the release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,12 @@ jobs:
           path: ./bin/neo-go*
           if-no-files-found: error
 
+      - name: Attach binary to the release as an asset
+        if: ${{ github.event_name == 'release' }}
+        run: gh release upload ${{ github.event.release.tag_name }} ./bin/neo-go-${{ matrix.os.bin-name }}-${{ matrix.arch }}${{ (matrix.os.bin-name == 'windows' && '.exe') || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build_image:
     needs: build_cli
     name: Build and push docker image


### PR DESCRIPTION
Close #3001.

Here's the workflow example: https://github.com/AnnaShaleva/neo-go/actions/runs/4939304132/jobs/8829920604
Here's the release example with binaries attached: https://github.com/AnnaShaleva/neo-go/releases/tag/v0.104.0
