### PR TITLE
*: drop legacy addresses from examples

### DIFF
--- a/cli/cmdargs/parser.go
+++ b/cli/cmdargs/parser.go
@@ -84,8 +84,8 @@ const (
     * 'dead' is a byte array with a value of 'dead'
     * 'string:dead' is a string with a value of 'dead'
     * 'filebytes:my_data.txt' is bytes decoded from a content of my_data.txt
-    * 'AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y' is a hash160 with a value
-      of '23ba2703c53263e8d6e522dc32203339dcd8eee9'
+    * 'NSiVJYZej4XsxG5CUpdwn7VRQk8iiiDMPM' is a hash160 with a value
+      of '682cca3ebdc66210e5847d7f8115846586079d4a'
     * '\4\2' is an integer with a value of 42
     * '\\4\2' is a string with a value of '\42'
     * 'string:string' is a string with a value of 'string'

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -411,11 +411,11 @@ see `contract` command help for more details. They all work via RPC, so it's a
 mandatory parameter.
 
 Example call (contract `f84d6a337fbc3d3a201d41da99e86b479e7a2554` with method
-`balanceOf` and method's parameter `AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y` using
+`balanceOf` and method's parameter `NVTiAjNgagDkTr5HTzDmQP9kPwPHN5BgVq` using
 given RPC server and wallet and paying 0.00001 extra GAS for this transaction):
 
 ```
-$ ./bin/neo-go contract invokefunction -r http://localhost:20331 -w my_wallet.json -g 0.00001 f84d6a337fbc3d3a201d41da99e86b479e7a2554 balanceOf AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y
+$ ./bin/neo-go contract invokefunction -r http://localhost:20331 -w my_wallet.json -g 0.00001 f84d6a337fbc3d3a201d41da99e86b479e7a2554 balanceOf NVTiAjNgagDkTr5HTzDmQP9kPwPHN5BgVq
 ```
 
 ### Generating contract bindings


### PR DESCRIPTION
They can't even be used now because they'll fail the conversion.
