### PR TITLE
rpcbinding: convert `scriptFor*` from function to method

### DIFF
--- a/cli/smartcontract/testdata/nameservice/nns.go
+++ b/cli/smartcontract/testdata/nameservice/nns.go
@@ -194,7 +194,7 @@ func (c *Contract) SetPriceUnsigned(priceList []any) (*transaction.Transaction, 
 	return c.actor.MakeUnsignedCall(c.hash, "setPrice", nil, priceList)
 }
 
-func scriptForRegister(name string, owner util.Uint160) ([]byte, error) {
+func (c *Contract) scriptForRegister(name string, owner util.Uint160) ([]byte, error) {
 	return smartcontract.CreateCallWithAssertScript(c.hash, "register", name, owner)
 }
 

--- a/cli/smartcontract/testdata/verifyrpc/verify.go
+++ b/cli/smartcontract/testdata/verifyrpc/verify.go
@@ -41,7 +41,7 @@ func New(actor Actor) *Contract {
 	return &Contract{actor, hash}
 }
 
-func scriptForVerify() ([]byte, error) {
+func (c *Contract) scriptForVerify() ([]byte, error) {
 	return smartcontract.CreateCallWithAssertScript(c.hash, "verify")
 }
 

--- a/pkg/smartcontract/rpcbinding/binding.go
+++ b/pkg/smartcontract/rpcbinding/binding.go
@@ -58,7 +58,7 @@ func (c *ContractReader) {{.Name}}Expanded({{range $index, $arg := .Arguments}}{
 }
 {{ end }}{{ end }}`
 	methodDefinition = `{{ define "METHOD" }}{{ if eq .ReturnType "bool"}}
-func scriptFor{{.Name}}({{range $index, $arg := .Arguments -}}
+func (c *Contract) scriptFor{{.Name}}({{range $index, $arg := .Arguments -}}
 	{{- if ne $index 0}}, {{end}}
 		{{- .Name}} {{.Type}}
 	{{- end}}) ([]byte, error) {


### PR DESCRIPTION
Should be a part of #3012, otherwise generated bindings are failed to be compiled.