### PR TITLE
rpcbinding: call `scriptFor*` as method

### DIFF
--- a/cli/smartcontract/testdata/nameservice/nns.go
+++ b/cli/smartcontract/testdata/nameservice/nns.go
@@ -202,7 +202,7 @@ func (c *Contract) scriptForRegister(name string, owner util.Uint160) ([]byte, e
 // This transaction is signed and immediately sent to the network.
 // The values returned are its hash, ValidUntilBlock value and error if any.
 func (c *Contract) Register(name string, owner util.Uint160) (util.Uint256, uint32, error) {
-	script, err := scriptForRegister(name, owner)
+	script, err := c.scriptForRegister(name, owner)
 	if err != nil {
 		return util.Uint256{}, 0, err
 	}
@@ -213,7 +213,7 @@ func (c *Contract) Register(name string, owner util.Uint160) (util.Uint256, uint
 // This transaction is signed, but not sent to the network, instead it's
 // returned to the caller.
 func (c *Contract) RegisterTransaction(name string, owner util.Uint160) (*transaction.Transaction, error) {
-	script, err := scriptForRegister(name, owner)
+	script, err := c.scriptForRegister(name, owner)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (c *Contract) RegisterTransaction(name string, owner util.Uint160) (*transa
 // Any fields of it that do not affect fees can be changed (ValidUntilBlock,
 // Nonce), fee values (NetworkFee, SystemFee) can be increased as well.
 func (c *Contract) RegisterUnsigned(name string, owner util.Uint160) (*transaction.Transaction, error) {
-	script, err := scriptForRegister(name, owner)
+	script, err := c.scriptForRegister(name, owner)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/smartcontract/testdata/verifyrpc/verify.go
+++ b/cli/smartcontract/testdata/verifyrpc/verify.go
@@ -49,7 +49,7 @@ func (c *Contract) scriptForVerify() ([]byte, error) {
 // This transaction is signed and immediately sent to the network.
 // The values returned are its hash, ValidUntilBlock value and error if any.
 func (c *Contract) Verify() (util.Uint256, uint32, error) {
-	script, err := scriptForVerify()
+	script, err := c.scriptForVerify()
 	if err != nil {
 		return util.Uint256{}, 0, err
 	}
@@ -60,7 +60,7 @@ func (c *Contract) Verify() (util.Uint256, uint32, error) {
 // This transaction is signed, but not sent to the network, instead it's
 // returned to the caller.
 func (c *Contract) VerifyTransaction() (*transaction.Transaction, error) {
-	script, err := scriptForVerify()
+	script, err := c.scriptForVerify()
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (c *Contract) VerifyTransaction() (*transaction.Transaction, error) {
 // Any fields of it that do not affect fees can be changed (ValidUntilBlock,
 // Nonce), fee values (NetworkFee, SystemFee) can be increased as well.
 func (c *Contract) VerifyUnsigned() (*transaction.Transaction, error) {
-	script, err := scriptForVerify()
+	script, err := c.scriptForVerify()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/smartcontract/rpcbinding/binding.go
+++ b/pkg/smartcontract/rpcbinding/binding.go
@@ -73,7 +73,7 @@ func (c *Contract) {{.Name}}({{range $index, $arg := .Arguments -}}
 		{{- .Name}} {{.Type}}
 	{{- end}}) (util.Uint256, uint32, error) {
 	{{if ne .ReturnType "bool"}}return c.actor.SendCall(c.hash, "{{ .NameABI }}"
-	{{- range $index, $arg := .Arguments -}}, {{.Name}}{{end}}){{else}}script, err := scriptFor{{.Name}}({{- range $index, $arg := .Arguments -}}{{- if ne $index 0}}, {{end}}{{.Name}}{{end}})
+	{{- range $index, $arg := .Arguments -}}, {{.Name}}{{end}}){{else}}script, err := c.scriptFor{{.Name}}({{- range $index, $arg := .Arguments -}}{{- if ne $index 0}}, {{end}}{{.Name}}{{end}})
 	if err != nil {
 		return util.Uint256{}, 0, err
 	}
@@ -88,7 +88,7 @@ func (c *Contract) {{.Name}}Transaction({{range $index, $arg := .Arguments -}}
 		{{- .Name}} {{.Type}}
 	{{- end}}) (*transaction.Transaction, error) {
 	{{if ne .ReturnType "bool"}}return c.actor.MakeCall(c.hash, "{{ .NameABI }}"
-	{{- range $index, $arg := .Arguments -}}, {{.Name}}{{end}}){{else}}script, err := scriptFor{{.Name}}({{- range $index, $arg := .Arguments -}}{{- if ne $index 0}}, {{end}}{{.Name}}{{end}})
+	{{- range $index, $arg := .Arguments -}}, {{.Name}}{{end}}){{else}}script, err := c.scriptFor{{.Name}}({{- range $index, $arg := .Arguments -}}{{- if ne $index 0}}, {{end}}{{.Name}}{{end}})
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (c *Contract) {{.Name}}Unsigned({{range $index, $arg := .Arguments -}}
 		{{- .Name}} {{.Type}}
 	{{- end}}) (*transaction.Transaction, error) {
 	{{if ne .ReturnType "bool"}}return c.actor.MakeUnsignedCall(c.hash, "{{ .NameABI }}", nil
-	{{- range $index, $arg := .Arguments -}}, {{.Name}}{{end}}){{else}}script, err := scriptFor{{.Name}}({{- range $index, $arg := .Arguments -}}{{- if ne $index 0}}, {{end}}{{.Name}}{{end}})
+	{{- range $index, $arg := .Arguments -}}, {{.Name}}{{end}}){{else}}script, err := c.scriptFor{{.Name}}({{- range $index, $arg := .Arguments -}}{{- if ne $index 0}}, {{end}}{{.Name}}{{end}})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Should be a part of #3035, otherwise generated bindings are failed to be compiled.