### PR TITLE
compiler: temporary disallow generics usages

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -31,6 +31,8 @@ a dialect of Go rather than a complete port of the language:
  * type assertion with two return values is not supported; single return value (of the desired type)
    is supported; type assertion panics if value can't be asserted to the desired type, therefore
    it's up to the programmer whether assert can be performed successfully.
+ * type aliases including the built-in `any` alias are supported.
+ * generics are not supported, but eventually will be (at least, partially), ref. https://github.com/nspcc-dev/neo-go/issues/2376.
 
 ## VM API (interop layer)
 Compiler translates interop function calls into Neo VM syscalls or (for custom

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -563,6 +563,11 @@ func (c *codegen) checkGenericsFuncDecl(n *ast.FuncDecl, funcName string) error 
 		}
 	}
 
+	// Generic function parameters type: func SumInts[V int64 | int32](vals []V) V
+	if n.Type.TypeParams != nil {
+		errGenerics = errors.New("function type parameters")
+	}
+
 	if errGenerics != nil {
 		return fmt.Errorf("%w: %s has %s", ErrGenericsUnsuppored, funcName, errGenerics.Error())
 	}

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -566,6 +566,13 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 	//     x = 2
 	// )
 	case *ast.GenDecl:
+		// Filter out generics usage.
+		err := c.checkGenericsGenDecl(n, c.currPkg.PkgPath)
+		if err != nil {
+			c.prog.Err = err
+			return nil // Program is invalid.
+		}
+
 		if n.Tok == token.VAR || n.Tok == token.CONST {
 			c.saveSequencePoint(n)
 		}

--- a/pkg/compiler/generics_test.go
+++ b/pkg/compiler/generics_test.go
@@ -36,3 +36,18 @@ func TestGenericMethodReceiver(t *testing.T) {
 		require.ErrorIs(t, err, compiler.ErrGenericsUnsuppored)
 	})
 }
+
+func TestGenericFuncArgument(t *testing.T) {
+	src := `
+		package sum
+		func SumInts[V int64 | int32 | int16](vals []V) V { // doesn't make sense with NeoVM, but still it's a valid go code.
+			var s V
+			for i := range vals {
+				s += vals[i]
+			}
+			return s
+		}
+`
+	_, _, err := compiler.CompileWithOptions("foo.go", strings.NewReader(src), nil)
+	require.ErrorIs(t, err, compiler.ErrGenericsUnsuppored)
+}

--- a/pkg/compiler/generics_test.go
+++ b/pkg/compiler/generics_test.go
@@ -51,3 +51,41 @@ func TestGenericFuncArgument(t *testing.T) {
 	_, _, err := compiler.CompileWithOptions("foo.go", strings.NewReader(src), nil)
 	require.ErrorIs(t, err, compiler.ErrGenericsUnsuppored)
 }
+
+func TestGenericTypeDecl(t *testing.T) {
+	t.Run("global scope", func(t *testing.T) {
+		src := `
+		package sum
+		type List[T any] struct {
+			next *List[T]
+			val  T
+		}
+
+		func Main() any {
+			l := List[int]{}
+			return l
+		}
+`
+		_, _, err := compiler.CompileWithOptions("foo.go", strings.NewReader(src), nil)
+		require.ErrorIs(t, err, compiler.ErrGenericsUnsuppored)
+	})
+	t.Run("local scope", func(t *testing.T) {
+		src := `
+		package sum
+		func Main() any {
+			type (
+				SomeGoodType int
+			
+				List[T any] struct {
+					next *List[T]
+					val  T
+				}
+			)
+			l := List[int]{}
+			return l
+		}
+`
+		_, _, err := compiler.CompileWithOptions("foo.go", strings.NewReader(src), nil)
+		require.ErrorIs(t, err, compiler.ErrGenericsUnsuppored)
+	})
+}

--- a/pkg/compiler/generics_test.go
+++ b/pkg/compiler/generics_test.go
@@ -1,0 +1,38 @@
+package compiler_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/compiler"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenericMethodReceiver(t *testing.T) {
+	t.Run("star expression", func(t *testing.T) {
+		src := `
+		package receiver
+		type Pointer[T any] struct {
+			value T
+		}
+		func (x *Pointer[T]) Load() *T {
+			return &x.value
+		}
+`
+		_, _, err := compiler.CompileWithOptions("foo.go", strings.NewReader(src), nil)
+		require.ErrorIs(t, err, compiler.ErrGenericsUnsuppored)
+	})
+	t.Run("ident expression", func(t *testing.T) {
+		src := `
+		package receiver
+		type Pointer[T any] struct {
+			value T
+		}
+		func (x Pointer[T]) Load() *T {
+			return &x.value
+		}
+`
+		_, _, err := compiler.CompileWithOptions("foo.go", strings.NewReader(src), nil)
+		require.ErrorIs(t, err, compiler.ErrGenericsUnsuppored)
+	})
+}


### PR DESCRIPTION
This PR includes the following changes:

1. Properly retrieve name of generic functions (fix panic described in #3040).
2. Disallow generics usages in the following cases:
    * Generic method receiver
    * Generic function parameters
    * Generic type declaration

Close #3040. Ref. #2377.