### PR TITLE
core: remove contract script check on deploy/update

### DIFF
--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -23,8 +23,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/nef"
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/nspcc-dev/neo-go/pkg/util/bitfield"
-	"github.com/nspcc-dev/neo-go/pkg/vm"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
@@ -717,12 +715,10 @@ func (m *Management) emitNotification(ic *interop.Context, name string, hash uti
 
 func checkScriptAndMethods(script []byte, methods []manifest.Method) error {
 	l := len(script)
-	offsets := bitfield.New(l)
 	for i := range methods {
 		if methods[i].Offset >= l {
 			return fmt.Errorf("method %s/%d: offset is out of the script range", methods[i].Name, len(methods[i].Parameters))
 		}
-		offsets.Set(methods[i].Offset)
 	}
-	return vm.IsScriptCorrect(script, offsets)
+	return nil
 }

--- a/pkg/core/native/native_test/management_test.go
+++ b/pkg/core/native/native_test/management_test.go
@@ -143,17 +143,6 @@ func TestManagement_ContractDeploy(t *testing.T) {
 
 		managementInvoker.InvokeFail(t, "method add/2: offset is out of the script range", "deploy", nefBytes, manifB)
 	})
-	t.Run("bad methods in manifest 2", func(t *testing.T) {
-		var badManifest = cs1.Manifest
-		badManifest.ABI.Methods = make([]manifest.Method, len(cs1.Manifest.ABI.Methods))
-		copy(badManifest.ABI.Methods, cs1.Manifest.ABI.Methods)
-		badManifest.ABI.Methods[0].Offset = len(cs1.NEF.Script) - 2 // Ends with `CALLT(X,X);RET`.
-
-		manifB, err := json.Marshal(badManifest)
-		require.NoError(t, err)
-
-		managementInvoker.InvokeFail(t, "some methods point to wrong offsets (not to instruction boundary)", "deploy", nefBytes, manifB)
-	})
 	t.Run("duplicated methods in manifest 1", func(t *testing.T) {
 		badManifest := cs1.Manifest
 		badManifest.ABI.Methods = make([]manifest.Method, len(cs1.Manifest.ABI.Methods))


### PR DESCRIPTION
This check is good and was present here since #1729, but it was accidently removed from the reference implementation (see the discussion in https://github.com/neo-project/neo/issues/2848). The removal of this check from the C# node leaded to the T5 testnet state diff since 1670095 heigh which causes inability to process new blocks since 2272533 height (see #3049). This check was added back to the C# node in https://github.com/neo-project/neo/pull/2849, but it is planned to be the part of the upcoming 3.6.0 C# node release.

We need to keep our testnet healthy, thus, strict contract script check will be temporary removed from the node code and is planned to be added back to be a part of the next 3.6.0-compatible release.

Close #3049.