### PR TITLE
Release 0.101.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 This document outlines major changes between releases.
 
+## 0.101.3 "Yuckiness" (08 Jul 2023)
+
+Yet another 3.5.0-compatible emergency version that removes scrupulous
+instructions check of smart contract's script on contract deployment or update.
+Presence of this check leads to the known T5 testnet state incompatibility
+(since 1670095) which causes inability to process new blocks (since 2272533).
+It should be noted that the corresponding check was accidentally removed from
+the reference C# node implementation way back in neo-project/neo#2266 and added
+again in neo-project/neo#2849 which is planned to be a part of the upcoming
+3.6.0 C# node release. Thus, changes made in the presented 0.101.3 release will
+be reverted afterwards and strict contract script check will be present in the
+next 3.6.0-compatible version of NeoGo node.
+
+T5 testnet chain requires a complete resynchronization for this version. Mainnet
+chain resynchronization is recommended.
+
+Bugs fixed:
+
+ * extra strict contract script check on contract deployment or update is
+   removed (#3052)
+
 ## 0.101.2 "Excavation" (29 Jun 2023)
 
 One more (and unexpected one!) 3.5.0-compatible version that fixes a VM bug

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -23,8 +23,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/nef"
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/nspcc-dev/neo-go/pkg/util/bitfield"
-	"github.com/nspcc-dev/neo-go/pkg/vm"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
@@ -719,12 +717,10 @@ func (m *Management) emitNotification(ic *interop.Context, name string, hash uti
 
 func checkScriptAndMethods(script []byte, methods []manifest.Method) error {
 	l := len(script)
-	offsets := bitfield.New(l)
 	for i := range methods {
 		if methods[i].Offset >= l {
 			return fmt.Errorf("method %s/%d: offset is out of the script range", methods[i].Name, len(methods[i].Parameters))
 		}
-		offsets.Set(methods[i].Offset)
 	}
-	return vm.IsScriptCorrect(script, offsets)
+	return nil
 }

--- a/pkg/core/native/native_test/management_test.go
+++ b/pkg/core/native/native_test/management_test.go
@@ -143,17 +143,6 @@ func TestManagement_ContractDeploy(t *testing.T) {
 
 		managementInvoker.InvokeFail(t, "method add/2: offset is out of the script range", "deploy", nefBytes, manifB)
 	})
-	t.Run("bad methods in manifest 2", func(t *testing.T) {
-		var badManifest = cs1.Manifest
-		badManifest.ABI.Methods = make([]manifest.Method, len(cs1.Manifest.ABI.Methods))
-		copy(badManifest.ABI.Methods, cs1.Manifest.ABI.Methods)
-		badManifest.ABI.Methods[0].Offset = len(cs1.NEF.Script) - 2 // Ends with `CALLT(X,X);RET`.
-
-		manifB, err := json.Marshal(badManifest)
-		require.NoError(t, err)
-
-		managementInvoker.InvokeFail(t, "some methods point to wrong offsets (not to instruction boundary)", "deploy", nefBytes, manifB)
-	})
 	t.Run("duplicated methods in manifest 1", func(t *testing.T) {
 		badManifest := cs1.Manifest
 		badManifest.ABI.Methods = make([]manifest.Method, len(cs1.Manifest.ABI.Methods))


### PR DESCRIPTION
Depends on #3052.

The release plan is the following:
1. Merge #3052, update `rel-0.101.3` branch which is based on v0.101.2 + two commits.
2. Merge `rel-0.101.3` into master.
3. Create `v0.101.3` tag pointing to CHANGELOG update for 0.101.3 (00e076b2993cca149ccb61daa35c71bbbdafc11d).
4. Release accoarding to the release notes.