### PR TITLE
neorpc: adjust `SignerWithWitness` marshalling scheme

### DIFF
--- a/pkg/core/transaction/witness_scope.go
+++ b/pkg/core/transaction/witness_scope.go
@@ -3,6 +3,7 @@ package transaction
 //go:generate stringer -type=WitnessScope -linecomment -output=witness_scope_string.go
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -28,6 +29,19 @@ const (
 	// This cannot be combined with other flags.
 	Global WitnessScope = 0x80
 )
+
+// ScopesFromByte converts byte to a set of WitnessScopes and performs validity
+// check.
+func ScopesFromByte(b byte) (WitnessScope, error) {
+	var res = WitnessScope(b)
+	if (res&Global != 0) && (res&(None|CalledByEntry|CustomContracts|CustomGroups|Rules) != 0) {
+		return 0, errors.New("Global scope can not be combined with other scopes")
+	}
+	if res&^(None|CalledByEntry|CustomContracts|CustomGroups|Rules|Global) != 0 {
+		return 0, fmt.Errorf("invalid scope %d", res)
+	}
+	return res, nil
+}
 
 // ScopesFromString converts string of comma-separated scopes to a set of scopes
 // (case-sensitive). String can combine several scopes, e.g. be any of: 'Global',

--- a/pkg/core/transaction/witness_scope.go
+++ b/pkg/core/transaction/witness_scope.go
@@ -68,7 +68,7 @@ func ScopesFromString(s string) (WitnessScope, error) {
 			return result, fmt.Errorf("invalid witness scope: %v", scopeStr)
 		}
 		if isGlobal && !(scope == Global) {
-			return result, fmt.Errorf("Global scope can not be combined with other scopes")
+			return result, errors.New("Global scope can not be combined with other scopes")
 		}
 		result |= scope
 		if scope == Global {

--- a/pkg/core/transaction/witness_scope_test.go
+++ b/pkg/core/transaction/witness_scope_test.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,4 +51,65 @@ func TestScopesFromString(t *testing.T) {
 	s, err = ScopesFromString("CalledByEntry, CustomGroups, CustomContracts")
 	require.NoError(t, err)
 	require.Equal(t, CalledByEntry|CustomGroups|CustomContracts, s)
+}
+
+func TestScopesFromByte(t *testing.T) {
+	testCases := []struct {
+		in         byte
+		expected   WitnessScope
+		shouldFail bool
+	}{
+		{
+			in:       0,
+			expected: None,
+		},
+		{
+			in:       1,
+			expected: CalledByEntry,
+		},
+		{
+			in:       16,
+			expected: CustomContracts,
+		},
+		{
+			in:       32,
+			expected: CustomGroups,
+		},
+		{
+			in:       64,
+			expected: Rules,
+		},
+		{
+			in:       128,
+			expected: Global,
+		},
+		{
+			in:       17,
+			expected: CalledByEntry | CustomContracts,
+		},
+		{
+			in:       48,
+			expected: CustomContracts | CustomGroups,
+		},
+		{
+			in:         128 + 1, // Global can't be combined with others.
+			shouldFail: true,
+		},
+		{
+			in:         2, // No such scope.
+			shouldFail: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(strconv.Itoa(int(tc.in)), func(t *testing.T) {
+			actual, err := ScopesFromByte(tc.in)
+			if tc.shouldFail {
+				require.Error(t, err, tc.in)
+			} else {
+				require.NoError(t, err, tc.in)
+				require.Equal(t, tc.expected, actual, tc.in)
+			}
+		})
+	}
 }

--- a/pkg/neorpc/types.go
+++ b/pkg/neorpc/types.go
@@ -97,7 +97,7 @@ func (s *SignerWithWitness) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal scopes: %w", err)
 	}
 	signer := &signerWithWitnessAux{
-		Account:            s.Account.StringLE(),
+		Account:            `0x` + s.Account.StringLE(),
 		Scopes:             sc,
 		AllowedContracts:   s.AllowedContracts,
 		AllowedGroups:      s.AllowedGroups,

--- a/pkg/neorpc/types.go
+++ b/pkg/neorpc/types.go
@@ -82,7 +82,7 @@ type (
 // DisallowUnknownFields JSON marshaller setting.
 type signerWithWitnessAux struct {
 	Account            string                    `json:"account"`
-	Scopes             transaction.WitnessScope  `json:"scopes"`
+	Scopes             json.RawMessage           `json:"scopes"`
 	AllowedContracts   []util.Uint160            `json:"allowedcontracts,omitempty"`
 	AllowedGroups      []*keys.PublicKey         `json:"allowedgroups,omitempty"`
 	Rules              []transaction.WitnessRule `json:"rules,omitempty"`
@@ -92,9 +92,13 @@ type signerWithWitnessAux struct {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (s *SignerWithWitness) MarshalJSON() ([]byte, error) {
+	sc, err := s.Scopes.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal scopes: %w", err)
+	}
 	signer := &signerWithWitnessAux{
 		Account:            s.Account.StringLE(),
-		Scopes:             s.Scopes,
+		Scopes:             sc,
 		AllowedContracts:   s.AllowedContracts,
 		AllowedGroups:      s.AllowedGroups,
 		Rules:              s.Rules,
@@ -118,9 +122,31 @@ func (s *SignerWithWitness) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("not a signer: %w", err)
 	}
+	var (
+		jStr   string
+		jByte  byte
+		scopes transaction.WitnessScope
+	)
+	if len(aux.Scopes) != 0 {
+		if err := json.Unmarshal(aux.Scopes, &jStr); err == nil {
+			scopes, err = transaction.ScopesFromString(jStr)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve scopes from string: %w", err)
+			}
+		} else {
+			err := json.Unmarshal(aux.Scopes, &jByte)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal scopes from byte: %w", err)
+			}
+			scopes, err = transaction.ScopesFromByte(jByte)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve scopes from byte: %w", err)
+			}
+		}
+	}
 	s.Signer = transaction.Signer{
 		Account:          acc,
-		Scopes:           aux.Scopes,
+		Scopes:           scopes,
 		AllowedContracts: aux.AllowedContracts,
 		AllowedGroups:    aux.AllowedGroups,
 		Rules:            aux.Rules,

--- a/pkg/neorpc/types_test.go
+++ b/pkg/neorpc/types_test.go
@@ -1,0 +1,40 @@
+package neorpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/internal/testserdes"
+	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignerWithWitnessMarshalUnmarshalJSON(t *testing.T) {
+	s := &SignerWithWitness{
+		Signer: transaction.Signer{
+			Account:          util.Uint160{1, 2, 3},
+			Scopes:           transaction.CalledByEntry | transaction.CustomContracts,
+			AllowedContracts: []util.Uint160{{1, 2, 3, 4}},
+		},
+		Witness: transaction.Witness{
+			InvocationScript:   []byte{1, 2, 3},
+			VerificationScript: []byte{4, 5, 6},
+		},
+	}
+	testserdes.MarshalUnmarshalJSON(t, s, &SignerWithWitness{})
+
+	// Check marshalling separately to ensure Scopes are marshalled OK.
+	expected := `{"account":"0xcadb3dc2faa3ef14a13b619c9a43124755aa2569","scopes":"CalledByEntry, CustomContracts"}`
+	acc, err := util.Uint160DecodeStringLE("cadb3dc2faa3ef14a13b619c9a43124755aa2569")
+	require.NoError(t, err)
+	s = &SignerWithWitness{
+		Signer: transaction.Signer{
+			Account: acc,
+			Scopes:  transaction.CalledByEntry | transaction.CustomContracts,
+		},
+	}
+	actual, err := json.Marshal(s)
+	require.NoError(t, err)
+	require.Equal(t, expected, string(actual))
+}


### PR DESCRIPTION
Close #3059. C#'s rules for RPC-server signers unmarshalling are not as strict as for core signers. Not sure whether it's worth bug in C# node, because it's a valid behaviour. Let's fix it in our side.
