### PR TITLE
smartcontract: allow to pass nil as parameter to (*Invoker).Call

### DIFF
--- a/pkg/smartcontract/parameter.go
+++ b/pkg/smartcontract/parameter.go
@@ -360,6 +360,8 @@ func NewParameterFromValue(value any) (Parameter, error) {
 		}
 		result.Type = ArrayType
 		result.Value = arr
+	case nil:
+		result.Type = AnyType
 	default:
 		return result, fmt.Errorf("unsupported parameter %T", value)
 	}

--- a/pkg/smartcontract/parameter_test.go
+++ b/pkg/smartcontract/parameter_test.go
@@ -691,6 +691,11 @@ func TestParameterFromValue(t *testing.T) {
 			expVal:  pk2.PublicKey().Bytes(),
 		},
 		{
+			value:   nil,
+			expType: AnyType,
+			expVal:  nil,
+		},
+		{
 			value:   [][]byte{{1, 2, 3}, {3, 2, 1}},
 			expType: ArrayType,
 			expVal:  []Parameter{{ByteArrayType, []byte{1, 2, 3}}, {ByteArrayType, []byte{3, 2, 1}}},


### PR DESCRIPTION
### Problem

Error on passing `nil` as an argument to `(*Invoker).Call`

### Solution

Merge.
