### PR TITLE
rpcclient: adjust `unwrapContract` helper

### DIFF
--- a/pkg/rpcclient/management/management.go
+++ b/pkg/rpcclient/management/management.go
@@ -105,15 +105,22 @@ func (c *ContractReader) GetContract(hash util.Uint160) (*state.Contract, error)
 	return unwrapContract(c.invoker.Call(Hash, "getContract", hash))
 }
 
-// GetContractByID allows to get contract data from its ID.
+// GetContractByID allows to get contract data from its ID. In case of missing
+// contract it returns nil state.Contract and nil error.
 func (c *ContractReader) GetContractByID(id int32) (*state.Contract, error) {
 	return unwrapContract(c.invoker.Call(Hash, "getContractById", id))
 }
 
+// unwrapContract tries to retrieve state.Contract from the provided result.Invoke.
+// If the resulting stack contains stackitem.Null, then nil state and nil error
+// will be returned.
 func unwrapContract(r *result.Invoke, err error) (*state.Contract, error) {
 	itm, err := unwrap.Item(r, err)
 	if err != nil {
 		return nil, err
+	}
+	if itm.Equals(stackitem.Null{}) {
+		return nil, nil
 	}
 	res := new(state.Contract)
 	err = res.FromStackItem(itm)

--- a/pkg/rpcclient/management/management_test.go
+++ b/pkg/rpcclient/management/management_test.go
@@ -103,6 +103,17 @@ func TestReader(t *testing.T) {
 	ta.res = &result.Invoke{
 		State: "HALT",
 		Stack: []stackitem.Item{
+			stackitem.Null{},
+		},
+	}
+
+	cs, err := man.GetContract(util.Uint160{1, 2, 3})
+	require.NoError(t, err)
+	require.Nil(t, cs)
+
+	ta.res = &result.Invoke{
+		State: "HALT",
+		Stack: []stackitem.Item{
 			stackitem.Make([]stackitem.Item{}),
 		},
 	}
@@ -127,7 +138,7 @@ func TestReader(t *testing.T) {
 			}),
 		},
 	}
-	cs, err := man.GetContract(util.Uint160{1, 2, 3})
+	cs, err = man.GetContract(util.Uint160{1, 2, 3})
 	require.NoError(t, err)
 	require.Equal(t, int32(1), cs.ID)
 	require.Equal(t, uint16(0), cs.UpdateCounter)


### PR DESCRIPTION
There may be no such contract, then Null stackitem is expected on stack.