### PR TITLE
compiler: fix sequence point boundaries

### DIFF
--- a/pkg/compiler/debug.go
+++ b/pkg/compiler/debug.go
@@ -138,9 +138,9 @@ func (c *codegen) saveSequencePoint(n ast.Node) {
 		Opcode:    c.prog.Len(),
 		Document:  c.docIndex[start.Filename],
 		StartLine: start.Line,
-		StartCol:  start.Offset,
+		StartCol:  start.Column,
 		EndLine:   end.Line,
-		EndCol:    end.Offset,
+		EndCol:    end.Column,
 	})
 }
 


### PR DESCRIPTION
Thanks to @fyrchik, see the
https://github.com/neo-project/neo-devpack-dotnet/pull/154/files#diff-ebf53d00d5ba1f1197fedd2b8111fe9a8f44fb96699ef1314d54d05d5ceeb3f3R27

Not tested yet, need to take more careful look at it.