### PR TITLE
rpcsrv: carefully store Oracle service instance

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -359,7 +359,14 @@ func resetDB(ctx *cli.Context) error {
 	return nil
 }
 
-func mkOracle(config config.OracleConfiguration, magic netmode.Magic, chain *core.Blockchain, serv *network.Server, log *zap.Logger) (*oracle.Oracle, error) {
+// oracleService is an interface representing Oracle service with network.Service
+// capabilities and ability to submit oracle responses.
+type oracleService interface {
+	rpcsrv.OracleHandler
+	network.Service
+}
+
+func mkOracle(config config.OracleConfiguration, magic netmode.Magic, chain *core.Blockchain, serv *network.Server, log *zap.Logger) (oracleService, error) {
 	if !config.Enabled {
 		return nil, nil
 	}

--- a/cli/vm/cli_test.go
+++ b/cli/vm/cli_test.go
@@ -1094,7 +1094,7 @@ func TestRunWithHistoricState(t *testing.T) {
 	e.checkNextLine(t, "READY: loaded 36 instructions")
 	e.checkStack(t, []byte{1})
 	e.checkNextLine(t, "READY: loaded 36 instructions")
-	e.checkNextLineExact(t, "Error: at instruction 31 (SYSCALL): System.Contract.Call failed: called contract 73a23e915b66ae406866787f4a6c1c517dc981e2 not found: key not found\n")
+	e.checkNextLineExact(t, "Error: at instruction 31 (SYSCALL): System.Contract.Call failed: called contract 0f825b050eb8ce9eaa82993e90615025ab798016 not found: key not found\n")
 }
 
 func TestEvents(t *testing.T) {


### PR DESCRIPTION
### Problem

Invalid `submitoracleresponse` RPC handler behaviour in case of disabled Oracle service: no `neorpc.NewRPCError("Oracle is not enabled", "")` error is returned. Thanks to @tatiana-nspcc for the report.

### Solution

Check for typed nil value while setting Oracle service. I know, that we don't want to import the whole `oracle` package from the `rpcsrv`, but the alternatives I see looks worser to me:
  1. Check that Oracle service is a proper nil value each time when `rpcsrv.New(...)` is used. It's not very convinient; there are three places in the code and a couple more in tests.
  2. Use reflection inside `rpcsrv` to ensure that Oracle service is really nil. We'd better avoid reflection untill there are no other choices.