### PR TITLE
Implement `getrawnotaryrequest` and `getrawnotarytransaction` RPC extensions

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -284,7 +284,27 @@ state has all its values got from MPT with the specified stateroot. This allows
 to track the contract storage scheme using the specified past chain state. These
 methods may be useful for debugging purposes.
 
-#### `submitnotaryrequest` call
+#### P2PNotary extensions
+
+The following P2PNotary extensions can be used on P2P Notary enabled networks
+only.
+
+##### `getrawnotarypool` call
+
+`getrawnotarypool` method provides the ability to retrieve the content of the 
+RPC node's notary pool (a map from main transaction hashes to the corresponding
+fallback transaction hashes for currently processing P2PNotaryRequest payloads).
+You can use the `getrawnotarytransaction` method to iterate through
+the results of `getrawnotarypool`, retrieve main/fallback transactions,
+check their contents and act accordingly.
+
+##### `getrawnotarytransaction` call
+
+The `getrawnotarytransaction` method takes a transaction hash and aims to locate
+the corresponding transaction in the P2PNotaryRequest pool. It performs
+this search across all the verified main and fallback transactions.
+
+##### `submitnotaryrequest` call
 
 This method can be used on P2P Notary enabled networks to submit new notary
 payloads to be relayed from RPC to P2P.

--- a/pkg/core/mempool/mem_pool.go
+++ b/pkg/core/mempool/mem_pool.go
@@ -609,3 +609,19 @@ func (mp *Pool) removeConflictsOf(tx *transaction.Transaction) {
 		}
 	}
 }
+
+// IterateVerifiedTransactions iterates through verified transactions and invokes
+// function `cont`. Iterations continue while the function `cont` returns true.
+// Function `cont` is executed within a read-locked memory pool,
+// thus IterateVerifiedTransactions will block any write mempool operation,
+// use it with care. Do not modify transaction or data via `cont`.
+func (mp *Pool) IterateVerifiedTransactions(cont func(tx *transaction.Transaction, data any) bool) {
+	mp.lock.RLock()
+	defer mp.lock.RUnlock()
+
+	for i := range mp.verifiedTxes {
+		if !cont(mp.verifiedTxes[i].txn, mp.verifiedTxes[i].data) {
+			return
+		}
+	}
+}

--- a/pkg/neorpc/result/raw_notary_pool.go
+++ b/pkg/neorpc/result/raw_notary_pool.go
@@ -1,0 +1,48 @@
+package result
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+// RawNotaryPool represents a result of `getrawnotarypool` RPC call.
+// The structure consist of `Hashes`. `Hashes` field is a map, where key is
+// the hash of the main transaction and value is a slice of related fallback
+// transaction hashes.
+type RawNotaryPool struct {
+	Hashes map[util.Uint256][]util.Uint256
+}
+
+// rawNotaryPoolAux is an auxiliary struct for RawNotaryPool JSON marshalling.
+type rawNotaryPoolAux struct {
+	Hashes map[string][]util.Uint256 `json:"hashes,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (p RawNotaryPool) MarshalJSON() ([]byte, error) {
+	var aux rawNotaryPoolAux
+	aux.Hashes = make(map[string][]util.Uint256, len(p.Hashes))
+	for main, fallbacks := range p.Hashes {
+		aux.Hashes["0x"+main.StringLE()] = fallbacks
+	}
+	return json.Marshal(aux)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (p *RawNotaryPool) UnmarshalJSON(data []byte) error {
+	var aux rawNotaryPoolAux
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	p.Hashes = make(map[util.Uint256][]util.Uint256, len(aux.Hashes))
+	for main, fallbacks := range aux.Hashes {
+		hashMain, err := util.Uint256DecodeStringLE(strings.TrimPrefix(main, "0x"))
+		if err != nil {
+			return err
+		}
+		p.Hashes[hashMain] = fallbacks
+	}
+	return nil
+}

--- a/pkg/rpcclient/doc.go
+++ b/pkg/rpcclient/doc.go
@@ -96,6 +96,8 @@ Supported methods
 Extensions:
 
 	getblocksysfee
+	getrawnotarypool
+	getrawnotarytransaction
 	submitnotaryrequest
 
 Unsupported methods

--- a/pkg/rpcclient/rpc.go
+++ b/pkg/rpcclient/rpc.go
@@ -1285,3 +1285,44 @@ func (c *Client) TerminateSession(sessionID uuid.UUID) (bool, error) {
 
 	return resp, nil
 }
+
+// GetRawNotaryTransaction  returns main or fallback transaction from the
+// RPC node's notary request pool.
+func (c *Client) GetRawNotaryTransaction(hash util.Uint256) (*transaction.Transaction, error) {
+	var (
+		params = []any{hash.StringLE()}
+		resp   []byte
+		err    error
+	)
+	if err = c.performRequest("getrawnotarytransaction", params, &resp); err != nil {
+		return nil, err
+	}
+	return transaction.NewTransactionFromBytes(resp)
+}
+
+// GetRawNotaryTransactionVerbose returns main or fallback transaction from the
+// RPC node's notary request pool.
+// NOTE: to get transaction.ID and transaction.Size, use t.Hash() and
+// io.GetVarSize(t) respectively.
+func (c *Client) GetRawNotaryTransactionVerbose(hash util.Uint256) (*transaction.Transaction, error) {
+	var (
+		params = []any{hash.StringLE(), 1} // 1 for verbose.
+		resp   = &transaction.Transaction{}
+		err    error
+	)
+	if err = c.performRequest("getrawnotarytransaction", params, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// GetRawNotaryPool returns hashes of main P2PNotaryRequest transactions that
+// are currently in the RPC node's notary request pool with the corresponding
+// hashes of fallback transactions.
+func (c *Client) GetRawNotaryPool() (*result.RawNotaryPool, error) {
+	resp := &result.RawNotaryPool{}
+	if err := c.performRequest("getrawnotarypool", nil, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/pkg/rpcclient/rpc_test.go
+++ b/pkg/rpcclient/rpc_test.go
@@ -1375,6 +1375,89 @@ var rpcClientTestCases = map[string][]rpcClientTestCase{
 			},
 		},
 	},
+	"getrawnotarytransaction": {
+		{
+			name: "positive",
+			invoke: func(c *Client) (any, error) {
+				hash, err := util.Uint256DecodeStringLE("ad1c2875de823a54188949490e2d68580fd070fcc5ff409609f478d23d12355f")
+				if err != nil {
+					panic(err)
+				}
+				return c.GetRawNotaryTransaction(hash)
+			},
+			serverResponse: `{"id":1,"jsonrpc":"2.0","result":"AAMAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAHunqIsJ+NL0BSPxBCOCPdOj1BIsgABIgEBQAEDAQQHAwMGCQ=="}`,
+			result: func(c *Client) any {
+				return &transaction.Transaction{}
+			},
+			check: func(t *testing.T, c *Client, uns any) {
+				res, ok := uns.(*transaction.Transaction)
+				require.True(t, ok)
+				assert.NotNil(t, res)
+				expectHash, err := util.Uint256DecodeStringLE("ad1c2875de823a54188949490e2d68580fd070fcc5ff409609f478d23d12355f")
+				require.NoError(t, err)
+				assert.Equal(t, expectHash, res.Hash())
+			},
+		},
+		{
+			name: "positive verbose",
+			invoke: func(c *Client) (any, error) {
+				hash, err := util.Uint256DecodeStringLE("ad1c2875de823a54188949490e2d68580fd070fcc5ff409609f478d23d12355f")
+				if err != nil {
+					panic(err)
+				}
+				return c.GetRawNotaryTransactionVerbose(hash)
+			},
+			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{"hash":"0xad1c2875de823a54188949490e2d68580fd070fcc5ff409609f478d23d12355f","size":61,"version":0,"nonce":3,"sender":"Nhfg3TbpwogLvDGVvAvqyThbsHgoSUKwtn","sysfee":"0","netfee":"0","validuntilblock":123,"attributes":[{"nkeys":1,"type":"NotaryAssisted"}],"signers":[{"account":"0xb248508f4ef7088e10c48f14d04be3272ca29eee","scopes":"None"}],"script":"QA==","witnesses":[{"invocation":"AQQH","verification":"AwYJ"}]}}`,
+			result: func(c *Client) any {
+				return &transaction.Transaction{}
+			},
+			check: func(t *testing.T, c *Client, uns any) {
+				res, ok := uns.(*transaction.Transaction)
+				require.True(t, ok)
+				assert.NotNil(t, res)
+				expectHash, err := util.Uint256DecodeStringLE("ad1c2875de823a54188949490e2d68580fd070fcc5ff409609f478d23d12355f")
+				require.NoError(t, err)
+				assert.Equal(t, expectHash, res.Hash())
+			},
+		},
+	},
+	"getrawnotarypool": {
+		{
+			name: "empty pool",
+			invoke: func(c *Client) (any, error) {
+				return c.GetRawNotaryPool()
+			},
+			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{}}`,
+			result: func(c *Client) any {
+				return &result.RawNotaryPool{
+					Hashes: map[util.Uint256][]util.Uint256{},
+				}
+			},
+		},
+		{
+			name: "nonempty pool",
+			invoke: func(c *Client) (any, error) {
+				return c.GetRawNotaryPool()
+			},
+			serverResponse: `{"id":1,"jsonrpc":"2.0","result":{"hashes":{"0xd86b5346e9bbe6dba845cc4192fa716535a3d05c4f2084431edc99dc3862a299":["0xbb0b2f1d5539dd776637f00e5011d97921a1400d3a63c02977a38446180c6d7c"]}}}`,
+			result: func(c *Client) any {
+				return &result.RawNotaryPool{
+					Hashes: map[util.Uint256][]util.Uint256{},
+				}
+			},
+			check: func(t *testing.T, c *Client, uns any) {
+				res, ok := uns.(*result.RawNotaryPool)
+				require.True(t, ok)
+				mainHash, err := util.Uint256DecodeStringLE("d86b5346e9bbe6dba845cc4192fa716535a3d05c4f2084431edc99dc3862a299")
+				require.NoError(t, err, "can't decode `mainHash` result hash")
+				fallbackHash, err := util.Uint256DecodeStringLE("bb0b2f1d5539dd776637f00e5011d97921a1400d3a63c02977a38446180c6d7c")
+				require.NoError(t, err, "can't decode `fallbackHash` result hash")
+				fallbacks, ok := res.Hashes[mainHash]
+				require.True(t, ok)
+				assert.Equal(t, fallbacks[0], fallbackHash)
+			},
+		},
+	},
 }
 
 type rpcClientErrorCase struct {

--- a/pkg/services/rpcsrv/client_test.go
+++ b/pkg/services/rpcsrv/client_test.go
@@ -1135,6 +1135,137 @@ func TestSignAndPushP2PNotaryRequest(t *testing.T) {
 	})
 }
 
+func TestGetRawNotaryPoolAndTransaction(t *testing.T) {
+	var (
+		mainHash1, fallbackHash1, mainHash2, fallbackHash2 util.Uint256
+		tx1, tx2                                           *transaction.Transaction
+	)
+
+	chain, rpcSrv, httpSrv := initServerWithInMemoryChainAndServices(t, false, true, false)
+	defer chain.Close()
+	defer rpcSrv.Shutdown()
+
+	c, err := rpcclient.New(context.Background(), httpSrv.URL, rpcclient.Options{})
+	require.NoError(t, err)
+	t.Run("getrawnotarypool", func(t *testing.T) {
+		t.Run("empty pool", func(t *testing.T) {
+			np, err := c.GetRawNotaryPool()
+			require.NoError(t, err)
+			require.Equal(t, 0, len(np.Hashes))
+		})
+
+		sender := testchain.PrivateKeyByID(0) // owner of the deposit in testchain
+		acc := wallet.NewAccountFromPrivateKey(sender)
+
+		comm, err := c.GetCommittee()
+		require.NoError(t, err)
+
+		multiAcc := &wallet.Account{}
+		*multiAcc = *acc
+		require.NoError(t, multiAcc.ConvertMultisig(smartcontract.GetMajorityHonestNodeCount(len(comm)), comm))
+
+		nact, err := notary.NewActor(c, []actor.SignerAccount{{
+			Signer: transaction.Signer{
+				Account: multiAcc.Contract.ScriptHash(),
+				Scopes:  transaction.CalledByEntry,
+			},
+			Account: multiAcc,
+		}}, acc)
+		require.NoError(t, err)
+		neoW := neo.New(nact)
+		// Send the 1st notary request
+		tx1, err = neoW.SetRegisterPriceTransaction(1_0000_0000)
+		require.NoError(t, err)
+		mainHash1, fallbackHash1, _, err = nact.Notarize(tx1, err)
+		require.NoError(t, err)
+
+		checkTxInPool := func(t *testing.T, mainHash, fallbackHash util.Uint256, res *result.RawNotaryPool) {
+			actFallbacks, ok := res.Hashes[mainHash]
+			require.Equal(t, true, ok)
+			require.Equal(t, 1, len(actFallbacks))
+			require.Equal(t, fallbackHash, actFallbacks[0])
+		}
+		t.Run("nonempty pool", func(t *testing.T) {
+			actNotaryPool, err := c.GetRawNotaryPool()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(actNotaryPool.Hashes))
+			checkTxInPool(t, mainHash1, fallbackHash1, actNotaryPool)
+		})
+
+		// Send the 2nd notary request
+		tx2, err = neoW.SetRegisterPriceTransaction(2_0000_0000)
+		require.NoError(t, err)
+		mainHash2, fallbackHash2, _, err = nact.Notarize(tx2, err)
+		require.NoError(t, err)
+
+		t.Run("pool with 2", func(t *testing.T) {
+			actNotaryPool, err := c.GetRawNotaryPool()
+			require.NoError(t, err)
+			require.Equal(t, 2, len(actNotaryPool.Hashes))
+			checkTxInPool(t, mainHash1, fallbackHash1, actNotaryPool)
+			checkTxInPool(t, mainHash2, fallbackHash2, actNotaryPool)
+		})
+	})
+	t.Run("getrawnotarytransaction", func(t *testing.T) {
+		t.Run("client GetRawNotaryTransaction", func(t *testing.T) {
+			t.Run("unknown transaction", func(t *testing.T) {
+				_, err := c.GetRawNotaryTransaction(util.Uint256{0, 0, 0})
+				require.Error(t, err)
+				require.ErrorIs(t, err, neorpc.ErrUnknownTransaction)
+			})
+			_ = tx1.Size()
+			_ = tx2.Size()
+			// RPC server returns empty scripts in transaction.Witness,
+			// thus here the nil-value was changed to empty value.
+			if tx1.Scripts[1].InvocationScript == nil && tx1.Scripts[1].VerificationScript == nil {
+				tx1.Scripts[1] = transaction.Witness{
+					InvocationScript:   []byte{},
+					VerificationScript: []byte{},
+				}
+			}
+			if tx2.Scripts[1].InvocationScript == nil && tx2.Scripts[1].VerificationScript == nil {
+				tx2.Scripts[1] = transaction.Witness{
+					InvocationScript:   []byte{},
+					VerificationScript: []byte{},
+				}
+			}
+			t.Run("transactions from pool", func(t *testing.T) {
+				mainTx1, err := c.GetRawNotaryTransaction(mainHash1)
+				require.NoError(t, err)
+				require.Equal(t, tx1, mainTx1)
+				_, err = c.GetRawNotaryTransaction(fallbackHash1)
+				require.NoError(t, err)
+
+				mainTx2, err := c.GetRawNotaryTransaction(mainHash2)
+				require.NoError(t, err)
+				require.Equal(t, tx2, mainTx2)
+				_, err = c.GetRawNotaryTransaction(fallbackHash2)
+				require.NoError(t, err)
+			})
+		})
+		t.Run("client GetRawNotaryTransactionVerbose", func(t *testing.T) {
+			t.Run("unknown transaction", func(t *testing.T) {
+				_, err := c.GetRawNotaryTransactionVerbose(util.Uint256{0, 0, 0})
+				require.Error(t, err)
+				require.ErrorIs(t, err, neorpc.ErrUnknownTransaction)
+			})
+			t.Run("transactions from pool", func(t *testing.T) {
+				mainTx1, err := c.GetRawNotaryTransactionVerbose(mainHash1)
+				require.NoError(t, err)
+				require.Equal(t, tx1, mainTx1)
+				_, err = c.GetRawNotaryTransactionVerbose(fallbackHash1)
+				require.NoError(t, err)
+
+				mainTx2, err := c.GetRawNotaryTransactionVerbose(mainHash2)
+				require.NoError(t, err)
+				require.Equal(t, tx2, mainTx2)
+				_, err = c.GetRawNotaryTransactionVerbose(fallbackHash2)
+				require.NoError(t, err)
+			})
+		})
+	})
+}
+
 func TestCalculateNotaryFee(t *testing.T) {
 	chain, rpcSrv, httpSrv := initServerWithInMemoryChain(t)
 	defer chain.Close()

--- a/pkg/services/rpcsrv/subscription_test.go
+++ b/pkg/services/rpcsrv/subscription_test.go
@@ -144,7 +144,7 @@ func TestSubscriptions(t *testing.T) {
 
 	// We should manually add NotaryRequest to test notification.
 	sender := testchain.PrivateKeyByID(0)
-	err := rpcSrv.coreServer.RelayP2PNotaryRequest(createValidNotaryRequest(chain, sender, 1))
+	err := rpcSrv.coreServer.RelayP2PNotaryRequest(createValidNotaryRequest(chain, sender, 1, 2_0000_0000, nil))
 	require.NoError(t, err)
 	for {
 		resp := getNotification(t, respMsgs)
@@ -390,7 +390,7 @@ func TestFilteredNotaryRequestSubscriptions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			subID := callSubscribe(t, c, respMsgs, this.params)
 
-			err := rpcSrv.coreServer.RelayP2PNotaryRequest(createValidNotaryRequest(chain, priv0, nonce))
+			err := rpcSrv.coreServer.RelayP2PNotaryRequest(createValidNotaryRequest(chain, priv0, nonce, 2_0000_0000, nil))
 			require.NoError(t, err)
 			nonce++
 


### PR DESCRIPTION
### Problem

We have notary pool subscriptions, but it's not enough for debugging some unexpected things that may happen while submitting notary requests.
The problem is described in https://github.com/nspcc-dev/neo-go/issues/2951

### Solution

Add the following RPC extensions:

- `getRawNotaryPool` returns hashes from all the verified transactions, including both main and fallback transactions. 

- `getRawNotaryRequest` takes a transaction hash and attempts to find the corresponding transaction in the notary requests mempool. It searches through all the verified main and fallback transactions.

Close https://github.com/nspcc-dev/neo-go/issues/2951.