### PR TITLE
rpcsrv: enforce default config values on server creation if malformed value specified

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,8 @@ const (
 	// UserAgentFormat is a formatted string used to generate user agent string.
 	UserAgentFormat = UserAgentWrapper + UserAgentPrefix + "%s" + UserAgentWrapper
 	// DefaultMaxIteratorResultItems is the default upper bound of traversed
-	// iterator items per JSON-RPC response.
+	// iterator items per JSON-RPC response. It covers both session-based and
+	// naive iterators.
 	DefaultMaxIteratorResultItems = 100
 	// DefaultMaxFindStorageResultItems is the default maximum number of resulting
 	// contract storage items that can be retrieved by `findstorge` JSON-RPC handler.
@@ -74,7 +75,6 @@ func LoadFile(configPath string) (Config, error) {
 				PingTimeout:  90 * time.Second,
 			},
 			RPC: RPC{
-				MaxIteratorResultItems:    DefaultMaxIteratorResultItems,
 				MaxFindResultItems:        100,
 				MaxFindStorageResultItems: DefaultMaxFindStorageResultItems,
 				MaxNEP11Tokens:            100,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,8 +78,7 @@ func LoadFile(configPath string) (Config, error) {
 				PingTimeout:  90 * time.Second,
 			},
 			RPC: RPC{
-				MaxFindStorageResultItems: DefaultMaxFindStorageResultItems,
-				MaxNEP11Tokens:            100,
+				MaxNEP11Tokens: 100,
 			},
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,9 @@ const (
 	// iterator items per JSON-RPC response. It covers both session-based and
 	// naive iterators.
 	DefaultMaxIteratorResultItems = 100
+	// DefaultMaxFindResultItems is the default maximum number of resulting
+	// contract states items that can be retrieved by `findstates` JSON-RPC handler.
+	DefaultMaxFindResultItems = 100
 	// DefaultMaxFindStorageResultItems is the default maximum number of resulting
 	// contract storage items that can be retrieved by `findstorge` JSON-RPC handler.
 	DefaultMaxFindStorageResultItems = 50
@@ -75,7 +78,6 @@ func LoadFile(configPath string) (Config, error) {
 				PingTimeout:  90 * time.Second,
 			},
 			RPC: RPC{
-				MaxFindResultItems:        100,
 				MaxFindStorageResultItems: DefaultMaxFindStorageResultItems,
 				MaxNEP11Tokens:            100,
 			},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,9 @@ const (
 	// DefaultMaxFindStorageResultItems is the default maximum number of resulting
 	// contract storage items that can be retrieved by `findstorge` JSON-RPC handler.
 	DefaultMaxFindStorageResultItems = 50
+	// DefaultMaxNEP11Tokens is the default maximum number of resulting NEP11 tokens
+	// that can be traversed by `getnep11balances` JSON-RPC handler.
+	DefaultMaxNEP11Tokens = 100
 )
 
 // Version is the version of the node, set at the build time.
@@ -76,9 +79,6 @@ func LoadFile(configPath string) (Config, error) {
 			P2P: P2P{
 				PingInterval: 30 * time.Second,
 				PingTimeout:  90 * time.Second,
-			},
-			RPC: RPC{
-				MaxNEP11Tokens: 100,
 			},
 		},
 	}

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -2487,7 +2487,7 @@ func (s *Server) traverseIterator(reqParams params.Params) (any, *neorpc.Error) 
 		return nil, neorpc.NewInvalidParamsError("invalid iterator items count: not an int32")
 	}
 	if count > s.config.MaxIteratorResultItems {
-		return nil, neorpc.NewInvalidParamsError(fmt.Sprintf("iterator items count is out of range (%d at max)", s.config.MaxIteratorResultItems))
+		return nil, neorpc.NewInvalidParamsError(fmt.Sprintf("iterator items count (%d) is out of range (%d at max)", count, s.config.MaxIteratorResultItems))
 	}
 
 	s.sessionsLock.Lock()

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -307,6 +307,10 @@ func New(chain Ledger, conf config.RPC, coreServer *network.Server,
 		conf.MaxFindStorageResultItems = config.DefaultMaxFindStorageResultItems
 		log.Info("MaxFindStorageResultItems is not set or wrong, setting default value", zap.Int("MaxFindStorageResultItems", config.DefaultMaxFindStorageResultItems))
 	}
+	if conf.MaxNEP11Tokens <= 0 {
+		conf.MaxNEP11Tokens = config.DefaultMaxNEP11Tokens
+		log.Info("MaxNEP11Tokens is not set or wrong, setting default value", zap.Int("MaxNEP11Tokens", config.DefaultMaxNEP11Tokens))
+	}
 	if conf.MaxWebSocketClients == 0 {
 		conf.MaxWebSocketClients = defaultMaxWebSocketClients
 		log.Info("MaxWebSocketClients is not set or wrong, setting default value", zap.Int("MaxWebSocketClients", defaultMaxWebSocketClients))

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -295,6 +295,10 @@ func New(chain Ledger, conf config.RPC, coreServer *network.Server,
 			log.Info("SessionPoolSize is not set or wrong, setting default value", zap.Int("SessionPoolSize", defaultSessionPoolSize))
 		}
 	}
+	if conf.MaxIteratorResultItems <= 0 {
+		conf.MaxIteratorResultItems = config.DefaultMaxIteratorResultItems
+		log.Info("MaxIteratorResultItems is not set or wrong, setting default value", zap.Int("MaxIteratorResultItems", config.DefaultMaxIteratorResultItems))
+	}
 	if conf.MaxWebSocketClients == 0 {
 		conf.MaxWebSocketClients = defaultMaxWebSocketClients
 		log.Info("MaxWebSocketClients is not set or wrong, setting default value", zap.Int("MaxWebSocketClients", defaultMaxWebSocketClients))

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -299,6 +299,10 @@ func New(chain Ledger, conf config.RPC, coreServer *network.Server,
 		conf.MaxIteratorResultItems = config.DefaultMaxIteratorResultItems
 		log.Info("MaxIteratorResultItems is not set or wrong, setting default value", zap.Int("MaxIteratorResultItems", config.DefaultMaxIteratorResultItems))
 	}
+	if conf.MaxFindResultItems <= 0 {
+		conf.MaxFindResultItems = config.DefaultMaxFindResultItems
+		log.Info("MaxFindResultItems is not set or wrong, setting default value", zap.Int("MaxFindResultItems", config.DefaultMaxFindResultItems))
+	}
 	if conf.MaxWebSocketClients == 0 {
 		conf.MaxWebSocketClients = defaultMaxWebSocketClients
 		log.Info("MaxWebSocketClients is not set or wrong, setting default value", zap.Int("MaxWebSocketClients", defaultMaxWebSocketClients))

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -303,6 +303,10 @@ func New(chain Ledger, conf config.RPC, coreServer *network.Server,
 		conf.MaxFindResultItems = config.DefaultMaxFindResultItems
 		log.Info("MaxFindResultItems is not set or wrong, setting default value", zap.Int("MaxFindResultItems", config.DefaultMaxFindResultItems))
 	}
+	if conf.MaxFindStorageResultItems <= 0 {
+		conf.MaxFindStorageResultItems = config.DefaultMaxFindStorageResultItems
+		log.Info("MaxFindStorageResultItems is not set or wrong, setting default value", zap.Int("MaxFindStorageResultItems", config.DefaultMaxFindStorageResultItems))
+	}
 	if conf.MaxWebSocketClients == 0 {
 		conf.MaxWebSocketClients = defaultMaxWebSocketClients
 		log.Info("MaxWebSocketClients is not set or wrong, setting default value", zap.Int("MaxWebSocketClients", defaultMaxWebSocketClients))

--- a/pkg/services/rpcsrv/server_test.go
+++ b/pkg/services/rpcsrv/server_test.go
@@ -2973,9 +2973,9 @@ func testRPCProtocol(t *testing.T, doRPCCall func(string, string, *testing.T) []
 		})
 		t.Run("count is out of range", func(t *testing.T) {
 			sID, iID := prepareIteratorSession(t)
-			rpc := fmt.Sprintf(`{"jsonrpc": "2.0", "id": 1, "method": "traverseiterator", "params": ["%s", "%s", %d]}"`, sID.String(), iID.String(), rpcSrv.config.MaxIteratorResultItems+1)
+			rpc := fmt.Sprintf(`{"jsonrpc": "2.0", "id": 1, "method": "traverseiterator", "params": ["%s", "%s", %d]}"`, sID.String(), iID.String(), config.DefaultMaxIteratorResultItems+1)
 			body := doRPCCall(rpc, httpSrv.URL, t)
-			checkErrGetResult(t, body, true, neorpc.InvalidParamsCode, fmt.Sprintf("iterator items count is out of range (%d at max)", rpcSrv.config.MaxIteratorResultItems))
+			checkErrGetResult(t, body, true, neorpc.InvalidParamsCode, fmt.Sprintf("iterator items count is out of range (%d at max)", config.DefaultMaxIteratorResultItems))
 		})
 		t.Run("unknown session", func(t *testing.T) {
 			_, iID := prepareIteratorSession(t)

--- a/pkg/services/rpcsrv/server_test.go
+++ b/pkg/services/rpcsrv/server_test.go
@@ -2975,7 +2975,7 @@ func testRPCProtocol(t *testing.T, doRPCCall func(string, string, *testing.T) []
 			sID, iID := prepareIteratorSession(t)
 			rpc := fmt.Sprintf(`{"jsonrpc": "2.0", "id": 1, "method": "traverseiterator", "params": ["%s", "%s", %d]}"`, sID.String(), iID.String(), config.DefaultMaxIteratorResultItems+1)
 			body := doRPCCall(rpc, httpSrv.URL, t)
-			checkErrGetResult(t, body, true, neorpc.InvalidParamsCode, fmt.Sprintf("iterator items count is out of range (%d at max)", config.DefaultMaxIteratorResultItems))
+			checkErrGetResult(t, body, true, neorpc.InvalidParamsCode, fmt.Sprintf("iterator items count (%d) is out of range (%d at max)", config.DefaultMaxIteratorResultItems+1, config.DefaultMaxIteratorResultItems))
 		})
 		t.Run("unknown session", func(t *testing.T) {
 			_, iID := prepareIteratorSession(t)


### PR DESCRIPTION
Ref. https://github.com/nspcc-dev/neo-go/issues/3106. This PR makes the life of NeoFS IR supernode better.
