### PR TITLE
workflows: reuse org-wide DCO workflow

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -7,15 +7,4 @@ on:
 
 jobs:
   commits_check_job:
-    runs-on: ubuntu-latest
-    name: Commits Check
-    steps:
-    - name: Get PR Commits
-      id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - name: DCO Check
-      uses: tim-actions/dco@master
-      with:
-        commits: ${{ steps.get-pr-commits.outputs.commits }}
+    uses: nspcc-dev/.github/.github/workflows/dco.yml@master


### PR DESCRIPTION
@mike-petrov, it can look like this in other repos. We just drop a local copy and go with an org-wide workflow.