### PR TITLE
Fix `DBConfiguration` description

### DIFF
--- a/pkg/core/storage/dbconfig/store_config.go
+++ b/pkg/core/storage/dbconfig/store_config.go
@@ -4,7 +4,8 @@ Package dbconfig is a micropackage that contains storage DB configuration option
 package dbconfig
 
 type (
-	// DBConfiguration describes configuration for DB. Supported: 'levelDB', 'boltDB'.
+	// DBConfiguration describes configuration for DB. Supported types:
+	// [LevelDB], [BoltDB] or [InMemoryDB] (not recommended for production usage).
 	DBConfiguration struct {
 		Type           string         `yaml:"Type"`
 		LevelDBOptions LevelDBOptions `yaml:"LevelDBOptions"`


### PR DESCRIPTION
### Problem

There are incorrect values for Type in the DBConfiguration struct description.
The problem is described in https://github.com/nspcc-dev/neo-go/issues/2931

### Solution

Add the correct supported types (`Type`) in the `DBConfiguration` struct.

Close https://github.com/nspcc-dev/neo-go/issues/2931
