### PR TITLE
Add `unwrap.Nothing` function

### DIFF
--- a/pkg/rpcclient/unwrap/unwrap.go
+++ b/pkg/rpcclient/unwrap/unwrap.go
@@ -374,3 +374,15 @@ func Item(r *result.Invoke, err error) (stackitem.Item, error) {
 	}
 	return r.Stack[0], nil
 }
+
+// Nothing expects zero stack items and a successful invocation (HALT state).
+func Nothing(r *result.Invoke, err error) error {
+	err = checkResOK(r, err)
+	if err != nil {
+		return err
+	}
+	if len(r.Stack) != 0 {
+		return errors.New("result stack is not empty")
+	}
+	return nil
+}

--- a/pkg/rpcclient/unwrap/unwrap_test.go
+++ b/pkg/rpcclient/unwrap/unwrap_test.go
@@ -123,6 +123,24 @@ func TestBool(t *testing.T) {
 	require.True(t, b)
 }
 
+func TestNothing(t *testing.T) {
+	// Error on input.
+	err := Nothing(&result.Invoke{State: "HALT", Stack: []stackitem.Item{}}, errors.New("some"))
+	require.Error(t, err)
+
+	// Nonempty stack.
+	err = Nothing(&result.Invoke{State: "HALT", Stack: []stackitem.Item{stackitem.Make(42)}}, nil)
+	require.Error(t, err)
+
+	// FAULT state.
+	err = Nothing(&result.Invoke{State: "FAULT", Stack: []stackitem.Item{}}, nil)
+	require.Error(t, err)
+
+	// Positive.
+	err = Nothing(&result.Invoke{State: "HALT", Stack: []stackitem.Item{}}, nil)
+	require.NoError(t, err)
+}
+
 func TestInt64(t *testing.T) {
 	_, err := Int64(&result.Invoke{State: "HALT", Stack: []stackitem.Item{stackitem.Make("0x03c564ed28ba3d50beb1a52dcb751b929e1d747281566bd510363470be186bc0")}}, nil)
 	require.Error(t, err)


### PR DESCRIPTION
### Problem

A check for successful invocation (in the HALT state) that returns nothing is required.
The problem is described in https://github.com/nspcc-dev/neo-go/issues/3070

### Solution

Add unwrap.Nothing(aer, error) error for it, which should expect zero stack items and the HALT state.

Close https://github.com/nspcc-dev/neo-go/issues/3070