### PR TITLE
smartcontract: fix wildcard trusts deserialization

### DIFF
--- a/pkg/core/state/contract_test.go
+++ b/pkg/core/state/contract_test.go
@@ -55,6 +55,16 @@ func TestContractStateToFromSI(t *testing.T) {
 	t.Run("Convertible", func(t *testing.T) {
 		contractDecoded := new(Contract)
 		testserdes.ToFromStackItem(t, contract, contractDecoded)
+
+		t.Run("preserve wildcard trusts", func(t *testing.T) {
+			contract.Manifest.Trusts.Value = nil
+			require.True(t, contract.Manifest.Trusts.IsWildcard())
+			actual := new(Contract)
+			item, err := contract.ToStackItem()
+			require.NoError(t, err)
+			require.NoError(t, actual.FromStackItem(item))
+			require.True(t, actual.Manifest.Trusts.IsWildcard())
+		})
 	})
 	t.Run("JSON", func(t *testing.T) {
 		contractDecoded := new(Contract)

--- a/pkg/smartcontract/manifest/manifest.go
+++ b/pkg/smartcontract/manifest/manifest.go
@@ -250,7 +250,7 @@ func (m *Manifest) FromStackItem(item stackitem.Item) error {
 		m.Permissions[i] = *p
 	}
 	if _, ok := str[6].(stackitem.Null); ok {
-		m.Trusts.Restrict()
+		m.Trusts = WildPermissionDescs{Value: nil} // wildcard by default
 	} else {
 		if str[6].Type() != stackitem.ArrayT {
 			return errors.New("invalid Trusts stackitem type")


### PR DESCRIPTION
If manifest trusts presented as Null stackitem, then they should be treated as wildcard, not as restricted.

It's not the same problem as described and fixed in https://github.com/neo-project/neo/pull/2901 and
https://github.com/neo-project/neo/pull/2892, although these two PRs are related.
