### PR TITLE
rpcclient: fix wsclient hang on making request

### DIFF
--- a/pkg/rpcclient/local.go
+++ b/pkg/rpcclient/local.go
@@ -29,7 +29,8 @@ func NewInternal(ctx context.Context, register InternalHook) (*Internal, error) 
 			Client: Client{},
 
 			shutdown:      make(chan struct{}),
-			done:          make(chan struct{}),
+			readerDone:    make(chan struct{}),
+			writerDone:    make(chan struct{}),
 			subscriptions: make(map[string]notificationReceiver),
 			receivers:     make(map[any][]string),
 		},
@@ -63,7 +64,7 @@ eventloop:
 			c.notifySubscribers(ntf)
 		}
 	}
-	close(c.done)
+	close(c.readerDone)
 	c.ctxCancel()
 	// ctx is cancelled, server is notified and will finish soon.
 drainloop:


### PR DESCRIPTION
* Rename c.done channel to c.readerDone
* Introduce c.writerDone channel that is closed if the wsWriter's loop is done
* Make the error returned by makeWsRequests verbose

Fix #3135