### PR TITLE
compiler: Fix emitting big uint64 constants

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -9,6 +9,7 @@ import (
 	"go/token"
 	"go/types"
 	"math"
+	"math/big"
 	"sort"
 	"strings"
 
@@ -208,9 +209,12 @@ func (c *codegen) emitLoadConst(t types.TypeAndValue) {
 	case types.Int, types.UntypedInt, types.Uint,
 		types.Int8, types.Uint8,
 		types.Int16, types.Uint16,
-		types.Int32, types.Uint32, types.Int64, types.Uint64:
+		types.Int32, types.Uint32, types.Int64:
 		val, _ := constant.Int64Val(t.Value)
 		emit.Int(c.prog.BinWriter, val)
+	case types.Uint64:
+		val, _ := constant.Int64Val(t.Value)
+		emit.BigInt(c.prog.BinWriter, new(big.Int).SetUint64(uint64(val)))
 	case types.String, types.UntypedString:
 		val := constant.StringVal(t.Value)
 		emit.String(c.prog.BinWriter, val)

--- a/pkg/compiler/numeric_test.go
+++ b/pkg/compiler/numeric_test.go
@@ -18,6 +18,14 @@ var numericTestCases = []testCase{
 		`,
 		big.NewInt(6),
 	},
+	{
+		"shift uint64",
+		`package foo
+		func Main() uint64 {
+			return 1 << 63
+		}`,
+		new(big.Int).SetUint64(1 << 63),
+	},
 }
 
 func TestNumericExprs(t *testing.T) {


### PR DESCRIPTION
### Problem
Currently we take int64 value from the Go parser and push it to the stack. It is not a common practice (usually we just use `int`), but can be a problem while doing bit arithmetic and serializing numbers.

### Solution
Make a separate case for uint64. Because `emit.BigInt` checks whether an integer is small, the emitted byte-code should be the same in other cases.