### PR TITLE
storage: Use timeout for boltdb database opening

### DIFF
--- a/pkg/core/storage/boltdb_store.go
+++ b/pkg/core/storage/boltdb_store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/storage/dbconfig"
 	"github.com/nspcc-dev/neo-go/pkg/io"
@@ -21,6 +22,10 @@ type BoltDBStore struct {
 	db *bbolt.DB
 }
 
+// defaultOpenTimeout is the default timeout for performing flock on a bbolt database.
+// bbolt does retries every 50ms during this interval.
+const defaultOpenTimeout = 1 * time.Second
+
 // NewBoltDBStore returns a new ready to use BoltDB storage with created bucket.
 func NewBoltDBStore(cfg dbconfig.BoltDBOptions) (*BoltDBStore, error) {
 	cp := *bbolt.DefaultOptions // Do not change bbolt's global variable.
@@ -34,6 +39,8 @@ func NewBoltDBStore(cfg dbconfig.BoltDBOptions) (*BoltDBStore, error) {
 			return nil, err
 		}
 	}
+	opts.Timeout = defaultOpenTimeout
+
 	db, err := bbolt.Open(fileName, fileMode, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open BoltDB instance: %w", err)


### PR DESCRIPTION
### Problem
To dump the DB, the service must be stopped. If this is not the case `dump` command just hangs without any output.
This _may_ be unexpected from the ops POV (hello, @532910).

### Solution
Introduce timeout for bbolt db open. I have decided not to put it in the configuration, because 5 seconds is more than enough, given that flock retry is 50 milliseconds
https://github.com/etcd-io/bbolt/blob/db45d0d6b1f6d173baad00019fdc7c58ad0ab002/db.go#L19
https://github.com/etcd-io/bbolt/blob/db45d0d6b1f6d173baad00019fdc7c58ad0ab002/db.go#L222

Do you think this is worth having in the configuration (like I dump and _then_ stop the service and _expect_ dump to work for such a usecase)?
