### PR TITLE
Fix timeout of RPC tests on Windows

### DIFF
--- a/config/protocol.unit_testnet.single.yml
+++ b/config/protocol.unit_testnet.single.yml
@@ -58,7 +58,7 @@ ApplicationConfiguration:
     MaxGasInvoke: 15
     Enabled: true
     Addresses:
-      - "localhost:0" # let the system choose port dynamically
+      - "127.0.0.1:0" # let the system choose port dynamically
     EnableCORSWorkaround: false
   Prometheus:
     Enabled: false #since it's not useful for unit tests.

--- a/config/protocol.unit_testnet.yml
+++ b/config/protocol.unit_testnet.yml
@@ -12,9 +12,9 @@ ProtocolConfiguration:
     - 02c4de32252c50fa171dbe25379e4e2d55cdc12f69e382c39f59a44573ecff2f9d
   ValidatorsCount: 4
   SeedList:
-    - localhost:20334
-    - localhost:20335
-    - localhost:20336
+    - 127.0.0.1:20334
+    - 127.0.0.1:20335
+    - 127.0.0.1:20336
   VerifyTransactions: true
   P2PSigExtensions: true
   NativeActivations:
@@ -62,7 +62,7 @@ ApplicationConfiguration:
     MaxGasInvoke: 15
     Enabled: true
     Addresses:
-      - "localhost:0" # let the system choose port dynamically
+      - "127.0.0.1:0" # let the system choose port dynamically
     EnableCORSWorkaround: false
     SessionEnabled: true
     SessionExpirationTime: 2 # enough for tests as they run locally.

--- a/pkg/network/payload/address_test.go
+++ b/pkg/network/payload/address_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestEncodeDecodeAddress(t *testing.T) {
 	var (
-		e, _ = net.ResolveTCPAddr("tcp", "localhost:2000")
+		e, _ = net.ResolveTCPAddr("tcp", "127.0.0.1:2000")
 		ts   = time.Now()
 		addr = NewAddressAndTime(e, ts, capability.Capabilities{
 			{
@@ -45,7 +45,7 @@ func TestEncodeDecodeAddress(t *testing.T) {
 
 func fillAddressList(al *AddressList) {
 	for i := 0; i < len(al.Addrs); i++ {
-		e, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:20%d", i))
+		e, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("127.0.0.1:20%d", i))
 		al.Addrs[i] = NewAddressAndTime(e, time.Now(), capability.Capabilities{
 			{
 				Type: capability.TCPServer,


### PR DESCRIPTION
Ref. #2975.

Here's the example of successful run: https://github.com/nspcc-dev/neo-go/actions/runs/6562296558/job/17823936017. I'll run it a couple of times to ensure that the problem is gone before the merge. Thus, currently is in draft.

Just for the record, an alternative to this PR was a Dialler fix at 6ec8126d0042f3ad01e403c31d7caa80250696da. I've also considered to enable IPv6 on our Windonws GA runner, but it's not possible at the current moment due to GitHub infrastructure constraints, see the https://github.com/actions/runner-images/issues/668.