### PR TITLE
vm: reduce maximum stckitem size

### DIFF
--- a/pkg/vm/stackitem/item.go
+++ b/pkg/vm/stackitem/item.go
@@ -21,7 +21,7 @@ const (
 	// MaxBigIntegerSizeBits is the maximum size of a BigInt item in bits.
 	MaxBigIntegerSizeBits = 32 * 8
 	// MaxSize is the maximum item size allowed in the VM.
-	MaxSize = 1024 * 1024
+	MaxSize = math.MaxUint16 * 2
 	// MaxComparableNumOfItems is the maximum number of items that can be compared for structs.
 	MaxComparableNumOfItems = MaxDeserialized
 	// MaxClonableNumOfItems is the maximum number of items that can be cloned in structs.

--- a/pkg/vm/stackitem/json_test.go
+++ b/pkg/vm/stackitem/json_test.go
@@ -383,7 +383,7 @@ func TestToJSONWithTypesBadCases(t *testing.T) {
 		// until the necessary branch is covered #ididthemath.
 		arr := NewArray([]Item{
 			NewByteArray(bigBuf[:MaxSize/4*3-70]),
-			NewBigInteger(big.NewInt(1234)),
+			NewBigInteger(big.NewInt(123456)),
 		})
 		_, err := ToJSONWithTypes(arr)
 		require.ErrorIs(t, err, errTooBigSize)


### PR DESCRIPTION
To prevent possible DoS. Port the https://github.com/neo-project/neo-vm/pull/514, close #3170.

Draft until some proximity to 0.104.0.