### PR TITLE
Restrict maximum serialized NEF file size

### DIFF
--- a/pkg/core/state/contract.go
+++ b/pkg/core/state/contract.go
@@ -37,6 +37,8 @@ type NativeContract struct {
 
 // ToStackItem converts state.Contract to stackitem.Item.
 func (c *Contract) ToStackItem() (stackitem.Item, error) {
+	// Do not skip the NEF size check, it won't affect native Management related
+	// states as the same checked is performed during contract deploy/update.
 	rawNef, err := c.NEF.Bytes()
 	if err != nil {
 		return nil, err

--- a/pkg/smartcontract/nef/nef_test.go
+++ b/pkg/smartcontract/nef/nef_test.go
@@ -144,7 +144,7 @@ func TestNewFileFromBytesLimits(t *testing.T) {
 	}
 	expected.Checksum = expected.CalculateChecksum()
 
-	bytes, err := expected.Bytes()
+	bytes, err := expected.BytesLong()
 	require.NoError(t, err)
 	_, err = FileFromBytes(bytes)
 	require.Error(t, err)


### PR DESCRIPTION
In this PR:
- Port the https://github.com/neo-project/neo/pull/2939;
- Introduce NEF size check on file serialization and forbid large NEFs compilation;
- Add `--no-nef-check` option to `contract compile` CLI command and compiler.

Ref. #3170 and depends on #3185. Draft until some real proximity to 0.104.0.