### PR TITLE
Fix native Neo cache initialization

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -468,6 +468,8 @@ func (bc *Blockchain) init() error {
 	}
 	bc.blockHeight = bHeight
 	bc.persistedHeight = bHeight
+
+	bc.log.Debug("initializing caches", zap.Uint32("blockHeight", bHeight))
 	if err = bc.stateRoot.Init(bHeight); err != nil {
 		return fmt.Errorf("can't init MPT at height %d: %w", bHeight, err)
 	}

--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -970,7 +970,7 @@ func (dao *Simple) GetRWCache(id int32) NativeContractCache {
 func (dao *Simple) getCache(k int32, ro bool) NativeContractCache {
 	if itm, ok := dao.nativeCache[k]; ok {
 		// Don't need to create itm copy, because its value was already copied
-		// the first time it was retrieved from loser ps.
+		// the first time it was retrieved from lower ps.
 		return itm
 	}
 

--- a/pkg/core/native/policy.go
+++ b/pkg/core/native/policy.go
@@ -365,8 +365,9 @@ func (p *Policy) unblockAccount(ic *interop.Context, args []stackitem.Item) stac
 // like not being signed by a blocked account or not exceeding the block-level system
 // fee limit.
 func (p *Policy) CheckPolicy(d *dao.Simple, tx *transaction.Transaction) error {
+	cache := d.GetROCache(p.ID).(*PolicyCache)
 	for _, signer := range tx.Signers {
-		if _, isBlocked := p.isBlockedInternal(d.GetROCache(p.ID).(*PolicyCache), signer.Account); isBlocked {
+		if _, isBlocked := p.isBlockedInternal(cache, signer.Account); isBlocked {
 			return fmt.Errorf("account %s is blocked", signer.Account.StringLE())
 		}
 	}

--- a/pkg/core/native/policy.go
+++ b/pkg/core/native/policy.go
@@ -241,26 +241,33 @@ func (p *Policy) setExecFeeFactor(ic *interop.Context, args []stackitem.Item) st
 // isBlocked is Policy contract method that checks whether provided account is blocked.
 func (p *Policy) isBlocked(ic *interop.Context, args []stackitem.Item) stackitem.Item {
 	hash := toUint160(args[0])
-	_, blocked := p.isBlockedInternal(ic.DAO, hash)
+	_, blocked := p.isBlockedInternal(ic.DAO.GetROCache(p.ID).(*PolicyCache), hash)
 	return stackitem.NewBool(blocked)
 }
 
-// IsBlocked checks whether provided account is blocked.
+// IsBlocked checks whether provided account is blocked. Normally it uses Policy
+// cache, falling back to the DB queries when Policy cache is not available yet
+// (the only case is native cache initialization pipeline, where native Neo cache
+// is being initialized before the Policy's one).
 func (p *Policy) IsBlocked(dao *dao.Simple, hash util.Uint160) bool {
-	_, isBlocked := p.isBlockedInternal(dao, hash)
+	cache := dao.GetROCache(p.ID)
+	if cache == nil {
+		key := append([]byte{blockedAccountPrefix}, hash.BytesBE()...)
+		return dao.GetStorageItem(p.ID, key) == nil
+	}
+	_, isBlocked := p.isBlockedInternal(cache.(*PolicyCache), hash)
 	return isBlocked
 }
 
 // isBlockedInternal checks whether provided account is blocked. It returns position
 // of the blocked account in the blocked accounts list (or the position it should be
 // put at).
-func (p *Policy) isBlockedInternal(dao *dao.Simple, hash util.Uint160) (int, bool) {
-	cache := dao.GetROCache(p.ID).(*PolicyCache)
-	length := len(cache.blockedAccounts)
+func (p *Policy) isBlockedInternal(roCache *PolicyCache, hash util.Uint160) (int, bool) {
+	length := len(roCache.blockedAccounts)
 	i := sort.Search(length, func(i int) bool {
-		return !cache.blockedAccounts[i].Less(hash)
+		return !roCache.blockedAccounts[i].Less(hash)
 	})
-	if length != 0 && i != length && cache.blockedAccounts[i].Equals(hash) {
+	if length != 0 && i != length && roCache.blockedAccounts[i].Equals(hash) {
 		return i, true
 	}
 	return i, false
@@ -320,7 +327,7 @@ func (p *Policy) blockAccount(ic *interop.Context, args []stackitem.Item) stacki
 	return stackitem.NewBool(p.blockAccountInternal(ic.DAO, hash))
 }
 func (p *Policy) blockAccountInternal(d *dao.Simple, hash util.Uint160) bool {
-	i, blocked := p.isBlockedInternal(d, hash)
+	i, blocked := p.isBlockedInternal(d.GetROCache(p.ID).(*PolicyCache), hash)
 	if blocked {
 		return false
 	}
@@ -343,7 +350,7 @@ func (p *Policy) unblockAccount(ic *interop.Context, args []stackitem.Item) stac
 		panic("invalid committee signature")
 	}
 	hash := toUint160(args[0])
-	i, blocked := p.isBlockedInternal(ic.DAO, hash)
+	i, blocked := p.isBlockedInternal(ic.DAO.GetROCache(p.ID).(*PolicyCache), hash)
 	if !blocked {
 		return stackitem.NewBool(false)
 	}
@@ -359,7 +366,7 @@ func (p *Policy) unblockAccount(ic *interop.Context, args []stackitem.Item) stac
 // fee limit.
 func (p *Policy) CheckPolicy(d *dao.Simple, tx *transaction.Transaction) error {
 	for _, signer := range tx.Signers {
-		if _, isBlocked := p.isBlockedInternal(d, signer.Account); isBlocked {
+		if _, isBlocked := p.isBlockedInternal(d.GetROCache(p.ID).(*PolicyCache), signer.Account); isBlocked {
 			return fmt.Errorf("account %s is blocked", signer.Account.StringLE())
 		}
 	}


### PR DESCRIPTION
Refactored native NeoToken cache scheme introduced in #3110 sometimes requires validators list recalculation during native cache initialization process (when initializing with the existing storage from the block that is preceded each N-th block). To recalculate validators from candidates, native NeoToken needs an access to cached native Policy blocked accounts. By the moment of native Neo initialization, the cache of native Policy is not yet initialized, thus we need a direct DAO access for Policy to handle blocked account check.

Close #3181. Also refactor native Policy cache a bit.
