### PR TITLE
native: prohibit non-zero GAS/NEO roundtrip with zero balance

### DIFF
--- a/pkg/core/native/native_nep17.go
+++ b/pkg/core/native/native_nep17.go
@@ -180,6 +180,9 @@ func (c *nep17TokenNative) updateAccBalance(ic *interop.Context, acc util.Uint16
 		if amount.Sign() < 0 {
 			return nil, errors.New("insufficient funds")
 		}
+		if requiredBalance != nil && requiredBalance.Sign() > 0 {
+			return nil, errors.New("insufficient funds")
+		}
 		if amount.Sign() == 0 {
 			// it's OK to transfer 0 if the balance is 0, no need to put si to the storage
 			return nil, nil

--- a/pkg/core/native/native_test/neo_test.go
+++ b/pkg/core/native/native_test/neo_test.go
@@ -595,6 +595,22 @@ func TestNEO_TransferZeroWithNonZeroBalance(t *testing.T) {
 	})
 }
 
+// https://github.com/nspcc-dev/neo-go/issues/3190
+func TestNEO_TransferNonZeroWithZeroBalance(t *testing.T) {
+	neoValidatorsInvoker := newNeoValidatorsClient(t)
+	e := neoValidatorsInvoker.Executor
+
+	acc := neoValidatorsInvoker.WithSigners(e.NewAccount(t))
+	accH := acc.Signers[0].ScriptHash()
+	h := acc.Invoke(t, false, "transfer", accH, accH, int64(5), nil)
+	aer := e.CheckHalt(t, h, stackitem.Make(false))
+	require.Equal(t, 0, len(aer.Events))
+	// check balance wasn't changed and height was not updated
+	updatedBalance, updatedHeight := e.Chain.GetGoverningTokenBalance(accH)
+	require.Equal(t, int64(0), updatedBalance.Int64())
+	require.Equal(t, uint32(0), updatedHeight)
+}
+
 func TestNEO_CalculateBonus(t *testing.T) {
 	neoCommitteeInvoker := newNeoCommitteeClient(t, 10_0000_0000)
 	e := neoCommitteeInvoker.Executor


### PR DESCRIPTION
Close #3190.

I'm struggling with the fact that we have `updateAccBalance`. It's the third time when I'm trying to fix roundtrips. We already have `TestNEO_Roundtrip`, `TestNEO_TransferZeroWithNonZeroBalance` and `TestNEO_TransferZeroWithZeroBalance`, and I'm still not sure that it works correctly. To be honest, I would love to rewrite `TransferInternal` and remove `updateAccBalance` at all, to match C# code perfectly, line-by-line.

Node sync is in progress to check that the bug is fixed.