### PR TITLE
cli: allow to override consensus wallet path

### DIFF
--- a/cli/options/options.go
+++ b/cli/options/options.go
@@ -73,6 +73,13 @@ var ConfigFile = cli.StringFlag{
 	Usage: "path to the node configuration file (overrides --config-path option)",
 }
 
+// RelativePath is a flag for commands that use node configuration and provides
+// the path to the consensus wallet instead of reading it from the config file.
+var RelativePath = cli.StringFlag{
+	Name:  "relative-path",
+	Usage: "path to the consensus wallet file (overrides path defined in the config)",
+}
+
 // Debug is a flag for commands that allow node in debug mode usage.
 var Debug = cli.BoolFlag{
 	Name:  "debug, d",
@@ -160,14 +167,24 @@ func GetRPCWithInvoker(gctx context.Context, ctx *cli.Context, signers []transac
 // returns an appropriate config.
 func GetConfigFromContext(ctx *cli.Context) (config.Config, error) {
 	var configFile = ctx.String("config-file")
+	var relativePath = ctx.String("relative-path")
 	if len(configFile) != 0 {
-		return config.LoadFile(configFile)
+		cfg, err := config.LoadFile(configFile)
+		if err == nil && len(relativePath) != 0 {
+			cfg.ApplicationConfiguration.Consensus.UnlockWallet.Path = relativePath
+		}
+		return cfg, err
 	}
 	var configPath = "./config"
 	if argCp := ctx.String("config-path"); argCp != "" {
 		configPath = argCp
 	}
-	return config.Load(configPath, GetNetwork(ctx))
+
+	cfg, err := config.Load(configPath, GetNetwork(ctx))
+	if err == nil && len(relativePath) != 0 {
+		cfg.ApplicationConfiguration.Consensus.UnlockWallet.Path = relativePath
+	}
+	return cfg, err
 }
 
 var (

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -34,7 +34,7 @@ import (
 
 // NewCommands returns 'node' command.
 func NewCommands() []cli.Command {
-	cfgFlags := []cli.Flag{options.Config, options.ConfigFile}
+	cfgFlags := []cli.Flag{options.Config, options.ConfigFile, options.RelativePath}
 	cfgFlags = append(cfgFlags, options.Network...)
 	var cfgWithCountFlags = make([]cli.Flag, len(cfgFlags))
 	copy(cfgWithCountFlags, cfgFlags)

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -34,7 +34,7 @@ import (
 
 // NewCommands returns 'node' command.
 func NewCommands() []cli.Command {
-	cfgFlags := []cli.Flag{options.Config, options.ConfigFile, options.RelativePath}
+	cfgFlags := []cli.Flag{options.Config, options.ConfigFile, options.ConsensusWalletPath}
 	cfgFlags = append(cfgFlags, options.Network...)
 	var cfgWithCountFlags = make([]cli.Flag, len(cfgFlags))
 	copy(cfgWithCountFlags, cfgFlags)

--- a/cli/vm/vm.go
+++ b/cli/vm/vm.go
@@ -13,7 +13,7 @@ import (
 
 // NewCommands returns 'vm' command.
 func NewCommands() []cli.Command {
-	cfgFlags := []cli.Flag{options.Config, options.ConfigFile}
+	cfgFlags := []cli.Flag{options.Config, options.ConfigFile, options.ConsensusWalletPath}
 	cfgFlags = append(cfgFlags, options.Network...)
 	return []cli.Command{{
 		Name:   "vm",


### PR DESCRIPTION
### Problem

close #3179 

### Solution

as per https://github.com/nspcc-dev/neo-go/issues/3179#issuecomment-1785154680

I wasn't sure if it made sense to add `options.RelativePath` here
https://github.com/nspcc-dev/neo-go/blob/8ed6d97085d3229d4faf56a47bbd6cf73c132a76/cli/vm/vm.go#L16

 so I left it out until told otherwise.