### PR TITLE
core, services: fix Designation-dependant service initialisation

### DIFF
--- a/pkg/services/notary/notary.go
+++ b/pkg/services/notary/notary.go
@@ -230,6 +230,13 @@ func (n *Notary) Shutdown() {
 	n.wallet.Close()
 }
 
+// IsAuthorized returns whether Notary service currently is authorized to collect
+// signatures. It returnes true iff designated Notary node's account provided to
+// the Notary service in decrypted state.
+func (n *Notary) IsAuthorized() bool {
+	return n.getAccount() != nil
+}
+
 // OnNewRequest is a callback method which is called after a new notary request is added to the notary request pool.
 func (n *Notary) OnNewRequest(payload *payload.P2PNotaryRequest) {
 	if !n.started.Load() {

--- a/pkg/services/oracle/oracle.go
+++ b/pkg/services/oracle/oracle.go
@@ -206,6 +206,13 @@ func (o *Oracle) Start() {
 	go o.start()
 }
 
+// IsAuthorized returns whether Oracle service currently is authorized to collect
+// signatures. It returns true iff designated Oracle node's account provided to
+// the Oracle service in decrypted state.
+func (o *Oracle) IsAuthorized() bool {
+	return o.getAccount() != nil
+}
+
 func (o *Oracle) start() {
 	o.requestMap <- o.pending // Guaranteed to not block, only AddRequests sends to it.
 	o.pending = nil


### PR DESCRIPTION
1. Initialise services dependant on roles designation based on N+1 block so that Genesis roles extension work properly. There's not much sence to fetch node roles information for the latest persisted block because Designation contract itself makes designated nodes responsible since the next subsequent block.
2. Perform initialisation of StateRoot service with designated StateValidator's node list in the service constructor. There's no need to wait until the next role update event, and it may lead to inaccuraces in service work on SIGHUP/server restart.

Close #3228.