### PR TITLE
neotest: Add contract signer support

### DIFF
--- a/pkg/core/native/native_test/ledger_test.go
+++ b/pkg/core/native/native_test/ledger_test.go
@@ -225,7 +225,7 @@ func TestLedger_GetTransactionSignersInteropAPI(t *testing.T) {
 			},
 		},
 	}}
-	neotest.AddNetworkFee(e.Chain, tx, c.Committee)
+	neotest.AddNetworkFee(t, e.Chain, tx, c.Committee)
 	neotest.AddSystemFee(e.Chain, tx, -1)
 	require.NoError(t, c.Committee.SignTx(e.Chain.GetConfig().Magic, tx))
 	c.AddNewBlock(t, tx)


### PR DESCRIPTION
### Problem
When using another contract for verification in unit tests, the transaction cost is calculated incorrectly.
...

### Solution
To calculate the transaction cost, a test neo-vm is started on which the verification is performed.
...
