### PR TITLE
core: remove UpdateHistory from NativeContract structure

### DIFF
--- a/pkg/core/state/contract.go
+++ b/pkg/core/state/contract.go
@@ -32,7 +32,6 @@ type ContractBase struct {
 // NativeContract holds information about the native contract.
 type NativeContract struct {
 	ContractBase
-	UpdateHistory []uint32 `json:"updatehistory"`
 }
 
 // ToStackItem converts state.Contract to stackitem.Item.


### PR DESCRIPTION
Although it doesn't rais an exception on our side, we still have this unrelevant information in the resulting RPC call response structure. This should be a part of https://github.com/nspcc-dev/neo-go/pull/3212.

Port https://github.com/neo-project/neo-modules/pull/851.