### PR TITLE
Allow complex contract signature schemes in `wallet.Account`

### DIFF
--- a/pkg/neotest/basic.go
+++ b/pkg/neotest/basic.go
@@ -301,8 +301,9 @@ func AddNetworkFee(t testing.TB, bc *core.Blockchain, tx *transaction.Transactio
 	baseFee := bc.GetBaseExecFee()
 	size := io.GetVarSize(tx)
 	for _, sgr := range signers {
-		if csgr, ok := sgr.(ContractSigner); ok {
-			sc, err := csgr.InvocationScript(tx)
+		csgr, ok := sgr.(SingleSigner)
+		if ok && csgr.Account().Contract.InvocationBuilder != nil {
+			sc, err := csgr.Account().Contract.InvocationBuilder(tx)
 			require.NoError(t, err)
 
 			txCopy := *tx

--- a/pkg/rpcclient/actor/maker.go
+++ b/pkg/rpcclient/actor/maker.go
@@ -191,6 +191,14 @@ func (a *Actor) MakeUnsignedUncheckedRun(script []byte, sysFee int64, attrs []tr
 	for i := range a.signers {
 		if !a.signers[i].Account.Contract.Deployed {
 			tx.Scripts[i].VerificationScript = a.signers[i].Account.Contract.Script
+			continue
+		}
+		if build := a.signers[i].Account.Contract.InvocationBuilder; build != nil {
+			invoc, err := build(tx)
+			if err != nil {
+				return nil, fmt.Errorf("building witness for contract signer: %w", err)
+			}
+			tx.Scripts[i].InvocationScript = invoc
 		}
 	}
 	// CalculateNetworkFee doesn't call Hash or Size, only serializes the


### PR DESCRIPTION
Close #3015 

Implement second option from https://github.com/nspcc-dev/neo-go/issues/3015#issuecomment-1546110354
In the first one (interface instead of `wallet.Account`) we still have a problem with network fee calculation: actor modifiers are executed after network fee is calculated and there are no hooks to change invocation script.

This implementation disallows providing signature as an argument (though in a backward compatible way).
It is a restriction, but not a sad one: if we have a private key, we can always add a simple signer and provide its address to `verify()`, which can use `runtime.CheckWitness` to effectively perform the same check (with proper scopes it could be _exactly_ the same).

Also, not sure about the meaning of `CanSign`, so didn't touch it here.

TBH I would remove `func` argument in the `NewContractSigner` in neotest, it introduces a subtle dependency on the condition order in `SignTx`. Other option is to provide an integer but it is also a bit annoying. As an example, there is `wallet.NewContractAccount` which can be used instead of `notary.FakeContractAccount` in complex cases and which _could_ be reused in tests.

We have 2 similar usecases for complex `Verify` scenarios, and in every in test we use constant arguments, could be more concise:
```go
s := neotest.NewContractSigner(e.Hash, func(*transaction.Transaction) []any { return []any{acc.ScriptHash()} })
// could be
s := neotest.NewContractSigner(e.Hash, acc.ScriptHash())
```

Initially I wanted to add type-safe `VerifyAccount` constructors to rpcbinding but is doesn't provide much benefit compared to effort taken.