### PR TITLE
rpcclient: check network initialisation for blocks subscriptions

### DIFF
--- a/pkg/rpcclient/wsclient.go
+++ b/pkg/rpcclient/wsclient.go
@@ -732,6 +732,9 @@ func (c *WSClient) ReceiveBlocks(flt *neorpc.BlockFilter, rcvr chan<- *block.Blo
 	if rcvr == nil {
 		return "", ErrNilNotificationReceiver
 	}
+	if !c.cache.initDone {
+		return "", errNetworkNotInitialized
+	}
 	params := []any{"block_added"}
 	if flt != nil {
 		flt = flt.Copy()


### PR DESCRIPTION
StateRootInHeader depends on it, so we better immediately return error if client is not initialised.

Thanks to @cthulhu-rider for request.
