### PR TITLE
rpc: subscription filters validity check

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -85,7 +85,8 @@ Recognized stream names:
  * `notification_from_execution`
    Filter: `contract` field containing a string with hex-encoded Uint160 (LE
    representation) and/or `name` field containing a string with execution 
-   notification name.
+   notification name which should be a valid UTF-8 string not longer than 
+   32 bytes.
  * `transaction_executed`
    Filter: `state` field containing `HALT` or `FAULT` string for successful
    and failed executions respectively and/or `container` field containing

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -67,11 +67,11 @@ omitted if empty).
 
 Recognized stream names:
  * `block_added`
-   Filter: `primary` as an integer with primary (speaker) node index from
-   ConsensusData and/or `since` field as an integer value with block
-   index starting from which new block notifications will be received and/or
-   `till` field as an integer values containing block index till which new
-   block notifications will be received.
+   Filter: `primary` as an integer with a valid range of 0-255 with 
+   primary (speaker) node index from ConsensusData and/or `since` field as 
+   an integer value with block index starting from which new block 
+   notifications will be received and/or `till` field as an integer values
+   containing block index till which new block notifications will be received.
  * `header_of_added_block`
    Filter: `primary` as an integer with primary (speaker) node index from
    ConsensusData and/or `since` field as an integer value with header

--- a/pkg/neorpc/filters.go
+++ b/pkg/neorpc/filters.go
@@ -11,7 +11,7 @@ type (
 	// since/till the specified index inclusively). nil value treated as missing
 	// filter.
 	BlockFilter struct {
-		Primary *int    `json:"primary,omitempty"`
+		Primary *byte   `json:"primary,omitempty"`
 		Since   *uint32 `json:"since,omitempty"`
 		Till    *uint32 `json:"till,omitempty"`
 	}
@@ -56,7 +56,7 @@ func (f *BlockFilter) Copy() *BlockFilter {
 	}
 	var res = new(BlockFilter)
 	if f.Primary != nil {
-		res.Primary = new(int)
+		res.Primary = new(byte)
 		*res.Primary = *f.Primary
 	}
 	if f.Since != nil {

--- a/pkg/neorpc/filters_test.go
+++ b/pkg/neorpc/filters_test.go
@@ -16,12 +16,12 @@ func TestBlockFilterCopy(t *testing.T) {
 	tf = bf.Copy()
 	require.Equal(t, bf, tf)
 
-	bf.Primary = new(int)
+	bf.Primary = new(byte)
 	*bf.Primary = 42
 
 	tf = bf.Copy()
 	require.Equal(t, bf, tf)
-	*bf.Primary = 100500
+	*bf.Primary = 100
 	require.NotEqual(t, bf, tf)
 
 	bf.Since = new(uint32)

--- a/pkg/neorpc/rpcevent/filter.go
+++ b/pkg/neorpc/rpcevent/filter.go
@@ -42,7 +42,7 @@ func Matches(f Comparator, r Container) bool {
 		} else {
 			b = &r.EventPayload().(*block.Block).Header
 		}
-		primaryOk := filt.Primary == nil || *filt.Primary == int(b.PrimaryIndex)
+		primaryOk := filt.Primary == nil || *filt.Primary == b.PrimaryIndex
 		sinceOk := filt.Since == nil || *filt.Since <= b.Index
 		tillOk := filt.Till == nil || b.Index <= *filt.Till
 		return primaryOk && sinceOk && tillOk

--- a/pkg/neorpc/rpcevent/filter.go
+++ b/pkg/neorpc/rpcevent/filter.go
@@ -13,7 +13,7 @@ type (
 	// filter notifications.
 	Comparator interface {
 		EventID() neorpc.EventID
-		Filter() any
+		Filter() neorpc.SubscriptionFilter
 	}
 	// Container is an interface required from notification event to be able to
 	// pass filter.

--- a/pkg/neorpc/rpcevent/filter_test.go
+++ b/pkg/neorpc/rpcevent/filter_test.go
@@ -18,7 +18,7 @@ import (
 type (
 	testComparator struct {
 		id     neorpc.EventID
-		filter any
+		filter neorpc.SubscriptionFilter
 	}
 	testContainer struct {
 		id  neorpc.EventID
@@ -29,7 +29,7 @@ type (
 func (c testComparator) EventID() neorpc.EventID {
 	return c.id
 }
-func (c testComparator) Filter() any {
+func (c testComparator) Filter() neorpc.SubscriptionFilter {
 	return c.filter
 }
 func (c testContainer) EventID() neorpc.EventID {

--- a/pkg/neorpc/rpcevent/filter_test.go
+++ b/pkg/neorpc/rpcevent/filter_test.go
@@ -40,8 +40,8 @@ func (c testContainer) EventPayload() any {
 }
 
 func TestMatches(t *testing.T) {
-	primary := 1
-	badPrimary := 2
+	primary := byte(1)
+	badPrimary := byte(2)
 	index := uint32(5)
 	badHigherIndex := uint32(6)
 	badLowerIndex := index - 1

--- a/pkg/rpcclient/wsclient.go
+++ b/pkg/rpcclient/wsclient.go
@@ -127,7 +127,7 @@ func (r *blockReceiver) EventID() neorpc.EventID {
 }
 
 // Filter implements neorpc.Comparator interface.
-func (r *blockReceiver) Filter() any {
+func (r *blockReceiver) Filter() neorpc.SubscriptionFilter {
 	if r.filter == nil {
 		return nil
 	}
@@ -174,7 +174,7 @@ func (r *headerOfAddedBlockReceiver) EventID() neorpc.EventID {
 }
 
 // Filter implements neorpc.Comparator interface.
-func (r *headerOfAddedBlockReceiver) Filter() any {
+func (r *headerOfAddedBlockReceiver) Filter() neorpc.SubscriptionFilter {
 	if r.filter == nil {
 		return nil
 	}
@@ -220,7 +220,7 @@ func (r *txReceiver) EventID() neorpc.EventID {
 }
 
 // Filter implements neorpc.Comparator interface.
-func (r *txReceiver) Filter() any {
+func (r *txReceiver) Filter() neorpc.SubscriptionFilter {
 	if r.filter == nil {
 		return nil
 	}
@@ -267,7 +267,7 @@ func (r *executionNotificationReceiver) EventID() neorpc.EventID {
 }
 
 // Filter implements neorpc.Comparator interface.
-func (r *executionNotificationReceiver) Filter() any {
+func (r *executionNotificationReceiver) Filter() neorpc.SubscriptionFilter {
 	if r.filter == nil {
 		return nil
 	}
@@ -314,7 +314,7 @@ func (r *executionReceiver) EventID() neorpc.EventID {
 }
 
 // Filter implements neorpc.Comparator interface.
-func (r *executionReceiver) Filter() any {
+func (r *executionReceiver) Filter() neorpc.SubscriptionFilter {
 	if r.filter == nil {
 		return nil
 	}
@@ -361,7 +361,7 @@ func (r *notaryRequestReceiver) EventID() neorpc.EventID {
 }
 
 // Filter implements neorpc.Comparator interface.
-func (r *notaryRequestReceiver) Filter() any {
+func (r *notaryRequestReceiver) Filter() neorpc.SubscriptionFilter {
 	if r.filter == nil {
 		return nil
 	}
@@ -766,6 +766,11 @@ func (c *WSClient) makeWsRequest(r *neorpc.Request) (*neorpc.Response, error) {
 func (c *WSClient) performSubscription(params []any, rcvr notificationReceiver) (string, error) {
 	var resp string
 
+	if flt := rcvr.Filter(); flt != nil {
+		if err := flt.IsValid(); err != nil {
+			return "", err
+		}
+	}
 	if err := c.performRequest("subscribe", params, &resp); err != nil {
 		return "", err
 	}
@@ -872,11 +877,6 @@ func (c *WSClient) ReceiveExecutions(flt *neorpc.ExecutionFilter, rcvr chan<- *s
 	}
 	params := []any{"transaction_executed"}
 	if flt != nil {
-		if flt.State != nil {
-			if *flt.State != "HALT" && *flt.State != "FAULT" {
-				return "", errors.New("bad state parameter")
-			}
-		}
 		flt = flt.Copy()
 		params = append(params, *flt)
 	}

--- a/pkg/rpcclient/wsclient_test.go
+++ b/pkg/rpcclient/wsclient_test.go
@@ -381,7 +381,7 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 	}{
 		{"block header primary",
 			func(t *testing.T, wsc *WSClient) {
-				primary := 3
+				primary := byte(3)
 				_, err := wsc.ReceiveHeadersOfAddedBlocks(&neorpc.BlockFilter{Primary: &primary}, make(chan *block.Header))
 				require.NoError(t, err)
 			},
@@ -389,7 +389,7 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 				param := p.Value(1)
 				filt := new(neorpc.BlockFilter)
 				require.NoError(t, json.Unmarshal(param.RawMessage, filt))
-				require.Equal(t, 3, *filt.Primary)
+				require.Equal(t, byte(3), *filt.Primary)
 				require.Equal(t, (*uint32)(nil), filt.Since)
 				require.Equal(t, (*uint32)(nil), filt.Till)
 			},
@@ -404,7 +404,7 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 				param := p.Value(1)
 				filt := new(neorpc.BlockFilter)
 				require.NoError(t, json.Unmarshal(param.RawMessage, filt))
-				require.Equal(t, (*int)(nil), filt.Primary)
+				require.Equal(t, (*byte)(nil), filt.Primary)
 				require.Equal(t, uint32(3), *filt.Since)
 				require.Equal(t, (*uint32)(nil), filt.Till)
 			},
@@ -419,7 +419,7 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 				param := p.Value(1)
 				filt := new(neorpc.BlockFilter)
 				require.NoError(t, json.Unmarshal(param.RawMessage, filt))
-				require.Equal(t, (*int)(nil), filt.Primary)
+				require.Equal(t, (*byte)(nil), filt.Primary)
 				require.Equal(t, (*uint32)(nil), filt.Since)
 				require.Equal(t, (uint32)(3), *filt.Till)
 			},
@@ -428,7 +428,7 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			func(t *testing.T, wsc *WSClient) {
 				var (
 					since   uint32 = 3
-					primary        = 2
+					primary        = byte(2)
 					till    uint32 = 5
 				)
 				_, err := wsc.ReceiveHeadersOfAddedBlocks(&neorpc.BlockFilter{
@@ -442,14 +442,14 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 				param := p.Value(1)
 				filt := new(neorpc.BlockFilter)
 				require.NoError(t, json.Unmarshal(param.RawMessage, filt))
-				require.Equal(t, 2, *filt.Primary)
+				require.Equal(t, byte(2), *filt.Primary)
 				require.Equal(t, uint32(3), *filt.Since)
 				require.Equal(t, uint32(5), *filt.Till)
 			},
 		},
 		{"blocks primary",
 			func(t *testing.T, wsc *WSClient) {
-				primary := 3
+				primary := byte(3)
 				_, err := wsc.ReceiveBlocks(&neorpc.BlockFilter{Primary: &primary}, make(chan *block.Block))
 				require.NoError(t, err)
 			},
@@ -457,7 +457,7 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 				param := p.Value(1)
 				filt := new(neorpc.BlockFilter)
 				require.NoError(t, json.Unmarshal(param.RawMessage, filt))
-				require.Equal(t, 3, *filt.Primary)
+				require.Equal(t, byte(3), *filt.Primary)
 				require.Equal(t, (*uint32)(nil), filt.Since)
 				require.Equal(t, (*uint32)(nil), filt.Till)
 			},
@@ -472,7 +472,7 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 				param := p.Value(1)
 				filt := new(neorpc.BlockFilter)
 				require.NoError(t, json.Unmarshal(param.RawMessage, filt))
-				require.Equal(t, (*int)(nil), filt.Primary)
+				require.Equal(t, (*byte)(nil), filt.Primary)
 				require.Equal(t, uint32(3), *filt.Since)
 				require.Equal(t, (*uint32)(nil), filt.Till)
 			},
@@ -487,7 +487,7 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 				param := p.Value(1)
 				filt := new(neorpc.BlockFilter)
 				require.NoError(t, json.Unmarshal(param.RawMessage, filt))
-				require.Equal(t, (*int)(nil), filt.Primary)
+				require.Equal(t, (*byte)(nil), filt.Primary)
 				require.Equal(t, (*uint32)(nil), filt.Since)
 				require.Equal(t, (uint32)(3), *filt.Till)
 			},
@@ -496,7 +496,7 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 			func(t *testing.T, wsc *WSClient) {
 				var (
 					since   uint32 = 3
-					primary        = 2
+					primary        = byte(2)
 					till    uint32 = 5
 				)
 				_, err := wsc.ReceiveBlocks(&neorpc.BlockFilter{
@@ -510,7 +510,7 @@ func TestWSFilteredSubscriptions(t *testing.T) {
 				param := p.Value(1)
 				filt := new(neorpc.BlockFilter)
 				require.NoError(t, json.Unmarshal(param.RawMessage, filt))
-				require.Equal(t, 2, *filt.Primary)
+				require.Equal(t, byte(2), *filt.Primary)
 				require.Equal(t, uint32(3), *filt.Since)
 				require.Equal(t, uint32(5), *filt.Till)
 			},

--- a/pkg/services/rpcsrv/client_test.go
+++ b/pkg/services/rpcsrv/client_test.go
@@ -2113,9 +2113,9 @@ func TestWSClient_SubscriptionsCompat(t *testing.T) {
 	blocks := getTestBlocks(t)
 	bCount := uint32(0)
 
-	getData := func(t *testing.T) (*block.Block, int, util.Uint160, string, string) {
+	getData := func(t *testing.T) (*block.Block, byte, util.Uint160, string, string) {
 		b1 := blocks[bCount]
-		primary := int(b1.PrimaryIndex)
+		primary := b1.PrimaryIndex
 		tx := b1.Transactions[0]
 		sender := tx.Sender()
 		ntfName := "Transfer"

--- a/pkg/services/rpcsrv/subscription.go
+++ b/pkg/services/rpcsrv/subscription.go
@@ -28,7 +28,7 @@ type (
 	// feed stores subscriber's desired event ID with filter.
 	feed struct {
 		event  neorpc.EventID
-		filter any
+		filter neorpc.SubscriptionFilter
 	}
 )
 
@@ -38,7 +38,7 @@ func (f feed) EventID() neorpc.EventID {
 }
 
 // Filter implements neorpc.EventComparator interface and returns notification filter.
-func (f feed) Filter() any {
+func (f feed) Filter() neorpc.SubscriptionFilter {
 	return f.filter
 }
 


### PR DESCRIPTION
Change BlockFilter Primary field from int to byte. Additional check of filters parameters added for filter validation.

Closes: #3241