### PR TITLE
services: improve notary service logging

### DIFF
--- a/pkg/services/notary/notary.go
+++ b/pkg/services/notary/notary.go
@@ -480,7 +480,9 @@ func (n *Notary) newTxCallbackLoop() {
 			n.reqMtx.Unlock()
 			err := n.onTransaction(tx.tx)
 			if err != nil {
-				n.Config.Log.Error("new transaction callback finished with error", zap.Error(err))
+				n.Config.Log.Error("new transaction callback finished with error",
+					zap.Error(err),
+					zap.Bool("is main", isMain))
 				continue
 			}
 


### PR DESCRIPTION
Let the user know whether it's main or fallback transaction that failed to be relayed to the network.
