### PR TITLE
config: fix TestGetConfigFromContext on Windows

### DIFF
--- a/cli/server/testdata/protocol.testnet.windows.yml
+++ b/cli/server/testdata/protocol.testnet.windows.yml
@@ -1,0 +1,96 @@
+ProtocolConfiguration:
+  Magic: 894710606
+  MaxBlockSize: 2097152
+  MaxBlockSystemFee: 150000000000
+  MaxTraceableBlocks: 2102400
+  MaxTransactionsPerBlock: 5000
+  InitialGASSupply: 52000000
+  TimePerBlock: 15s
+  MemPoolSize: 50000
+  StandbyCommittee:
+    - 023e9b32ea89b94d066e649b124fd50e396ee91369e8e2a6ae1b11c170d022256d
+    - 03009b7540e10f2562e5fd8fac9eaec25166a58b26e412348ff5a86927bfac22a2
+    - 02ba2c70f5996f357a43198705859fae2cfea13e1172962800772b3d588a9d4abd
+    - 03408dcd416396f64783ac587ea1e1593c57d9fea880c8a6a1920e92a259477806
+    - 02a7834be9b32e2981d157cb5bbd3acb42cfd11ea5c3b10224d7a44e98c5910f1b
+    - 0214baf0ceea3a66f17e7e1e839ea25fd8bed6cd82e6bb6e68250189065f44ff01
+    - 030205e9cefaea5a1dfc580af20c8d5aa2468bb0148f1a5e4605fc622c80e604ba
+    - 025831cee3708e87d78211bec0d1bfee9f4c85ae784762f042e7f31c0d40c329b8
+    - 02cf9dc6e85d581480d91e88e8cbeaa0c153a046e89ded08b4cefd851e1d7325b5
+    - 03840415b0a0fcf066bcc3dc92d8349ebd33a6ab1402ef649bae00e5d9f5840828
+    - 026328aae34f149853430f526ecaa9cf9c8d78a4ea82d08bdf63dd03c4d0693be6
+    - 02c69a8d084ee7319cfecf5161ff257aa2d1f53e79bf6c6f164cff5d94675c38b3
+    - 0207da870cedb777fceff948641021714ec815110ca111ccc7a54c168e065bda70
+    - 035056669864feea401d8c31e447fb82dd29f342a9476cfd449584ce2a6165e4d7
+    - 0370c75c54445565df62cfe2e76fbec4ba00d1298867972213530cae6d418da636
+    - 03957af9e77282ae3263544b7b2458903624adc3f5dee303957cb6570524a5f254
+    - 03d84d22b8753cf225d263a3a782a4e16ca72ef323cfde04977c74f14873ab1e4c
+    - 02147c1b1d5728e1954958daff2f88ee2fa50a06890a8a9db3fa9e972b66ae559f
+    - 03c609bea5a4825908027e4ab217e7efc06e311f19ecad9d417089f14927a173d5
+    - 0231edee3978d46c335e851c76059166eb8878516f459e085c0dd092f0f1d51c21
+    - 03184b018d6b2bc093e535519732b3fd3f7551c8cffaf4621dd5a0b89482ca66c9
+  ValidatorsCount: 7
+  SeedList:
+    - seed1t5.neo.org:20333
+    - seed2t5.neo.org:20333
+    - seed3t5.neo.org:20333
+    - seed4t5.neo.org:20333
+    - seed5t5.neo.org:20333
+  VerifyTransactions: false
+  P2PSigExtensions: false
+  Hardforks:
+    Aspidochelone: 210000
+    Basilisk: 2680000
+
+ApplicationConfiguration:
+  SkipBlockVerification: false
+  DBConfiguration:
+    Type: "leveldb" #other options: 'inmemory','boltdb'
+    # DB type options. Uncomment those you need in case you want to switch DB type.
+    LevelDBOptions:
+      DataDirectoryPath: ".\\chains\\testnet"
+  P2P:
+    Addresses:
+      - ":20333" # in form of "[host]:[port][:announcedPort]"
+    DialTimeout: 3s
+    ProtoTickInterval: 2s
+    PingInterval: 30s
+    PingTimeout: 90s
+    MaxPeers: 100
+    AttemptConnPeers: 20
+    MinPeers: 10
+  Relay: true
+  Consensus:
+    Enabled: false
+    UnlockWallet:
+      Path: "C:\\someFolder\\cn_wallet.json"
+      Password: "pass"
+  Oracle:
+    Enabled: false
+    AllowedContentTypes:
+      - application/json
+  P2PNotary:
+    Enabled: false
+    UnlockWallet:
+      Path: "C:\\someFolder\\notary_wallet.json"
+      Password: "pass"
+  RPC:
+    Enabled: true
+    Addresses:
+      - ":20332"
+    MaxGasInvoke: 15
+    EnableCORSWorkaround: false
+    TLSConfig:
+      Enabled: false
+      Addresses:
+        - ":20331"
+      CertFile: serv.crt
+      KeyFile: serv.key
+  Prometheus:
+    Enabled: true
+    Addresses:
+      - ":2112"
+  Pprof:
+    Enabled: false
+    Addresses:
+      - ":2113"


### PR DESCRIPTION
Failing test caused by hardcoded relative path check which is different for Windows.

Close #3305