### PR TITLE
services: fix logging data race after shutdown

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -498,7 +498,7 @@ func startServer(ctx *cli.Context) error {
 	rpcServer := rpcsrv.New(chain, cfg.ApplicationConfiguration.RPC, serv, oracleSrv, log, errChan)
 	serv.AddService(&rpcServer)
 
-	go serv.Start()
+	serv.Start()
 	if !cfg.ApplicationConfiguration.RPC.StartWhenSynchronized {
 		// Run RPC server in a separate routine. This is necessary to avoid a potential
 		// deadlock: Start() can write errors to errChan which is not yet read in the

--- a/internal/testcli/executor.go
+++ b/internal/testcli/executor.go
@@ -164,7 +164,7 @@ func NewTestChain(t *testing.T, f func(*config.Config), run bool) (*core.Blockch
 	})
 	require.NoError(t, err)
 	netSrv.AddConsensusService(cons, cons.OnPayload, cons.OnTransaction)
-	go netSrv.Start()
+	netSrv.Start()
 	errCh := make(chan error, 2)
 	rpcServer := rpcsrv.New(chain, cfg.ApplicationConfiguration.RPC, netSrv, nil, logger, errCh)
 	rpcServer.Start()

--- a/pkg/consensus/consensus.go
+++ b/pkg/consensus/consensus.go
@@ -295,6 +295,7 @@ func (s *service) Shutdown() {
 			s.wallet.Close()
 		}
 	}
+	_ = s.log.Sync()
 }
 
 func (s *service) eventLoop() {

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1447,6 +1447,7 @@ func (bc *Blockchain) Close() {
 	close(bc.stopCh)
 	<-bc.runToExitCh
 	bc.addLock.Unlock()
+	_ = bc.log.Sync()
 }
 
 // AddBlock accepts successive block for the Blockchain, verifies it and

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -320,6 +320,8 @@ func (s *Server) Shutdown() {
 	}
 	close(s.quit)
 	<-s.relayFin
+
+	_ = s.log.Sync()
 }
 
 // AddService allows to add a service to be started/stopped by Server.

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -296,7 +296,7 @@ func (s *Server) Start() {
 }
 
 // Shutdown disconnects all peers and stops listening. Calling it twice is a no-op,
-// once stopped the same intance of the Server can't be started again by calling Start.
+// once stopped the same instance of the Server can't be started again by calling Start.
 func (s *Server) Shutdown() {
 	if !s.started.CompareAndSwap(true, false) {
 		return

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -262,7 +262,7 @@ func (s *Server) ID() uint32 {
 }
 
 // Start will start the server and its underlying transport. Calling it twice
-// is an error.
+// is an error. Caller should wait for Start to finish for normal server operation.
 func (s *Server) Start() {
 	s.log.Info("node started",
 		zap.Uint32("blockHeight", s.chain.BlockHeight()),
@@ -285,7 +285,7 @@ func (s *Server) Start() {
 	setServerAndNodeVersions(s.UserAgent, strconv.FormatUint(uint64(s.id), 10))
 	setNeoGoVersion(config.Version)
 	setSeverID(strconv.FormatUint(uint64(s.id), 10))
-	s.run()
+	go s.run()
 }
 
 // Shutdown disconnects all peers and stops listening. Calling it twice is an error,

--- a/pkg/network/server_test.go
+++ b/pkg/network/server_test.go
@@ -90,7 +90,7 @@ func TestServerStartAndShutdown(t *testing.T) {
 	t.Run("no consensus", func(t *testing.T) {
 		s := newTestServer(t, ServerConfig{})
 
-		go s.Start()
+		s.Start()
 		p := newLocalPeer(t, s)
 		s.register <- p
 		require.Eventually(t, func() bool { return 1 == s.PeerCount() }, time.Second, time.Millisecond*10)
@@ -110,7 +110,7 @@ func TestServerStartAndShutdown(t *testing.T) {
 		cons := new(fakeConsensus)
 		s.AddConsensusService(cons, cons.OnPayload, cons.OnTransaction)
 
-		go s.Start()
+		s.Start()
 		p := newLocalPeer(t, s)
 		s.register <- p
 
@@ -312,7 +312,7 @@ func TestServerNotSendsVerack(t *testing.T) {
 	s.id = 1
 	finished := make(chan struct{})
 	go func() {
-		s.run()
+		go s.run()
 		close(finished)
 	}()
 	t.Cleanup(func() {
@@ -389,7 +389,7 @@ func startTestServer(t *testing.T, protocolCfg ...func(*config.Blockchain)) *Ser
 }
 
 func startWithCleanup(t *testing.T, s *Server) {
-	go s.Start()
+	s.Start()
 	t.Cleanup(func() {
 		s.Shutdown()
 	})

--- a/pkg/services/metrics/metrics.go
+++ b/pkg/services/metrics/metrics.go
@@ -75,4 +75,5 @@ func (ms *Service) ShutDown() {
 			ms.log.Error("can't shut service down", zap.String("endpoint", srv.Addr), zap.Error(err))
 		}
 	}
+	_ = ms.log.Sync()
 }

--- a/pkg/services/notary/notary.go
+++ b/pkg/services/notary/notary.go
@@ -175,13 +175,13 @@ func (n *Notary) Start() {
 		return
 	}
 	n.Config.Log.Info("starting notary service")
-	n.Config.Chain.SubscribeForBlocks(n.blocksCh)
-	n.mp.SubscribeForTransactions(n.reqCh)
 	go n.newTxCallbackLoop()
 	go n.mainLoop()
 }
 
 func (n *Notary) mainLoop() {
+	n.Config.Chain.SubscribeForBlocks(n.blocksCh)
+	n.mp.SubscribeForTransactions(n.reqCh)
 mainloop:
 	for {
 		select {

--- a/pkg/services/notary/notary.go
+++ b/pkg/services/notary/notary.go
@@ -228,6 +228,7 @@ func (n *Notary) Shutdown() {
 	close(n.stopCh)
 	<-n.done
 	n.wallet.Close()
+	_ = n.Config.Log.Sync()
 }
 
 // IsAuthorized returns whether Notary service currently is authorized to collect

--- a/pkg/services/oracle/oracle.go
+++ b/pkg/services/oracle/oracle.go
@@ -192,6 +192,7 @@ func (o *Oracle) Shutdown() {
 	o.ResponseHandler.Shutdown()
 	<-o.done
 	o.wallet.Close()
+	_ = o.Log.Sync()
 }
 
 // Start runs the oracle service in a separate goroutine.

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -482,6 +482,7 @@ func (s *Server) Shutdown() {
 
 	// Wait for handleSubEvents to finish.
 	<-s.subEventsToExitCh
+	_ = s.log.Sync()
 }
 
 // SetOracleHandler allows to update oracle handler used by the Server.

--- a/pkg/services/rpcsrv/subscription_test.go
+++ b/pkg/services/rpcsrv/subscription_test.go
@@ -99,7 +99,7 @@ func TestSubscriptions(t *testing.T) {
 	defer chain.Close()
 	defer rpcSrv.Shutdown()
 
-	go rpcSrv.coreServer.Start()
+	rpcSrv.coreServer.Start()
 	defer rpcSrv.coreServer.Shutdown()
 
 	for _, feed := range subFeeds {
@@ -395,7 +395,7 @@ func TestFilteredNotaryRequestSubscriptions(t *testing.T) {
 	}
 
 	chain, rpcSrv, c, respMsgs, finishedFlag := initCleanServerAndWSClient(t)
-	go rpcSrv.coreServer.Start()
+	rpcSrv.coreServer.Start()
 
 	defer chain.Close()
 	defer rpcSrv.Shutdown()

--- a/pkg/services/stateroot/validators.go
+++ b/pkg/services/stateroot/validators.go
@@ -77,6 +77,7 @@ func (s *service) Shutdown() {
 	if s.wallet != nil {
 		s.wallet.Close()
 	}
+	_ = s.log.Sync()
 }
 
 func (s *service) signAndSend(r *state.MPTRoot) error {

--- a/pkg/services/stateroot/validators.go
+++ b/pkg/services/stateroot/validators.go
@@ -29,11 +29,11 @@ func (s *service) Start() {
 		return
 	}
 	s.log.Info("starting state validation service")
-	s.chain.SubscribeForBlocks(s.blockCh)
 	go s.run()
 }
 
 func (s *service) run() {
+	s.chain.SubscribeForBlocks(s.blockCh)
 runloop:
 	for {
 		select {


### PR DESCRIPTION
The problem is writing to logs after the end of the test execution.
Added sync logs for every service separately to provide the ability to have a custom logger for each service. 
Data race is caused by missing synchronization channels in the network server. Shutdown doesn't wait for all goroutines to finish properly.

 Close #2973
 Close #2974
 Close #3112
