### PR TITLE
smartcontract: fix go version mismatch in TestContractInitAndCompile

### DIFF
--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -374,6 +374,9 @@ func initSmartContract(ctx *cli.Context) error {
 	}
 
 	gm := []byte("module " + contractName + `
+
+go 1.19
+
 require (
 	github.com/nspcc-dev/neo-go/pkg/interop ` + ver + `
 )`)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/nspcc-dev/neo-go
 
+go 1.19
+
 require (
 	github.com/chzyer/readline v1.5.1
 	github.com/consensys/gnark v0.9.1
@@ -76,5 +78,3 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-go 1.19


### PR DESCRIPTION
It is necessary to update dependencies in the test for go1.18 and above to match with the interop module.

Close #3152