### PR TITLE
vm: fix exit in vm tests

### DIFF
--- a/cli/vm/cli_test.go
+++ b/cli/vm/cli_test.go
@@ -681,6 +681,7 @@ func TestLoad_RunWithCALLT(t *testing.T) {
 		e.runProg(t,
 			"loaddeployed "+cH.StringLE()+" -- NbrUYaZgyhSkNoRo9ugRyEMdUZxrhkNaWB:Global", // the contract's owner got from the contract's code.
 			"run destroy",
+			"exit",
 		)
 		e.checkNextLine(t, "READY: loaded \\d* instructions")
 		e.checkStack(t) // Nothing on stack, successful execution.


### PR DESCRIPTION
 t.TempDir calls t.Cleanup while the levelDB file is still open.

Close #3154
