### PR TITLE
.github: use minimum required Go version from go.mod

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:


### PR DESCRIPTION
For linter job only, port
https://github.com/nspcc-dev/neofs-contract/pull/389/commits/e0ec4d24cb992232935a17b59c09927cbc842444.