### PR TITLE
rpcsrv: support Map parameter in `invokefunction` RPC handler

### DIFF
--- a/pkg/services/rpcsrv/params/param.go
+++ b/pkg/services/rpcsrv/params/param.go
@@ -34,6 +34,13 @@ type (
 		Type  smartcontract.ParamType `json:"type"`
 		Value Param                   `json:"value"`
 	}
+
+	// FuncParamKV represents a pair of function argument parameters
+	// a slice of which is stored in FuncParam of [smartcontract.MapType] type.
+	FuncParamKV struct {
+		Key   FuncParam `json:"key"`
+		Value FuncParam `json:"value"`
+	}
 )
 
 var (
@@ -356,6 +363,21 @@ func (p *Param) GetFuncParam() (FuncParam, error) {
 	fp := FuncParam{}
 	err := json.Unmarshal(p.RawMessage, &fp)
 	return fp, err
+}
+
+// GetFuncParamPair returns a pair of function call parameters.
+func (p *Param) GetFuncParamPair() (FuncParamKV, error) {
+	if p == nil {
+		return FuncParamKV{}, errMissingParameter
+	}
+	// This one doesn't need to be cached, it's used only once.
+	fpp := FuncParamKV{}
+	err := json.Unmarshal(p.RawMessage, &fpp)
+	if err != nil {
+		return FuncParamKV{}, err
+	}
+
+	return fpp, nil
 }
 
 // GetBytesHex returns a []byte value of the parameter if

--- a/pkg/services/rpcsrv/params/param_test.go
+++ b/pkg/services/rpcsrv/params/param_test.go
@@ -426,6 +426,48 @@ func TestParamGetFuncParam(t *testing.T) {
 	require.NotNil(t, err)
 }
 
+func TestParamGetFuncParamPair(t *testing.T) {
+	fp := FuncParam{
+		Type:  smartcontract.MapType,
+		Value: Param{RawMessage: []byte(`[{"key": {"type": "String", "value": "key1"}, "value": {"type": "Integer", "value": 123}}, {"key": {"type": "String", "value": "key2"}, "value": {"type": "Integer", "value": 456}}]`)},
+	}
+	p := Param{RawMessage: []byte(`{"type": "Map", "value": [{"key": {"type": "String", "value": "key1"}, "value": {"type": "Integer", "value": 123}}, {"key": {"type": "String", "value": "key2"}, "value": {"type": "Integer", "value": 456}}]}`)}
+	newfp, err := p.GetFuncParam()
+	assert.Equal(t, fp, newfp)
+	require.NoError(t, err)
+
+	kvs, err := newfp.Value.GetArray()
+	require.NoError(t, err)
+
+	p1, err := kvs[0].GetFuncParamPair()
+	require.NoError(t, err)
+
+	fp1Key := FuncParam{
+		Type:  smartcontract.StringType,
+		Value: Param{RawMessage: []byte(`"key1"`)},
+	}
+	fp1Value := FuncParam{
+		Type:  smartcontract.IntegerType,
+		Value: Param{RawMessage: []byte(`123`)},
+	}
+	assert.Equal(t, fp1Key, p1.Key)
+	assert.Equal(t, fp1Value, p1.Value)
+
+	p2, err := kvs[1].GetFuncParamPair()
+	require.NoError(t, err)
+
+	fp2Key := FuncParam{
+		Type:  smartcontract.StringType,
+		Value: Param{RawMessage: []byte(`"key2"`)},
+	}
+	fp2Value := FuncParam{
+		Type:  smartcontract.IntegerType,
+		Value: Param{RawMessage: []byte(`456`)},
+	}
+	assert.Equal(t, fp2Key, p2.Key)
+	assert.Equal(t, fp2Value, p2.Value)
+}
+
 func TestParamGetBytesHex(t *testing.T) {
 	in := "602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7"
 	inb, _ := hex.DecodeString(in)

--- a/pkg/services/rpcsrv/params/tx_builder_test.go
+++ b/pkg/services/rpcsrv/params/tx_builder_test.go
@@ -124,6 +124,17 @@ func TestExpandArrayIntoScript(t *testing.T) {
 			Input:    []Param{{RawMessage: []byte(`{"type": "Integer", "value": "` + bi.String() + `"}`)}},
 			Expected: append([]byte{byte(opcode.PUSHINT256)}, rawInt...),
 		},
+		{
+			Input: []Param{{RawMessage: []byte(`{"type": "Map", "value": [{"key": {"type": "String", "value": "a" }, "value": {"type": "Integer", "value": 1}}, {"key": {"type": "String", "value": "b"}, "value": {"type": "Integer", "value": 2}}]}`)}},
+			Expected: []byte{
+				byte(opcode.PUSH2),                   // value of element #2
+				byte(opcode.PUSHDATA1), 1, byte('b'), // key of element #2
+				byte(opcode.PUSH1),                   // value of element #1
+				byte(opcode.PUSHDATA1), 1, byte('a'), // key of element #1
+				byte(opcode.PUSH2), // map len
+				byte(opcode.PACKMAP),
+			},
+		},
 	}
 	for _, c := range testCases {
 		script := io.NewBufBinWriter()
@@ -141,6 +152,12 @@ func TestExpandArrayIntoScript(t *testing.T) {
 		{
 			{RawMessage: []byte(`{"type": "Integer", "value": "` +
 				new(big.Int).Lsh(big.NewInt(1), 255).String() + `"}`)},
+		},
+		{
+			{RawMessage: []byte(`{"type": "Map", "value": [{"key": {"type": "InvalidT", "value": "a" }, "value": {"type": "Integer", "value": 1}}]}`)},
+		},
+		{
+			{RawMessage: []byte(`{"type": "Map", "value": [{"key": {"type": "String", "value": "a" }, "value": {"type": "Integer", "value": "not-an-int"}}]}`)},
 		},
 	}
 	for _, c := range errorCases {


### PR DESCRIPTION
We have smartcontract.ParameterPair structure that can be properly marshalled and passed to RPC server as an element of smartcontract.Map structure. However, RPC server can't unmarshal map values properly without this change.

This change is compatible with C# node.