### PR TITLE
workflows: workaround Go 1.22 coverage problem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,7 @@ jobs:
 
     env:
       CGO_ENABLED: 0
+      GOEXPERIMENT: nocoverageredesign
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
See https://github.com/golang/go/issues/65653, the fix can be postponed up to Go 1.23 and we need green.
