### PR TITLE
workflows: give tests more time

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
           cache: true
 
       - name: Write coverage profile
-        run: go test -v ./... -coverprofile=./coverage.txt -covermode=atomic -coverpkg=./pkg...,./cli/...
+        run: go test -timeout 15m -v ./... -coverprofile=./coverage.txt -covermode=atomic -coverpkg=./pkg...,./cli/...
 
       - name: Upload coverage results to Codecov
         uses: codecov/codecov-action@v3
@@ -150,4 +150,4 @@ jobs:
           go-version: '${{ matrix.go_versions }}'
 
       - name: Run tests
-        run: go test -v -race ./...
+        run: go test -timeout 15m -v -race ./...


### PR DESCRIPTION
We have more and more timeouts happening for test runs, so 10m is not enough for busy GH machines sometime. I think we can just give them a bit more time.

Refs. #2379 though.