### PR TITLE
rpcsrv: close idle client connections in doRPCCallOverHTTP

### DIFF
--- a/pkg/services/rpcsrv/server_test.go
+++ b/pkg/services/rpcsrv/server_test.go
@@ -3464,6 +3464,7 @@ func doRPCCallOverHTTP(rpcCall string, url string, t *testing.T) []byte {
 	body, err := gio.ReadAll(resp.Body)
 	resp.Body.Close()
 	assert.NoErrorf(t, err, "could not read response from the request: %s", rpcCall)
+	cl.CloseIdleConnections()
 	return bytes.TrimSpace(body)
 }
 


### PR DESCRIPTION
This doesn't fix anything, but why not (at least let's see how it behaves on GH).

Just FYI, I've also tried
```patch
--- a/pkg/services/rpcsrv/server_test.go
+++ b/pkg/services/rpcsrv/server_test.go
@@ -2223,7 +2223,16 @@ var rpcTestCases = map[string][]rpcTestCase{
 
 func TestRPC(t *testing.T) {
        t.Run("http", func(t *testing.T) {
-               testRPCProtocol(t, doRPCCallOverHTTP)
+               cl := http.Client{Timeout: time.Second}
+               testRPCProtocol(t, func(rpcCall string, url string, t *testing.T) []byte {
+                       resp, err := cl.Post(url, "application/json", strings.NewReader(rpcCall))
+                       require.NoErrorf(t, err, "could not make a POST request")
+                       body, err := gio.ReadAll(resp.Body)
+                       resp.Body.Close()
+                       assert.NoErrorf(t, err, "could not read response from the request: %s", rpcCall)
+                       return bytes.TrimSpace(body)
+               })
+               cl.CloseIdleConnections()
        })
 
        t.Run("websocket", func(t *testing.T) {
```
as optimization, but it doesn't affect test time in any way.