### PR TITLE
rpcclient: return FaultException in checkResOk if any

### DIFF
--- a/pkg/rpcclient/unwrap/unwrap.go
+++ b/pkg/rpcclient/unwrap/unwrap.go
@@ -401,6 +401,9 @@ func checkResOK(r *result.Invoke, err error) error {
 	if r.State != vmstate.Halt.String() {
 		return fmt.Errorf("invocation failed: %s", r.FaultException)
 	}
+	if r.FaultException != "" {
+		return fmt.Errorf("inconsistent result, HALTed with exception: %s", r.FaultException)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Problem

Consider this test.
```golang
func TestItem(t *testing.T) {
	bigSlice := stackitem.NewByteArray(make([]byte, stackitem.MaxSize/2))
	arr := stackitem.NewArray([]stackitem.Item{bigSlice, bigSlice})
	res := &result.Invoke{
		State:          "HALT",
		GasConsumed:    237626000,
		Script:         []byte{10},
		Stack:          []stackitem.Item{arr},
		FaultException: "",
		Notifications:  []state.NotificationEvent{},
	}
	data, err := json.Marshal(res)
	require.NoError(t, err)

	var received result.Invoke
	require.NoError(t, json.Unmarshal(data, &received))

	_, err = Item(&received, nil)
	require.True(t, len(received.FaultException) != 0)
	require.Contains(t, err.Error(), received.FaultException)
}
```

It fails with
```
--- FAIL: TestItem (0.00s)
    /repo/neo-go/pkg/rpcclient/unwrap/unwrap_test.go:204: 
        	Error Trace:	/repo/neo-go/pkg/rpcclient/unwrap/unwrap_test.go:204
        	Error:      	"result stack is empty" does not contain "json error: too big: size"
        	Test:       	TestItem
```

That is because in `checkResOk` checks only VM state which is HALT https://github.com/nspcc-dev/neo-go/blob/9c83beffbb69a8d8a455050cfbba6aeb62d9676b/pkg/rpcclient/unwrap/unwrap.go#L401

## Solution
Communicate the error precisely, otherwise it leads to hard-to-debug failures, requiring moderate knowledge of neo-go internals (it is not obvious that `result stack is empty` just _cannot_ happen with good contracts, unless you know how VM works).