### PR TITLE
rpcsrv: fix RPC error codes proposal compatibility

### DIFF
--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -2657,7 +2657,7 @@ func getRelayResult(err error, hash util.Uint256) (any, *neorpc.Error) {
 		return nil, neorpc.WrapErrorWithData(neorpc.ErrInsufficientNetworkFee, err.Error())
 	case errors.Is(err, core.ErrInvalidAttribute):
 		return nil, neorpc.WrapErrorWithData(neorpc.ErrInvalidAttribute, err.Error())
-	case errors.Is(err, core.ErrInsufficientFunds):
+	case errors.Is(err, core.ErrMemPoolConflict):
 		return nil, neorpc.WrapErrorWithData(neorpc.ErrInsufficientFunds, err.Error())
 	case errors.Is(err, core.ErrInvalidSignature):
 		return nil, neorpc.WrapErrorWithData(neorpc.ErrInvalidSignature, err.Error())

--- a/pkg/services/rpcsrv/server_test.go
+++ b/pkg/services/rpcsrv/server_test.go
@@ -3380,7 +3380,7 @@ func newTxWithParams(t *testing.T, chain *core.Blockchain, code opcode.Opcode, v
 
 	height := chain.BlockHeight()
 	tx := transaction.New([]byte{byte(code)}, 0)
-	tx.Nonce = height + 1
+	tx.Nonce = uint32(random.Int(0, math.MaxUint32))
 	tx.ValidUntilBlock = height + validUntilIncr
 	tx.Signers = []transaction.Signer{{Account: acc0.PrivateKey().GetScriptHash()}}
 	tx.SystemFee = systemFee


### PR DESCRIPTION
### Problem

Implementation doesn't match https://github.com/neo-project/proposals/pull/156 wrt mempool-related transaction fee check on submitting new transaction to the node. Thanks to @carpawell for pointing that out.

### Solution

Fix the implementation.

@roman-khimov, I'd like to highlight: whereas it's quite easy to fix this compatibility problem on our side, C# node has the same divergence from the standard and requires more changes to fix it: `TransactionVerificationContext.CheckTransaction` should be adjusted to return some new special error, this error should be detached from `VerifyResult.InsufficientFunds` and ported to other components (ref. https://github.com/neo-project/neo/blob/b05501af882a0d1f2a1a7841c6ddc4d0504e5fc1/src/Neo/Network/P2P/Payloads/Transaction.cs#L368).

I may port it to C# or create an issue about it, what would we prefer?