### PR TITLE
rpcsrv: fix insufficient funds use

### DIFF
--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -2657,7 +2657,7 @@ func getRelayResult(err error, hash util.Uint256) (any, *neorpc.Error) {
 		return nil, neorpc.WrapErrorWithData(neorpc.ErrInsufficientNetworkFee, err.Error())
 	case errors.Is(err, core.ErrInvalidAttribute):
 		return nil, neorpc.WrapErrorWithData(neorpc.ErrInvalidAttribute, err.Error())
-	case errors.Is(err, core.ErrMemPoolConflict):
+	case errors.Is(err, core.ErrInsufficientFunds), errors.Is(err, core.ErrMemPoolConflict):
 		return nil, neorpc.WrapErrorWithData(neorpc.ErrInsufficientFunds, err.Error())
 	case errors.Is(err, core.ErrInvalidSignature):
 		return nil, neorpc.WrapErrorWithData(neorpc.ErrInvalidSignature, err.Error())

--- a/pkg/services/rpcsrv/server_test.go
+++ b/pkg/services/rpcsrv/server_test.go
@@ -2659,7 +2659,7 @@ func testRPCProtocol(t *testing.T, doRPCCall func(string, string, *testing.T) []
 		t.Run("insufficient funds", func(t *testing.T) {
 			b := testchain.NewBlock(t, chain, 1, 0, newTxWithParams(t, chain, opcode.PUSH1, 10, 899999999999, 1, false))
 			body := doRPCCall(fmt.Sprintf(rpc, encodeBinaryToString(t, b)), httpSrv.URL, t)
-			checkErrGetResult(t, body, true, neorpc.ErrVerificationFailedCode)
+			checkErrGetResult(t, body, true, neorpc.ErrInsufficientFundsCode)
 		})
 		t.Run("positive", func(t *testing.T) {
 			b := testchain.NewBlock(t, chain, 1, 0, newTxWithParams(t, chain, opcode.PUSH1, 10, 0, 1, false))


### PR DESCRIPTION
This is not the way intended in https://github.com/neo-project/proposals/pull/156. -511 covers _both_ cases because users hardly can distinguish one from another, it's just that our mempool implementation has error codes for both..

Refs. https://github.com/nspcc-dev/neo-go/pull/3360.