### PR TITLE
network: fix logging data race in the package

### DIFF
--- a/pkg/network/server_test.go
+++ b/pkg/network/server_test.go
@@ -335,16 +335,7 @@ func TestServerNotSendsVerack(t *testing.T) {
 		p2 = newLocalPeer(t, s)
 	)
 	s.id = 1
-	finished := make(chan struct{})
-	go func() {
-		go s.run()
-		close(finished)
-	}()
-	t.Cleanup(func() {
-		// close via quit as server was started via `run()`, not `Start()`
-		close(s.quit)
-		<-finished
-	})
+	startWithCleanup(t, s)
 
 	na, _ := net.ResolveTCPAddr("tcp", "0.0.0.0:3000")
 	p.netaddr = *na


### PR DESCRIPTION
An additional goroutine was added in TestServerNotSendsVerack in f8dc5ec44f5ed855ed78c82fe03479eb2da22c19 so it can be the cause of race.

Close #3316
