### PR TITLE
rpcsrv: fix TestRPC failing

### DIFF
--- a/pkg/services/rpcsrv/subscription_test.go
+++ b/pkg/services/rpcsrv/subscription_test.go
@@ -59,7 +59,7 @@ func getNotification(t *testing.T, respCh <-chan []byte) *neorpc.Notification {
 func initCleanServerAndWSClient(t *testing.T) (*core.Blockchain, *Server, *websocket.Conn, chan []byte, *atomic.Bool) {
 	chain, rpcSrv, httpSrv := initClearServerWithInMemoryChain(t)
 
-	dialer := websocket.Dialer{HandshakeTimeout: time.Second}
+	dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
 	url := "ws" + strings.TrimPrefix(httpSrv.URL, "http") + "/ws"
 	ws, r, err := dialer.Dial(url, nil)
 	require.NoError(t, err)
@@ -586,7 +586,7 @@ func TestWSClientsLimit(t *testing.T) {
 				cfg.ApplicationConfiguration.RPC.MaxWebSocketClients = limit
 			})
 
-			dialer := websocket.Dialer{HandshakeTimeout: time.Second}
+			dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
 			url := "ws" + strings.TrimPrefix(httpSrv.URL, "http") + "/ws"
 			wss := make([]*websocket.Conn, effectiveClients)
 


### PR DESCRIPTION
During the empirical selection of parameters got https://github.com/nspcc-dev/neo-go/issues/3367 so seems rpc test package is still big and therefore slow for gh windows runner. But with setup in this commit haven't got test timeout yet.

Close #2975.
Close #3314.