### PR TITLE
*: improve error text for System.Crypto.CheckMultisig handling

### DIFF
--- a/pkg/core/interop/crypto/ecdsa.go
+++ b/pkg/core/interop/crypto/ecdsa.go
@@ -18,14 +18,14 @@ import (
 func ECDSASecp256r1CheckMultisig(ic *interop.Context) error {
 	pkeys, err := ic.VM.Estack().PopSigElements()
 	if err != nil {
-		return fmt.Errorf("wrong parameters: %w", err)
+		return fmt.Errorf("wrong key parameters: %w", err)
 	}
 	if !ic.VM.AddGas(ic.BaseExecFee() * fee.ECDSAVerifyPrice * int64(len(pkeys))) {
 		return errors.New("gas limit exceeded")
 	}
 	sigs, err := ic.VM.Estack().PopSigElements()
 	if err != nil {
-		return fmt.Errorf("wrong parameters: %w", err)
+		return fmt.Errorf("wrong signature parameters: %w", err)
 	}
 	// It's ok to have more keys than there are signatures (it would
 	// just mean that some keys didn't sign), but not the other way around.

--- a/pkg/vm/stack.go
+++ b/pkg/vm/stack.go
@@ -345,7 +345,7 @@ func (s *Stack) PopSigElements() ([][]byte, error) {
 	default:
 		num = int(item.BigInt().Int64())
 		if num < 1 || num > s.Len() {
-			return nil, fmt.Errorf("wrong number of elements: %d", num)
+			return nil, fmt.Errorf("wrong number of elements: need %d, have %d", num, s.Len())
 		}
 		elems = make([][]byte, num)
 		for i := 0; i < num; i++ {


### PR DESCRIPTION
Might be helpful for users, no functional changes.