### PR TITLE
cli: improve wallet read related errors

### DIFF
--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -948,14 +948,14 @@ func createAccount(wall *wallet.Wallet, pass *string) error {
 func openWallet(ctx *cli.Context, canUseWalletConfig bool) (*wallet.Wallet, *string, error) {
 	path, pass, err := getWalletPathAndPass(ctx, canUseWalletConfig)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, cli.NewExitError(fmt.Errorf("failed to get wallet path or password: %w", err), 1)
 	}
 	if path == "-" {
 		return nil, nil, errNoStdin
 	}
 	w, err := wallet.NewWalletFromFile(path)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, cli.NewExitError(fmt.Errorf("failed to read wallet: %w", err), 1)
 	}
 	return w, pass, nil
 }


### PR DESCRIPTION
```
./bin/neo-go wallet import --wif qweqweqweqwe -w wallet1.json
failed to read wallet: open wallet: open wallet.json: no such file or directory

touch wallet.json

./bin/neo-go wallet import --wif qweqweqweqwe -w wallet.json
failed to read wallet: unmarshal wallet: EOF


```
@532910 is it a more understandable error?

Close #3134
