### PR TITLE
rpcsrv: enforce WS connection close on test cleanup

### DIFF
--- a/pkg/services/rpcsrv/subscription_test.go
+++ b/pkg/services/rpcsrv/subscription_test.go
@@ -100,8 +100,8 @@ func initCleanServerAndWSClient(t *testing.T, startNetworkServer ...bool) (*core
 			}
 		}
 		close(readerStopCh)
-		<-readerToExitCh
 		ws.Close()
+		<-readerToExitCh
 		if len(startNetworkServer) != 0 && startNetworkServer[0] {
 			rpcSrv.coreServer.Shutdown()
 		}


### PR DESCRIPTION
Do not wait until wsReader routine gracefully finishes its work before WS connection close. Instead, firstly close the connection, and after that wait for proper wsReader exit.

It's a harsh way, but I don't have any other options to try, because wsReader routine hangs on `ws.ReadMessage()` operation for more than ReadDeadline (more than 5 seconds) during test cleanup which results in the test timeout.

Close #3378.