### PR TITLE
network: take care of TestServerStartAndShutdown

### DIFF
--- a/pkg/network/server_test.go
+++ b/pkg/network/server_test.go
@@ -95,8 +95,10 @@ func TestServerStartAndShutdown(t *testing.T) {
 		s.register <- p
 		require.Eventually(t, func() bool { return 1 == s.PeerCount() }, time.Second, time.Millisecond*10)
 
-		assert.True(t, s.transports[0].(*fakeTransp).started.Load())
 		require.True(t, s.started.Load())
+		require.Eventually(t, func() bool {
+			return s.transports[0].(*fakeTransp).started.Load()
+		}, 2*time.Second, 200*time.Millisecond)
 		assert.Nil(t, s.txCallback)
 
 		s.Shutdown()
@@ -115,6 +117,7 @@ func TestServerStartAndShutdown(t *testing.T) {
 		s.Start()
 		p := newLocalPeer(t, s)
 		s.register <- p
+		require.Eventually(t, func() bool { return 1 == s.PeerCount() }, time.Second, time.Millisecond*10)
 
 		assert.True(t, s.services["fake"].(*fakeConsensus).started.Load())
 		require.True(t, s.started.Load())


### PR DESCRIPTION
We don't have a reliable way to know when transports are started since their start is being performed in a separate goroutine:

https://github.com/nspcc-dev/neo-go/blob/927dbb6dc48d578ae731e5a067c82d0611642338/pkg/network/server.go#L297-L299

And transports start is not connected with main server routine, thus, just wait for some time for the transports goroutine to be started.

Also wait for the peer to be properly registered.

Close #3399.