### PR TITLE
smartcontract: ensure nil ParameterContext Item's script is marshallable

### DIFF
--- a/pkg/smartcontract/context/item_test.go
+++ b/pkg/smartcontract/context/item_test.go
@@ -51,4 +51,8 @@ func TestContextItem_MarshalJSON(t *testing.T) {
 	}
 
 	testserdes.MarshalUnmarshalJSON(t, expected, new(Item))
+
+	// Empty script.
+	expected.Script = nil
+	testserdes.MarshalUnmarshalJSON(t, expected, new(Item))
 }


### PR DESCRIPTION
Ensure that ParameterContext's Item with nil script can be properly marshalled. Ref. https://github.com/neo-project/neo/pull/3198.