### PR TITLE
workflows: disable cache for golangci-lint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
         uses: golangci/golangci-lint-action@v4
         with:
           version: latest
+          skip-pkg-cache: true # golangci-lint can't work with this cache enabled, ref. https://github.com/golangci/golangci-lint-action/issues/135.
 
   gomodcheck:
     name: Check internal dependencies


### PR DESCRIPTION
Ref. https://github.com/golangci/golangci-lint-action/issues/135. Otherwies we've got a set of errors on attempt to setup linter:
```
Run golangci/golangci-lint-action@v4
  with:
    version: latest
    github-token: ***
    only-new-issues: false
    skip-cache: false
    skip-pkg-cache: false
    skip-build-cache: false
    install-mode: binary
prepare environment
  Checking for go.mod: go.mod
  Received 125829120 of 781115092 (16.1%), 119.8 MBs/sec
  Received 331350016 of 781115092 (42.4%), 157.8 MBs/sec
  Received 541065216 of 781115092 (69.3%), 171.9 MBs/sec
  Received 738197504 of 781115092 (94.5%), 175.8 MBs/sec
  Cache Size: ~745 MB (781115092 B)
  /usr/bin/tar -xf /home/runner/work/_temp/6de9500e-163b-4dda-a82b-d6b2ee7b1625/cache.tzst -P -C /home/runner/work/neo-go/neo-go --use-compress-program unzstd
  Received 781115092 of 781115092 (100.0%), 148.8 MBs/sec
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/LICENSE: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/.github/workflows/test.yml: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/README.md: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/annotation_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/retention_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/main.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/fmt/m.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/fmt/m.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_import_all.proto: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_import_a1m2.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_b_1/m1.proto: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_b_1/m2.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_import_all.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_import_a1m1.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_a_1/m1.proto: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_a_1/m2.proto: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_a_2/m3.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_a_2/m4.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/extensions/ext/ext.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/extensions/ext/ext.pb.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/extensions/extra/extra.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/extensions/extra/extra.proto: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/extensions/proto3/ext3.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/extensions/proto3/ext3.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/extensions/base/base.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/extensions/base/base.pb.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/proto2/fields.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/proto2/nested_messages.proto: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/proto2/proto2.proto: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/proto2/enum.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/proto2/enum.pb.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/proto2/proto2.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/proto2/fields.proto: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/proto2/nested_messages.pb.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/import_public/b.pb.go: Cannot open: File exists
  /usr/bin/tar: ../../../go/pkg/mod/google.golang.org/protobuf@v1.31.0/cmd/protoc-gen-go/testdata/import_public/a.proto: Cannot open: File exists
...
```