### PR TITLE
core: take care of block-targeted Conflicts attributes processing

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1515,8 +1515,11 @@ func (bc *Blockchain) AddBlock(block *block.Block) error {
 			} else {
 				err = bc.verifyAndPoolTx(tx, mp, bc)
 			}
-			if err != nil && bc.config.VerifyTransactions {
-				return fmt.Errorf("transaction %s failed to verify: %w", tx.Hash().StringLE(), err)
+			if err != nil {
+				if bc.config.VerifyTransactions {
+					return fmt.Errorf("transaction %s failed to verify: %w", tx.Hash().StringLE(), err)
+				}
+				bc.log.Warn(fmt.Sprintf("transaction %s failed to verify: %s", tx.Hash().StringLE(), err))
 			}
 		}
 	}

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -45,7 +45,7 @@ import (
 
 // Tuning parameters.
 const (
-	version = "0.2.11"
+	version = "0.2.12"
 
 	// DefaultInitialGAS is the default amount of GAS emitted to the standby validators
 	// multisignature account during native GAS contract initialization.

--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -789,6 +789,10 @@ func (dao *Simple) DeleteBlock(h util.Uint256) error {
 			if err != nil {
 				return fmt.Errorf("failed to retrieve conflict record stub for %s (height %d, conflict %s): %w", tx.Hash().StringLE(), b.Index, hash.StringLE(), err)
 			}
+			// It might be a block since we allow transactions to have block hash in the Conflicts attribute.
+			if v[0] != storage.ExecTransaction {
+				continue
+			}
 			index := binary.LittleEndian.Uint32(v[1:])
 			// We can check for `<=` here, but use equality comparison to be more precise
 			// and do not touch earlier conflict records (if any). Their removal must be triggered

--- a/pkg/core/transaction/transaction.go
+++ b/pkg/core/transaction/transaction.go
@@ -26,8 +26,6 @@ const (
 	// MaxAttributes is maximum number of attributes including signers that can be contained
 	// within a transaction. It is set to be 16.
 	MaxAttributes = 16
-	// DummyVersion represents reserved transaction version for trimmed transactions.
-	DummyVersion = 255
 )
 
 // ErrInvalidWitnessNum returns when the number of witnesses does not match signers.
@@ -408,7 +406,7 @@ var (
 
 // isValid checks whether decoded/unmarshalled transaction has all fields valid.
 func (t *Transaction) isValid() error {
-	if t.Version > 0 && t.Version != DummyVersion {
+	if t.Version > 0 {
 		return ErrInvalidVersion
 	}
 	if t.SystemFee < 0 {


### PR DESCRIPTION
Close #3426, close #3427.

A possible solution (the best from my POW) is implemented. The part with verification of such conflicting transactions may be discussed since I'm not quite sure it's a good solution to allow to pass verification for these transactions. We may forbid them since we have `VerifyTransactions` set to `false` in mainnet anyway.

@roman-khimov, the only question I have right now is: why our CN has successfully accepted PrepareRequest, verified the block and responded with PrepareReqponse. The node shouldn't ever accept this transaction to the mempool since `verifyTxAttributes` call should fail without e6ceee0f230a21c87006a9297636be29c0d8ea47 implemented.