### PR TITLE
state: drop NativeContract, fix #3430

### DIFF
--- a/internal/fakechain/fakechain.go
+++ b/internal/fakechain/fakechain.go
@@ -99,7 +99,7 @@ func (*FakeChain) IsExtensibleAllowed(uint160 util.Uint160) bool {
 }
 
 // GetNatives implements the blockchainer.Blockchainer interface.
-func (*FakeChain) GetNatives() []state.NativeContract {
+func (*FakeChain) GetNatives() []state.Contract {
 	panic("TODO")
 }
 

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2292,18 +2292,19 @@ func (bc *Blockchain) GetNativeContractScriptHash(name string) (util.Uint160, er
 }
 
 // GetNatives returns list of native contracts.
-func (bc *Blockchain) GetNatives() []state.NativeContract {
-	res := make([]state.NativeContract, 0, len(bc.contracts.Contracts))
+func (bc *Blockchain) GetNatives() []state.Contract {
+	res := make([]state.Contract, 0, len(bc.contracts.Contracts))
 	current := bc.getCurrentHF()
 	for _, c := range bc.contracts.Contracts {
 		activeIn := c.ActiveIn()
 		if !(activeIn == nil || activeIn.Cmp(current) <= 0) {
 			continue
 		}
-		md := c.Metadata().HFSpecificContractMD(&current)
-		res = append(res, state.NativeContract{
-			ContractBase: md.ContractBase,
-		})
+
+		st := bc.GetContractState(c.Metadata().Hash)
+		if st != nil { // Should never happen, but better safe than sorry.
+			res = append(res, *st)
+		}
 	}
 	return res
 }

--- a/pkg/core/state/contract.go
+++ b/pkg/core/state/contract.go
@@ -29,11 +29,6 @@ type ContractBase struct {
 	Manifest manifest.Manifest `json:"manifest"`
 }
 
-// NativeContract holds information about the native contract.
-type NativeContract struct {
-	ContractBase
-}
-
 // ToStackItem converts state.Contract to stackitem.Item.
 func (c *Contract) ToStackItem() (stackitem.Item, error) {
 	// Do not skip the NEF size check, it won't affect native Management related

--- a/pkg/rpcclient/rpc.go
+++ b/pkg/rpcclient/rpc.go
@@ -265,8 +265,8 @@ func (c *Client) getContractState(param any) (*state.Contract, error) {
 }
 
 // GetNativeContracts queries information about native contracts.
-func (c *Client) GetNativeContracts() ([]state.NativeContract, error) {
-	var resp []state.NativeContract
+func (c *Client) GetNativeContracts() ([]state.Contract, error) {
+	var resp []state.Contract
 	if err := c.performRequest("getnativecontracts", nil, &resp); err != nil {
 		return resp, err
 	}

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -86,7 +86,7 @@ type (
 		GetNEP11Contracts() []util.Uint160
 		GetNEP17Contracts() []util.Uint160
 		GetNativeContractScriptHash(string) (util.Uint160, error)
-		GetNatives() []state.NativeContract
+		GetNatives() []state.Contract
 		GetNextBlockValidators() ([]*keys.PublicKey, error)
 		GetNotaryContractScriptHash() util.Uint160
 		GetStateModule() core.StateRoot

--- a/pkg/services/rpcsrv/server_test.go
+++ b/pkg/services/rpcsrv/server_test.go
@@ -1192,13 +1192,13 @@ var rpcTestCases = map[string][]rpcTestCase{
 		{
 			params: "[]",
 			result: func(e *executor) any {
-				return new([]state.NativeContract)
+				return new([]state.Contract)
 			},
 			check: func(t *testing.T, e *executor, res any) {
-				lst := res.(*[]state.NativeContract)
+				lst := res.(*[]state.Contract)
 				for i := range *lst {
 					cs := e.chain.GetContractState((*lst)[i].Hash)
-					require.NotNil(t, cs)
+					require.Equal(t, *cs, (*lst)[i])
 					require.True(t, cs.ID <= 0)
 				}
 			},


### PR DESCRIPTION
This is somewhat deeper than its C# counterpart, but the essence is the same, we return proper []state.Contract from getnativecontracts RPC and thus many of older types are no longer needed. Some hacks around UpdateCounter are removed as well.

The change can potentially affect third-party apps, but should be easy to adopt.

UPD: simplified.
