### PR TITLE
native: fix Policy's IsBlocked behaviour

### DIFF
--- a/pkg/core/native/native_test/neo_test.go
+++ b/pkg/core/native/native_test/neo_test.go
@@ -39,7 +39,7 @@ func newNeoCommitteeClient(t *testing.T, expectedGASBalance int) *neotest.Contra
 	e := neotest.NewExecutor(t, bc, validators, committee)
 
 	if expectedGASBalance > 0 {
-		e.ValidatorInvoker(e.NativeHash(t, nativenames.Gas)).Invoke(t, true, "transfer", e.Validator.ScriptHash(), e.CommitteeHash, 100_0000_0000, nil)
+		e.ValidatorInvoker(e.NativeHash(t, nativenames.Gas)).Invoke(t, true, "transfer", e.Validator.ScriptHash(), e.CommitteeHash, expectedGASBalance, nil)
 	}
 
 	return e.CommitteeInvoker(e.NativeHash(t, nativenames.Neo))

--- a/pkg/core/native/policy.go
+++ b/pkg/core/native/policy.go
@@ -319,7 +319,7 @@ func (p *Policy) IsBlocked(dao *dao.Simple, hash util.Uint160) bool {
 	cache := dao.GetROCache(p.ID)
 	if cache == nil {
 		key := append([]byte{blockedAccountPrefix}, hash.BytesBE()...)
-		return dao.GetStorageItem(p.ID, key) == nil
+		return dao.GetStorageItem(p.ID, key) != nil
 	}
 	_, isBlocked := p.isBlockedInternal(cache.(*PolicyCache), hash)
 	return isBlocked


### PR DESCRIPTION
Account is blocked when it's in the Policy's storage, not when it's missing from the storage. Introduced in bbbc6805a8261bca51428ae9e96340fc62704b61.

This bug leads to the fact that during native Neo cache initialization at the last block in the dBFT epoch, all candidates accounts are "blocked", and thus, stand-by committee and validators are used in the subsequent new epoch. Close #3424.

This bug may lead to the consequences described in #3273, but it needs to be confirmed. @fyfyrchik, is it possible for your network to check whether "faulty" node has been restarted in the last block of some dBFT epoch? And then check what the receivers of block rewards in the next dBFT epoch are stand-by validators/committee. If so, then the problem is the same, since this bug leads to the wrong block reward distribution (to stand-by committee instead of elected committee) which may result in the failing OnPersist script if, for example, the sender of some in-block transaction is an elected committee member or validator.
