### PR TITLE
logs: distinguish WARN and INFO for `peer disconnected`

### DIFF
--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -44,12 +44,13 @@ const (
 )
 
 var (
-	errAlreadyConnected = errors.New("already connected")
-	errIdenticalID      = errors.New("identical node id")
-	errInvalidNetwork   = errors.New("invalid network")
-	errMaxPeers         = errors.New("max peers reached")
-	errServerShutdown   = errors.New("server shutdown")
-	errInvalidInvType   = errors.New("invalid inventory type")
+	errAlreadyConnected    = errors.New("already connected")
+	errIdenticalID         = errors.New("identical node id")
+	errInvalidNetwork      = errors.New("invalid network")
+	errMaxPeers            = errors.New("max peers reached")
+	errServerShutdown      = errors.New("server shutdown")
+	errInvalidInvType      = errors.New("invalid inventory type")
+	errBlocksRequestFailed = errors.New("blocks request failed")
 )
 
 type (
@@ -512,10 +513,17 @@ func (s *Server) run() {
 			if s.peers[drop.peer] {
 				delete(s.peers, drop.peer)
 				s.lock.Unlock()
-				s.log.Warn("peer disconnected",
-					zap.Stringer("addr", drop.peer.RemoteAddr()),
-					zap.Error(drop.reason),
-					zap.Int("peerCount", s.PeerCount()))
+				if errors.Is(drop.reason, errInvalidInvType) || errors.Is(drop.reason, errStateMismatch) || errors.Is(drop.reason, errBlocksRequestFailed) {
+					s.log.Warn("peer disconnected",
+						zap.Stringer("addr", drop.peer.RemoteAddr()),
+						zap.Error(drop.reason),
+						zap.Int("peerCount", s.PeerCount()))
+				} else {
+					s.log.Info("peer disconnected",
+						zap.Stringer("addr", drop.peer.RemoteAddr()),
+						zap.Error(drop.reason),
+						zap.Int("peerCount", s.PeerCount()))
+				}
 				if errors.Is(drop.reason, errIdenticalID) {
 					s.discovery.RegisterSelf(drop.peer)
 				} else {
@@ -793,7 +801,7 @@ func (s *Server) requestBlocksOrHeaders(p Peer) error {
 	}
 	err := s.requestBlocks(bq, p)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", errBlocksRequestFailed, err)
 	}
 	if requestMPTNodes {
 		return s.requestMPTNodes(p, s.stateSync.GetUnknownMPTNodesBatch(payload.MaxMPTHashesCount))

--- a/pkg/network/server.go
+++ b/pkg/network/server.go
@@ -1353,7 +1353,7 @@ func (s *Server) handleMessage(peer Peer, msg *Message) error {
 	if peer.Handshaked() {
 		if inv, ok := msg.Payload.(*payload.Inventory); ok {
 			if !inv.Type.Valid(s.chain.P2PSigExtensionsEnabled()) || len(inv.Hashes) == 0 {
-				return errInvalidInvType
+				return fmt.Errorf("%w: %s", errInvalidInvType, inv.Type.String())
 			}
 		}
 		switch msg.Command {


### PR DESCRIPTION
Peer disconnections are not warnings.

Close #3182



some errors that can be in the `peer disconnected` message:
```
err = msg.Decode(r)
errors.New("invalid payload size")
br.ReadBytes(m.compressedPayload)

fmt.Errorf("bind address for connection '%s' is not registered", localAddr.String())
errors.New("invalid handshake: already sent Version")
_, err = p.conn.Write(b) 

fmt.Errorf("handling %s message: %w", msg.Command.String(), err)
err = p.conn.SetWriteDeadline(time.Now().Add(writeTimeout))

s.requestBlocks(bq, p)
b, err := msg.Bytes()

	errGone           = errors.New("the peer is gone already")
	errStateMismatch  = errors.New("tried to send protocol message before handshake completed")
	errPingPong       = errors.New("ping/pong timeout")
	errUnexpectedPong = errors.New("pong message wasn't expected")  
```



For me, such messages look more like warnings:
```
read: can't assign requested address 
unexpected empty payload: CMDVersion
invalid inventory type
```