### PR TITLE
interop: use executing contract state for permissions checks

### DIFF
--- a/cli/vm/cli.go
+++ b/cli/vm/cli.go
@@ -1105,7 +1105,7 @@ func handleRun(c *cli.Context) error {
 			breaks := v.Context().BreakPoints() // We ensure that there's a context loaded.
 			ic.ReuseVM(v)
 			v.GasLimit = gasLimit
-			v.LoadNEFMethod(&cs.NEF, util.Uint160{}, cs.Hash, callflag.All, hasRet, offset, initOff, nil)
+			v.LoadNEFMethod(&cs.NEF, &cs.Manifest, util.Uint160{}, cs.Hash, callflag.All, hasRet, offset, initOff, nil)
 			for _, bp := range breaks {
 				v.AddBreakPoint(bp)
 			}

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2928,7 +2928,7 @@ func (bc *Blockchain) InitVerificationContext(ic *interop.Context, hash util.Uin
 			initOffset = md.Offset
 		}
 		ic.Invocations[cs.Hash]++
-		ic.VM.LoadNEFMethod(&cs.NEF, util.Uint160{}, hash, callflag.ReadOnly,
+		ic.VM.LoadNEFMethod(&cs.NEF, &cs.Manifest, util.Uint160{}, hash, callflag.ReadOnly,
 			true, verifyOffset, initOffset, nil)
 	}
 	if len(witness.InvocationScript) != 0 {

--- a/pkg/core/interop/contract/call.go
+++ b/pkg/core/interop/contract/call.go
@@ -144,7 +144,7 @@ func callExFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contra
 		}
 		return nil
 	}
-	ic.VM.LoadNEFMethod(&cs.NEF, caller, cs.Hash, f,
+	ic.VM.LoadNEFMethod(&cs.NEF, &cs.Manifest, caller, cs.Hash, f,
 		hasReturn, methodOff, initOff, onUnload)
 
 	for e, i := ic.VM.Estack(), len(args)-1; i >= 0; i-- {

--- a/pkg/core/interop/runtime/engine.go
+++ b/pkg/core/interop/runtime/engine.go
@@ -80,19 +80,19 @@ func Notify(ic *interop.Context) error {
 	if len(name) > MaxEventNameLen {
 		return fmt.Errorf("event name must be less than %d", MaxEventNameLen)
 	}
-	curHash := ic.VM.GetCurrentScriptHash()
-	ctr, err := ic.GetContract(curHash)
-	if err != nil {
+	curr := ic.VM.Context().GetManifest()
+	if curr == nil {
 		return errors.New("notifications are not allowed in dynamic scripts")
 	}
 	var (
-		ev       = ctr.Manifest.ABI.GetEvent(name)
+		ev       = curr.ABI.GetEvent(name)
 		checkErr error
+		curHash  = ic.VM.GetCurrentScriptHash()
 	)
 	if ev == nil {
 		checkErr = fmt.Errorf("notification %s does not exist", name)
 	} else {
-		err = ev.CheckCompliance(args)
+		err := ev.CheckCompliance(args)
 		if err != nil {
 			checkErr = fmt.Errorf("notification %s is invalid: %w", name, err)
 		}

--- a/pkg/core/interop/runtime/ext_test.go
+++ b/pkg/core/interop/runtime/ext_test.go
@@ -637,7 +637,7 @@ func TestNotify(t *testing.T) {
 		_, _, bc, cs := getDeployedInternal(t)
 		ic, err := bc.GetTestVM(trigger.Application, nil, nil)
 		require.NoError(t, err)
-		ic.VM.LoadNEFMethod(&cs.NEF, caller, cs.Hash, callflag.NoneFlag, true, 0, -1, nil)
+		ic.VM.LoadNEFMethod(&cs.NEF, &cs.Manifest, caller, cs.Hash, callflag.NoneFlag, true, 0, -1, nil)
 		ic.VM.Estack().PushVal(args)
 		ic.VM.Estack().PushVal(name)
 		return ic

--- a/pkg/vm/context.go
+++ b/pkg/vm/context.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/nef"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/vm/invocations"
@@ -44,6 +45,8 @@ type scriptContext struct {
 
 	// NEF represents a NEF file for the current contract.
 	NEF *nef.File
+	// Manifest represents a manifest for the current contract.
+	Manifest *manifest.Manifest
 	// invTree is an invocation tree (or a branch of it) for this context.
 	invTree *invocations.Tree
 	// onUnload is a callback that should be called after current context unloading
@@ -247,6 +250,11 @@ func (c *Context) ScriptHash() util.Uint160 {
 // GetNEF returns NEF structure used by this context if it's present.
 func (c *Context) GetNEF() *nef.File {
 	return c.sc.NEF
+}
+
+// GetManifest returns Manifest used by this context if it's present.
+func (c *Context) GetManifest() *manifest.Manifest {
+	return c.sc.Manifest
 }
 
 // NumOfReturnVals returns the number of return values expected from this context.

--- a/pkg/vm/debug_test.go
+++ b/pkg/vm/debug_test.go
@@ -56,6 +56,6 @@ func TestContext_BreakPoints(t *testing.T) {
 	require.Equal(t, []int{3, 5}, v.Context().BreakPoints())
 
 	// New context -> clean breakpoints.
-	v.loadScriptWithCallingHash(prog, nil, util.Uint160{}, util.Uint160{}, callflag.All, 1, 3, nil)
+	v.loadScriptWithCallingHash(prog, nil, nil, util.Uint160{}, util.Uint160{}, callflag.All, 1, 3, nil)
 	require.Equal(t, []int{}, v.Context().BreakPoints())
 }


### PR DESCRIPTION
Do not use the updated contract state from native Management to perform permissions checks. We need to use the currently executing state instead got from the currently executing VM context until context is unloaded.

Close #3471.

Mainnet check is in progress.