### PR TITLE
cli: add embedded node config

### DIFF
--- a/cli/options/options.go
+++ b/cli/options/options.go
@@ -201,7 +201,7 @@ func GetConfigFromContext(ctx *cli.Context) (config.Config, error) {
 	if len(configFile) != 0 {
 		return config.LoadFile(configFile, relativePath)
 	}
-	var configPath = "./config"
+	var configPath = config.DefaultConfigPath
 	if argCp := ctx.String("config-path"); argCp != "" {
 		configPath = argCp
 	}

--- a/config/config_embed.go
+++ b/config/config_embed.go
@@ -1,0 +1,32 @@
+// Package config contains embedded YAML configuration files for different network modes
+// of the Neo N3 blockchain and for NeoFS mainnet and testnet networks.
+package config
+
+import (
+	_ "embed"
+)
+
+// MainNet is the Neo N3 mainnet configuration.
+//
+//go:embed protocol.mainnet.yml
+var MainNet []byte
+
+// TestNet is the Neo N3 testnet configuration.
+//
+//go:embed protocol.testnet.yml
+var TestNet []byte
+
+// PrivNet is the private network configuration.
+//
+//go:embed protocol.privnet.yml
+var PrivNet []byte
+
+// MainNetNeoFS is the mainnet NeoFS configuration.
+//
+//go:embed protocol.mainnet.neofs.yml
+var MainNetNeoFS []byte
+
+// TestNetNeoFS is the testnet NeoFS configuration.
+//
+//go:embed protocol.testnet.neofs.yml
+var TestNetNeoFS []byte

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,12 +1,16 @@
 package config
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/config"
 	"github.com/nspcc-dev/neo-go/pkg/config/netmode"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 const testConfigPath = "./testdata/protocol.test.yml"
@@ -31,4 +35,22 @@ func TestUnknownConfigFields(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "field UnknownConfigurationField not found in type config.Config")
 	})
+}
+
+func TestLoadFileWithMissingDefaultConfigPath(t *testing.T) {
+	var cfgPrivNet Config
+	cfg, err := LoadFile(fmt.Sprintf("%s/protocol.%s.yml", DefaultConfigPath, netmode.PrivNet))
+	require.Nil(t, err)
+	decoder := yaml.NewDecoder(bytes.NewReader(config.PrivNet))
+	err = decoder.Decode(&cfgPrivNet)
+	require.NoError(t, err)
+	require.Equal(t, cfg, cfgPrivNet)
+
+	_, err = LoadFile(fmt.Sprintf("%s/protocol.%s.yml", os.TempDir(), netmode.PrivNet))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "doesn't exist and no matching embedded config was found")
+
+	_, err = LoadFile(fmt.Sprintf("%s/protocol.%s.yml", DefaultConfigPath, "aaa"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "doesn't exist and no matching embedded config was found")
 }


### PR DESCRIPTION
If `config-path` is not provided then the default config is used. If  `config-path` is provided but the directory does not contain a configuration file for the desired passed network and this directory isn't our default `./config`, the error "config '%s' doesn't exist" will be received.

Close #3450.
Close #3459.

