### PR TITLE
Ensure System.Runtime.GetNotifications can't break MaxStackSize constraint

### DIFF
--- a/pkg/vm/stackitem/item.go
+++ b/pkg/vm/stackitem/item.go
@@ -128,6 +128,12 @@ func Make(v any) Item {
 			a = append(a, Make(i))
 		}
 		return Make(a)
+	case []string:
+		var a []Item
+		for _, i := range val {
+			a = append(a, Make(i))
+		}
+		return Make(a)
 	case []any:
 		res := make([]Item, len(val))
 		for i := range val {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -594,7 +594,7 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 			err = newError(ctx.ip, op, errRecover)
 		} else if v.refs > MaxStackSize {
 			v.state = vmstate.Fault
-			err = newError(ctx.ip, op, "stack is too big")
+			err = newError(ctx.ip, op, fmt.Sprintf("stack is too big: %d vs %d", int(v.refs), MaxStackSize))
 		}
 	}()
 
@@ -1995,7 +1995,7 @@ func validateMapKey(key Element) {
 
 func (v *VM) checkInvocationStackSize() {
 	if len(v.istack) >= MaxInvocationStackSize {
-		panic("invocation stack is too big")
+		panic(fmt.Sprintf("invocation stack is too big: %d", len(v.istack)))
 	}
 }
 


### PR DESCRIPTION
This test ensures that NeoGo node doesn't have the DeepCopy problem described in https://github.com/neo-project/neo/issues/3300 and fixed in https://github.com/neo-project/neo/pull/3301. This problem leads to the fact that Notifications items are not being properly refcounted by C# node which leads to possibility to build an enormously large object on stack. Go node doesn't have this problem.

The reason (at least, as I understand it) is in the fact that C# node performs objects refcounting inside the DeepCopy even if the object itself is not yet on stack. I.e. System.Runtime.Notify handler immediately adds references to the notification argumetns inside DeepCopy:
https://github.com/neo-project/neo/blob/b1d27f0189861167b8005a7e40e6d8500fb48cc4/src/Neo.VM/Types/Array.cs#L108
https://github.com/neo-project/neo/blob/b1d27f0189861167b8005a7e40e6d8500fb48cc4/src/Neo.VM/Types/Array.cs#L75

Whereas Go node just performs the honest DeepCopy without references counting: https://github.com/nspcc-dev/neo-go/blob/b66cea5cccbcc8446312b012e29aaf2d1837430a/pkg/vm/stackitem/item.go#L1223
    
Going further, C# node clears refs for notification arguments (for array and underlying array items). Sytem.Runtime.GetNotifications pushes the notificaiton args array back on stack and increments counter only for the external array, not for its arguments. Which results in negative refcounter once notificaiton is removed from the stack. The fix itself (https://github.com/Jim8y/neo/blob/f471c0542ddd8f527478fbdcda76a3ab9194b958/src/Neo/SmartContract/NotifyEventArgs.cs#L84) doesn't need to be ported to NeoGo because Go node adds object to the refcounter only at the moment when it's being pushed to stack by System.Runtime.GetNotifications handler. This object is treated as new object since it was deepcopied earlier by System.Runtime.Notify handler:
https://github.com/nspcc-dev/neo-go/blob/b66cea5cccbcc8446312b012e29aaf2d1837430a/pkg/vm/stack.go#L178.
    
Thus, no functional changes from the NeoGo side. And we won't intentionally break our node to follow C# pre-Domovoi invalid behaviour.

Close #3484, close #3482.