### PR TITLE
invoker: add Signers() API

### DIFF
--- a/pkg/rpcclient/actor/actor.go
+++ b/pkg/rpcclient/actor/actor.go
@@ -280,6 +280,19 @@ func (a *Actor) SendUncheckedRun(script []byte, sysfee int64, attrs []transactio
 	return a.sendWrapper(a.MakeUncheckedRun(script, sysfee, attrs, txHook))
 }
 
+// SignerAccounts returns the array of actor's signers/accounts. It's useful in
+// case you need it elsewhere like for notary-related processing. Returned slice
+// is a newly allocated one with signers deeply copied, accounts however are not
+// so changing received account internals is an error.
+func (a *Actor) SignerAccounts() []SignerAccount {
+	var res = make([]SignerAccount, len(a.signers))
+	for i := range a.signers {
+		res[i].Signer = *a.signers[i].Signer.Copy()
+		res[i].Account = a.signers[i].Account
+	}
+	return res
+}
+
 // Sender return the sender address that will be used in transactions created
 // by Actor.
 func (a *Actor) Sender() util.Uint160 {

--- a/pkg/rpcclient/actor/actor_test.go
+++ b/pkg/rpcclient/actor/actor_test.go
@@ -101,9 +101,14 @@ func TestNew(t *testing.T) {
 	// Good simple.
 	a, err := NewSimple(client, acc)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(a.signers))
+	require.Equal(t, []SignerAccount{{
+		Signer: transaction.Signer{
+			Account: acc.ScriptHash(),
+			Scopes:  transaction.CalledByEntry,
+		},
+		Account: acc,
+	}}, a.SignerAccounts())
 	require.Equal(t, 1, len(a.txSigners))
-	require.Equal(t, transaction.CalledByEntry, a.signers[0].Signer.Scopes)
 	require.Equal(t, transaction.CalledByEntry, a.txSigners[0].Scopes)
 
 	// Contractless account.
@@ -158,7 +163,7 @@ func TestNew(t *testing.T) {
 	signers[0].Signer.Account = acc.Contract.ScriptHash()
 	a, err = New(client, signers)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(a.signers))
+	require.Equal(t, signers, a.SignerAccounts())
 	require.Equal(t, 2, len(a.txSigners))
 
 	// Good tuned

--- a/pkg/rpcclient/invoker/invoker.go
+++ b/pkg/rpcclient/invoker/invoker.go
@@ -137,6 +137,20 @@ func (h *historicConverter) TraverseIterator(sessionID, iteratorID uuid.UUID, ma
 	return h.client.TraverseIterator(sessionID, iteratorID, maxItemsCount)
 }
 
+// Signers returns the set of current invoker signers which is mostly useful
+// when working with upper-layer actors. Returned slice is a newly allocated
+// one (if this invoker has them), so it's safe to modify.
+func (v *Invoker) Signers() []transaction.Signer {
+	if v.signers == nil {
+		return nil
+	}
+	var res = make([]transaction.Signer, len(v.signers))
+	for i := range v.signers {
+		res[i] = *v.signers[i].Copy()
+	}
+	return res
+}
+
 // Call invokes a method of the contract with the given parameters (and
 // Invoker-specific list of signers) and returns the result as is.
 func (v *Invoker) Call(contract util.Uint160, operation string, params ...any) (*result.Invoke, error) {

--- a/pkg/rpcclient/invoker/invoker_test.go
+++ b/pkg/rpcclient/invoker/invoker_test.go
@@ -158,3 +158,19 @@ func TestInvoker(t *testing.T) {
 		}
 	})
 }
+
+func TestInvokerSigners(t *testing.T) {
+	resExp := &result.Invoke{State: "HALT"}
+	ri := &rpcInv{resExp, true, nil, nil}
+	inv := New(ri, nil)
+
+	require.Nil(t, inv.Signers())
+
+	s := []transaction.Signer{}
+	inv = New(ri, s)
+	require.Equal(t, s, inv.Signers())
+
+	s = append(s, transaction.Signer{Account: util.Uint160{1, 2, 3}, Scopes: transaction.CalledByEntry})
+	inv = New(ri, s)
+	require.Equal(t, s, inv.Signers())
+}


### PR DESCRIPTION
Signers are very important for notary checks and keeping/passing an additional copy of them is very inconvenient. Exposing them from invoker makes them available in actors too.