### PR TITLE
core: avoid extra call to GetNextBlockValidatorsInternal

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1833,7 +1833,7 @@ func (bc *Blockchain) updateExtensibleWhitelist(height uint32) error {
 		return err
 	}
 	newList = append(newList, hash.Hash160(script))
-	bc.updateExtensibleList(&newList, bc.contracts.NEO.GetNextBlockValidatorsInternal(bc.dao))
+	bc.updateExtensibleList(&newList, nextVals)
 
 	if len(stateVals) > 0 {
 		h, err := bc.contracts.Designate.GetLastDesignatedHash(bc.dao, noderoles.StateValidator)


### PR DESCRIPTION
It should be sufficient to retrieve next block validators once per updateExtensibleWhitelist call and then reuse this value. `nextVals` copy intentionally omitted since the only change that smartcontract.CreateDefaultMultiSigRedeemScript performs over the `nextVals` list is sorting.