### PR TITLE
Add a missing `mptdata` test

### DIFF
--- a/pkg/network/payload/mptdata_test.go
+++ b/pkg/network/payload/mptdata_test.go
@@ -21,4 +21,18 @@ func TestMPTData_EncodeDecodeBinary(t *testing.T) {
 		}
 		testserdes.EncodeDecodeBinary(t, d, new(MPTData))
 	})
+
+	t.Run("exceeds MaxArraySize", func(t *testing.T) {
+		bytes := []byte{
+			// The first byte represents the number 0x1.
+			// It encodes the size of the outer array (the number or rows in the Nodes matrix).
+			0x1,
+			// This sequence of 9 bytes represents the number 0xffffffffffffffff.
+			// It encodes the size of the first row in the Nodes matrix.
+			// This size exceeds the maximum array size, thus the decoder should
+			// return an error.
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		}
+		require.Error(t, testserdes.DecodeBinary(bytes, new(MPTData)))
+	})
 }


### PR DESCRIPTION
### Problem

The following [coverage report](https://app.codecov.io/gh/nspcc-dev/neo-go/commit/f5794e91a224f403223f73cd46cf4a9152d70963/blob/pkg/network/payload/mptdata.go) indicates that the following branch is not covered by tests:

```
// mptdata.go

31:		if r.Err != nil {
32:			return  // <--- this line
33:		}
34:	}
``` 

### Solution

This PR adds a single test that covers this branch.

This line is reached when there is an error parsing a single row in the array `Nodes: [][]byte`. An error occurs when the line length exceeds the maximum array size.


