### PR TITLE
*: Convert slices to arrays instead of `copy` where possible

### DIFF
--- a/pkg/core/interop/context.go
+++ b/pkg/core/interop/context.go
@@ -32,6 +32,8 @@ import (
 const (
 	// DefaultBaseExecFee specifies the default multiplier for opcode and syscall prices.
 	DefaultBaseExecFee = 30
+	// ContextNonceDataLen is a length of [Context.NonceData] in bytes.
+	ContextNonceDataLen = 16
 )
 
 // Ledger is the interface to Blockchain required for Context functionality.
@@ -52,7 +54,7 @@ type Context struct {
 	Natives          []Contract
 	Trigger          trigger.Type
 	Block            *block.Block
-	NonceData        [16]byte
+	NonceData        [ContextNonceDataLen]byte
 	Tx               *transaction.Transaction
 	DAO              *dao.Simple
 	Notifications    []state.NotificationEvent
@@ -97,7 +99,7 @@ func NewContext(trigger trigger.Type, bc Ledger, d *dao.Simple, baseExecFee, bas
 // InitNonceData initializes nonce to be used in `GetRandom` calculations.
 func (ic *Context) InitNonceData() {
 	if tx, ok := ic.Container.(*transaction.Transaction); ok {
-		copy(ic.NonceData[:], tx.Hash().BytesBE())
+		ic.NonceData = [ContextNonceDataLen]byte(tx.Hash().BytesBE())
 	}
 	if ic.Block != nil {
 		nonce := ic.Block.Nonce

--- a/pkg/core/interop/runtime/util.go
+++ b/pkg/core/interop/runtime/util.go
@@ -103,7 +103,7 @@ func GetRandom(ic *interop.Context) error {
 	}
 	res := murmur128(ic.NonceData[:], seed)
 	if !isHF {
-		copy(ic.NonceData[:], res)
+		ic.NonceData = [interop.ContextNonceDataLen]byte(res)
 	}
 	if !ic.VM.AddGas(ic.BaseExecFee() * price) {
 		return errors.New("gas limit exceeded")

--- a/pkg/util/uint160.go
+++ b/pkg/util/uint160.go
@@ -50,8 +50,7 @@ func Uint160DecodeBytesBE(b []byte) (u Uint160, err error) {
 	if len(b) != Uint160Size {
 		return u, fmt.Errorf("expected byte size of %d got %d", Uint160Size, len(b))
 	}
-	copy(u[:], b)
-	return
+	return Uint160(b), nil
 }
 
 // Uint160DecodeBytesLE attempts to decode the given bytes in little-endian

--- a/pkg/util/uint256.go
+++ b/pkg/util/uint256.go
@@ -50,8 +50,7 @@ func Uint256DecodeBytesBE(b []byte) (u Uint256, err error) {
 	if len(b) != Uint256Size {
 		return u, fmt.Errorf("expected []byte of size %d got %d", Uint256Size, len(b))
 	}
-	copy(u[:], b)
-	return u, nil
+	return Uint256(b), nil
 }
 
 // Uint256DecodeBytesLE attempts to decode the given string (in LE representation) into a Uint256.


### PR DESCRIPTION
https://github.com/nspcc-dev/neo-go/blob/5566e354d451fd14d3b2a856cfe4b1b654a7343e/pkg/core/blockchain.go#L1185-L1186 also looks like a candidate, but (un)fortunately the slice len is not checked, so the conversion cannot be used