### PR TITLE
rpcsrv: improve witness verification error

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2902,7 +2902,7 @@ var (
 func (bc *Blockchain) InitVerificationContext(ic *interop.Context, hash util.Uint160, witness *transaction.Witness) error {
 	if len(witness.VerificationScript) != 0 {
 		if witness.ScriptHash() != hash {
-			return ErrWitnessHashMismatch
+			return fmt.Errorf("%w: expected %s, got %s", ErrWitnessHashMismatch, hash.StringLE(), witness.ScriptHash().StringLE())
 		}
 		if bc.contracts.ByHash(hash) != nil {
 			return ErrNativeContractWitness

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -991,7 +991,7 @@ func (s *Server) calculateNetworkFee(reqParams params.Params) (any, *neorpc.Erro
 		}
 		gasConsumed, err := s.chain.VerifyWitness(signer.Account, tx, &w, gasLimit)
 		if err != nil && !errors.Is(err, core.ErrInvalidSignature) {
-			return nil, neorpc.WrapErrorWithData(neorpc.ErrInvalidSignature, err.Error())
+			return nil, neorpc.WrapErrorWithData(neorpc.ErrInvalidSignature, fmt.Sprintf("witness %d: %s", i, err))
 		}
 		gasLimit -= gasConsumed
 		netFee += gasConsumed


### PR DESCRIPTION
It's needed to give user a hint about what's wrong with the witness during `calculatenetworkfee` RPC request processing.