### PR TITLE
config: drop MTB value for NeoFS networks to three days

### DIFF
--- a/config/protocol.mainnet.neofs.yml
+++ b/config/protocol.mainnet.neofs.yml
@@ -1,6 +1,6 @@
 ProtocolConfiguration:
   Magic: 91414437
-  MaxTraceableBlocks: 2102400
+  MaxTraceableBlocks: 17280
   InitialGASSupply: 52000000
   TimePerBlock: 15s
   MemPoolSize: 50000

--- a/config/protocol.testnet.neofs.yml
+++ b/config/protocol.testnet.neofs.yml
@@ -1,6 +1,6 @@
 ProtocolConfiguration:
   Magic: 735783775
-  MaxTraceableBlocks: 2102400
+  MaxTraceableBlocks: 17280
   InitialGASSupply: 52000000
   TimePerBlock: 15s
   MemPoolSize: 50000


### PR DESCRIPTION
We want to cut the tail more aggressively, what matters is state, but not old blocks and transactions that contracts don't use in any way. #3493 suggests that it's safe to limit the tail to one day, but let's be a bit more conservative for now.

As a sidenote, EVM only allows to fetch things from the recent 256 blocks.