### PR TITLE
rpcclient/WS: do not deadlock on connection loss

### DIFF
--- a/pkg/rpcclient/wsclient.go
+++ b/pkg/rpcclient/wsclient.go
@@ -601,7 +601,13 @@ readloop:
 				connCloseErr = fmt.Errorf("unknown response channel for response %d", id)
 				break readloop // Unknown response (unexpected response ID).
 			}
-			ch <- &rr.Response
+			select {
+			case <-c.writerDone:
+				break readloop
+			case <-c.shutdown:
+				break readloop
+			case ch <- &rr.Response:
+			}
 		} else {
 			// Malformed response, neither valid request, nor valid response.
 			connCloseErr = fmt.Errorf("malformed response")


### PR DESCRIPTION
`makeWsRequest` creates a channel for response and waits for it. If between creating the channel and starting the reading `select` connection is lost (`writerDone` channel is closed), nothing reads from the channel and a deadlock appears. Looking at "done" channels when transferring RPC data solves the issue. Closes #3530.