### PR TITLE
smartcontrct: take care of manifest permission descriptor wildcardness

### DIFF
--- a/pkg/smartcontract/manifest/container.go
+++ b/pkg/smartcontract/manifest/container.go
@@ -64,8 +64,12 @@ func (c *WildPermissionDescs) Restrict() {
 // Add adds v to the container.
 func (c *WildStrings) Add(v string) { c.Value = append(c.Value, v) }
 
-// Add adds v to the container.
-func (c *WildPermissionDescs) Add(v PermissionDesc) { c.Value = append(c.Value, v) }
+// Add adds v to the container and converts container to non-wildcard (if it's still
+// wildcard).
+func (c *WildPermissionDescs) Add(v PermissionDesc) {
+	c.Value = append(c.Value, v)
+	c.Wildcard = false
+}
 
 // MarshalJSON implements the json.Marshaler interface.
 func (c WildStrings) MarshalJSON() ([]byte, error) {

--- a/pkg/smartcontract/manifest/container_test.go
+++ b/pkg/smartcontract/manifest/container_test.go
@@ -81,6 +81,17 @@ func TestContainer_Add(t *testing.T) {
 		require.False(t, c.Contains(PermissionDesc{Type: PermissionHash, Value: random.Uint160()}))
 		require.False(t, c.Contains(PermissionDesc{Type: PermissionGroup, Value: pkRand.PublicKey()}))
 	})
+
+	t.Run("from wildcard", func(t *testing.T) {
+		c := &WildPermissionDescs{
+			Value:    nil,
+			Wildcard: true,
+		}
+		require.True(t, c.IsWildcard())
+
+		c.Add(PermissionDesc{Type: PermissionHash, Value: random.Uint160()})
+		require.False(t, c.IsWildcard())
+	})
 }
 
 func TestContainer_MarshalJSON(t *testing.T) {


### PR DESCRIPTION
Starting from b10af1ed313283e081199a24cbda5ae5c99427b0 (*WildPermissionDescs).Add method's call is not enough to construct a proper restricted permission descriptor, because Wildcard field should be set properly at the same time. Ref. #3523.

There's nothing critical in the current implementation, but at the same time this PR allows to avoid possible future bug.