### PR TITLE
docs: adjust DB compatibility notes

### DIFF
--- a/docs/node-configuration.md
+++ b/docs/node-configuration.md
@@ -412,9 +412,9 @@ configurations you may want to save some resources by performing synchronization
 on one node and then copying the DB over to other instances. In general, this
 can be done and this is supported, but NeoGo has a lot of options that may
 affect this:
-- any differences in `ProtocolConfiguration` section make databases
-  incompatible, except for `Max*` settings, `MemPoolSize`,
-  `P2PNotaryRequestPayloadPoolSize`, `SeedList`, `TimePerBlock`.
+- any differences in `ProtocolConfiguration` section make (or may make) databases
+  incompatible, except for `MemPoolSize`, `P2PNotaryRequestPayloadPoolSize`,
+  `SeedList`, `TimePerBlock`.
   Protocol configuration is expected to be the same on all nodes of the same
   network, so don't touch it unless you know what you're doing.
 - DB types (Level/Bolt) must be the same


### PR DESCRIPTION
It's dangerous to change `Max*` ProtocolConfiguration settings:

* Changes in MaxBlockSize, MaxBlockSystemFee and MaxTransactionsPerBlock may lead to the fact that accepted block or transaction becomes invalid. I agree that these settings are not written in the DB, but at the same time it's not correct to compare databases that have these settings mismatched.
* Changes in MaxTraceableBlocks may lead to the fact that some transaction will be processed differently, it's a possible contract state mismatch.
* Changes in MaxValidUntilBlockIncrement may lead to the fact that `setMaxNotValidBeforeDelta` method of native Notary contract may be processed in a different way which is also a possible contract state mismatch.

Ref. 5d29a3fdabb5f643b843e874fd8ffd8872ad01aa.