### PR TITLE
*: migrate to Docker Compose V2

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.4'
-
 networks:
   default:
     name: neo_go_network

--- a/Makefile
+++ b/Makefile
@@ -131,19 +131,19 @@ env_image:
 env_up:
 	@echo "=> Bootup environment"
 	@echo "   Docker-compose file: $(DC_FILE)"
-	@docker-compose -f $(DC_FILE) up -d node_one node_two node_three node_four
+	@docker compose -f $(DC_FILE) up -d node_one node_two node_three node_four
 
 env_single:
 	@echo "=> Bootup environment"
-	@docker-compose -f $(DC_FILE) up -d node_single
+	@docker compose -f $(DC_FILE) up -d node_single
 
 env_down:
 	@echo "=> Stop environment"
-	@docker-compose -f $(DC_FILE) down
+	@docker compose -f $(DC_FILE) down
 
 env_restart:
 	@echo "=> Stop and start environment"
-	@docker-compose -f $(DC_FILE) restart
+	@docker compose -f $(DC_FILE) restart
 
 env_clean: env_down
 	@echo "=> Cleanup environment"

--- a/docs/consensus.md
+++ b/docs/consensus.md
@@ -155,7 +155,7 @@ four-node setup.
 
 #### Prerequisites
 - `docker` of version >= 20.10.0
-- `docker-compose`
+- `docker compose` V2
 - `go` compiler
 
 #### Instructions
@@ -166,7 +166,7 @@ make env_up    # start containers, use "make env_single" for single CN
 ```
 To monitor logs:
 ```bash
-docker-compose -f .docker/docker-compose.yml logs -f
+docker compose -f .docker/docker-compose.yml logs -f
 ```
 
 To stop:


### PR DESCRIPTION
Docker Compose V1 is deprecated since June 2023, ref. https://docs.docker.com/compose/migrate/ and
https://github.com/nspcc-dev/neo-bench/issues/166.