### PR TITLE
Improve neotest to serve coverage needs

### DIFF
--- a/pkg/core/native/management_neotest_test.go
+++ b/pkg/core/native/management_neotest_test.go
@@ -127,7 +127,7 @@ func TestManagement_CallInTheSameBlock(t *testing.T) {
 		m.Name = "another contract"
 		h := state.CreateContractHash(e.Validator.ScriptHash(), ne.Checksum, m.Name)
 
-		txDeploy := e.NewDeployTx(t, e.Chain, &neotest.Contract{Hash: h, NEF: ne, Manifest: m}, nil)
+		txDeploy := e.NewDeployTx(t, &neotest.Contract{Hash: h, NEF: ne, Manifest: m}, nil)
 		txHasMethod := e.NewTx(t, []neotest.Signer{e.Validator}, bc.ManagementContractHash(), "hasMethod", h, "main", 0)
 
 		txCall := e.NewUnsignedTx(t, h, "main") // Test invocation doesn't give true GAS cost before deployment.

--- a/pkg/core/native/native_test/cryptolib_verification_test.go
+++ b/pkg/core/native/native_test/cryptolib_verification_test.go
@@ -67,7 +67,7 @@ func TestCryptoLib_KoblitzVerificationScript(t *testing.T) {
 			},
 		}
 		neotest.AddNetworkFee(t, e.Chain, tx)
-		neotest.AddSystemFee(e.Chain, tx, -1)
+		e.AddSystemFee(tx, -1)
 
 		// Add some more network fee to pay for the witness verification. This value may be calculated precisely,
 		// but let's keep some inaccurate value for the test.
@@ -631,7 +631,7 @@ func TestCryptoLib_KoblitzMultisigVerificationScript(t *testing.T) {
 			},
 		}
 		neotest.AddNetworkFee(t, e.Chain, tx)
-		neotest.AddSystemFee(e.Chain, tx, -1)
+		e.AddSystemFee(tx, -1)
 
 		// Add some more network fee to pay for the witness verification. This value may be calculated precisely,
 		// but let's keep some inaccurate value for the test.

--- a/pkg/core/native/native_test/ledger_test.go
+++ b/pkg/core/native/native_test/ledger_test.go
@@ -227,7 +227,7 @@ func TestLedger_GetTransactionSignersInteropAPI(t *testing.T) {
 		},
 	}}
 	neotest.AddNetworkFee(t, e.Chain, tx, c.Committee)
-	neotest.AddSystemFee(e.Chain, tx, -1)
+	e.AddSystemFee(tx, -1)
 	require.NoError(t, c.Committee.SignTx(e.Chain.GetConfig().Magic, tx))
 	c.AddNewBlock(t, tx)
 	c.CheckHalt(t, tx.Hash(), stackitem.Make(e.Chain.BlockHeight()-1))


### PR DESCRIPTION
1. Bind `neotest.AddSystemFee` and `neotest.TestInvoke` to `Executor` state.
2. Calculate system fee for deployment transactions.

Reasons are explained in the commit messages. @roman-khimov, these commits made in a breaking way, but if we care about our users a lot, then I can mark related methods as "deprecated" and introduce new `Executor` methods in a soft way. Do we?

A ground for #3462.