### PR TITLE
Make PollingBased waiter more flexible

### DIFF
--- a/pkg/rpcclient/actor/actor.go
+++ b/pkg/rpcclient/actor/actor.go
@@ -106,10 +106,10 @@ type Options struct {
 	// before it's signed (other methods that perform test invocations
 	// use CheckerModifier). MakeUnsigned* methods do not run it.
 	Modifier TransactionModifier
-	// waiter.PollConfig is used by [waiter.Waiter] constructor to customize
-	// [waiter.PollingBased] behaviour. This option may be kept empty for default
-	// polling behaviour.
-	waiter.PollConfig
+	// WaiterConfig is used by [waiter.Waiter] constructor to customize
+	// awaiting behaviour. This option may be kept empty for default
+	// awaiting behaviour.
+	WaiterConfig waiter.Config
 }
 
 // New creates an Actor instance using the specified RPC interface and the set of
@@ -187,7 +187,7 @@ func NewTuned(ra RPCActor, signers []SignerAccount, opts Options) (*Actor, error
 	if opts.Modifier != nil {
 		a.opts.Modifier = opts.Modifier
 	}
-	a.Waiter = waiter.NewCustom(ra, a.version, opts.PollConfig)
+	a.Waiter = waiter.NewCustom(ra, a.version, opts.WaiterConfig)
 	return a, err
 }
 

--- a/pkg/rpcclient/actor/actor.go
+++ b/pkg/rpcclient/actor/actor.go
@@ -106,6 +106,10 @@ type Options struct {
 	// before it's signed (other methods that perform test invocations
 	// use CheckerModifier). MakeUnsigned* methods do not run it.
 	Modifier TransactionModifier
+	// waiter.PollConfig is used by [waiter.Waiter] constructor to customize
+	// [waiter.PollingBased] behaviour. This option may be kept empty for default
+	// polling behaviour.
+	waiter.PollConfig
 }
 
 // New creates an Actor instance using the specified RPC interface and the set of
@@ -183,6 +187,7 @@ func NewTuned(ra RPCActor, signers []SignerAccount, opts Options) (*Actor, error
 	if opts.Modifier != nil {
 		a.opts.Modifier = opts.Modifier
 	}
+	a.Waiter = waiter.NewCustom(ra, a.version, opts.PollConfig)
 	return a, err
 }
 

--- a/pkg/rpcclient/waiter/waiter.go
+++ b/pkg/rpcclient/waiter/waiter.go
@@ -167,9 +167,6 @@ func (w *PollingBased) WaitAny(ctx context.Context, vub uint32, hashes ...util.U
 		failedAttempt int
 		pollTime      = time.Millisecond * time.Duration(w.version.Protocol.MillisecondsPerBlock) / 2
 	)
-	if pollTime == 0 {
-		pollTime = time.Second
-	}
 	timer := time.NewTicker(pollTime)
 	defer timer.Stop()
 	for {

--- a/pkg/rpcclient/waiter/waiter.go
+++ b/pkg/rpcclient/waiter/waiter.go
@@ -118,14 +118,26 @@ func errIsAlreadyExists(err error) bool {
 // or not an implementation of these two interfaces. It returns websocket-based
 // waiter, polling-based waiter or a stub correspondingly.
 func New(base any, v *result.Version) Waiter {
+	return NewCustom(base, v, PollConfig{})
+}
+
+// NewCustom creates Waiter instance. It can be either websocket-based or
+// polling-base, otherwise Waiter stub is returned. As a first argument
+// it accepts RPCEventBased implementation, RPCPollingBased implementation
+// or not an implementation of these two interfaces. It returns websocket-based
+// waiter, polling-based waiter or a stub correspondingly. As the second
+// argument it accepts the RPC node version necessary for awaiting behaviour
+// customisation. As a third argument it accepts the configuration of
+// [PollingBased] [Waiter].
+func NewCustom(base any, v *result.Version, pollConfig PollConfig) Waiter {
 	if eventW, ok := base.(RPCEventBased); ok {
 		return &EventBased{
 			ws:      eventW,
-			polling: newCustomPollingBased(eventW, v, PollConfig{}),
+			polling: newCustomPollingBased(eventW, v, pollConfig),
 		}
 	}
 	if pollW, ok := base.(RPCPollingBased); ok {
-		return newCustomPollingBased(pollW, v, PollConfig{})
+		return newCustomPollingBased(pollW, v, pollConfig)
 	}
 	return NewNull()
 }

--- a/pkg/services/rpcsrv/client_test.go
+++ b/pkg/services/rpcsrv/client_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/oracle"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/policy"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/rolemgmt"
+	"github.com/nspcc-dev/neo-go/pkg/rpcclient/waiter"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
@@ -1808,6 +1809,15 @@ func TestClient_Wait(t *testing.T) {
 		b, err := chain.GetBlock(chain.GetHeaderHash(1))
 		require.NoError(t, err)
 		require.True(t, len(b.Transactions) > 0)
+
+		// Ensure Waiter constructor works properly.
+		if ws {
+			_, ok := act.Waiter.(*waiter.EventBased)
+			require.True(t, ok)
+		} else {
+			_, ok := act.Waiter.(*waiter.PollingBased)
+			require.True(t, ok)
+		}
 
 		check := func(t *testing.T, h util.Uint256, vub uint32, errExpected bool) {
 			rcvr := make(chan struct{})


### PR DESCRIPTION
Networks with short block time can't use `1s` as a default poll interval, it's too harsh for them. Ref. https://github.com/nspcc-dev/neofs-node/issues/2864.