### PR TITLE
*: fix linter issues

### DIFF
--- a/internal/random/random_util.go
+++ b/internal/random/random_util.go
@@ -32,9 +32,9 @@ func Fill(buf []byte) {
 	r.Read(buf)
 }
 
-// Int returns a random integer in [min,max).
-func Int(min, max int) int {
-	return min + rand.Intn(max-min)
+// Int returns a random integer in [minI,maxI).
+func Int(minI, maxI int) int {
+	return minI + rand.Intn(maxI-minI)
 }
 
 // Uint256 returns a random Uint256.

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -196,7 +196,7 @@ type StateRoot interface {
 	CurrentLocalHeight() uint32
 	CurrentLocalStateRoot() util.Uint256
 	CurrentValidatedHeight() uint32
-	FindStates(root util.Uint256, prefix, start []byte, max int) ([]storage.KeyValue, error)
+	FindStates(root util.Uint256, prefix, start []byte, maxNum int) ([]storage.KeyValue, error)
 	SeekStates(root util.Uint256, prefix []byte, f func(k, v []byte) bool)
 	GetState(root util.Uint256, key []byte) ([]byte, error)
 	GetStateProof(root util.Uint256, key []byte) ([][]byte, error)

--- a/pkg/core/interop/iterator/interop.go
+++ b/pkg/core/interop/iterator/interop.go
@@ -36,25 +36,25 @@ func IsIterator(item stackitem.Item) bool {
 	return ok
 }
 
-// ValuesTruncated returns an array of up to `max` iterator values. The second
+// ValuesTruncated returns an array of up to `maxNum` iterator values. The second
 // return parameter denotes whether iterator is truncated, i.e. has more values.
 // The provided iterator CAN NOT be reused in the subsequent calls to Values and
 // to ValuesTruncated.
-func ValuesTruncated(item stackitem.Item, max int) ([]stackitem.Item, bool) {
-	result := Values(item, max)
+func ValuesTruncated(item stackitem.Item, maxNum int) ([]stackitem.Item, bool) {
+	result := Values(item, maxNum)
 	arr := item.Value().(iterator)
 	return result, arr.Next()
 }
 
-// Values returns an array of up to `max` iterator values. The provided
+// Values returns an array of up to `maxNum` iterator values. The provided
 // iterator can safely be reused to retrieve the rest of its values in the
 // subsequent calls to Values and to ValuesTruncated.
-func Values(item stackitem.Item, max int) []stackitem.Item {
+func Values(item stackitem.Item, maxNum int) []stackitem.Item {
 	var result []stackitem.Item
 	arr := item.Value().(iterator)
-	for max > 0 && arr.Next() {
+	for maxNum > 0 && arr.Next() {
 		result = append(result, arr.Value())
-		max--
+		maxNum--
 	}
 	return result
 }

--- a/pkg/core/mpt/trie.go
+++ b/pkg/core/mpt/trie.go
@@ -572,8 +572,8 @@ func collapse(depth int, node Node) Node {
 
 // Find returns a list of storage key-value pairs whose key is prefixed by the specified
 // prefix starting from the specified `prefix`+`from` path (not including the item at
-// the specified `prefix`+`from` path if so). The `max` number of elements is returned at max.
-func (t *Trie) Find(prefix, from []byte, max int) ([]storage.KeyValue, error) {
+// the specified `prefix`+`from` path if so). The `maxNum` number of elements is returned at max.
+func (t *Trie) Find(prefix, from []byte, maxNum int) ([]storage.KeyValue, error) {
 	if len(prefix) > MaxKeyLength {
 		return nil, errors.New("invalid prefix length")
 	}
@@ -622,7 +622,7 @@ func (t *Trie) Find(prefix, from []byte, max int) ([]storage.KeyValue, error) {
 				count++
 			}
 		}
-		return count >= max
+		return count >= maxNum
 	}
 	_, err = b.traverse(start, path, fromP, process, false, false)
 	if err != nil && !errors.Is(err, errStop) {

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -260,7 +260,7 @@ func GetContractScriptHash(d *dao.Simple, id int32) (util.Uint160, error) {
 	return util.Uint160DecodeBytesBE(si)
 }
 
-func getLimitedSlice(arg stackitem.Item, max int) ([]byte, error) {
+func getLimitedSlice(arg stackitem.Item, maxLen int) ([]byte, error) {
 	_, isNull := arg.(stackitem.Null)
 	if isNull {
 		return nil, nil
@@ -272,8 +272,8 @@ func getLimitedSlice(arg stackitem.Item, max int) ([]byte, error) {
 	l := len(b)
 	if l == 0 {
 		return nil, errors.New("empty")
-	} else if l > max {
-		return nil, fmt.Errorf("len is %d (max %d)", l, max)
+	} else if l > maxLen {
+		return nil, fmt.Errorf("len is %d (max %d)", l, maxLen)
 	}
 
 	return b, nil

--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -1015,7 +1015,7 @@ func (n *NEO) ModifyAccountVotes(acc *state.NEOBalance, d *dao.Simple, value *bi
 	return nil
 }
 
-func (n *NEO) getCandidates(d *dao.Simple, sortByKey bool, max int) ([]keyWithVotes, error) {
+func (n *NEO) getCandidates(d *dao.Simple, sortByKey bool, maxNum int) ([]keyWithVotes, error) {
 	arr := make([]keyWithVotes, 0)
 	buf := io.NewBufBinWriter()
 	d.Seek(n.ID, storage.SeekRange{Prefix: []byte{prefixCandidate}}, func(k, v []byte) bool {
@@ -1025,7 +1025,7 @@ func (n *NEO) getCandidates(d *dao.Simple, sortByKey bool, max int) ([]keyWithVo
 			arr = append(arr, keyWithVotes{Key: string(k), Votes: &c.Votes})
 		}
 		buf.Reset()
-		return !sortByKey || max > 0 && len(arr) < max
+		return !sortByKey || maxNum > 0 && len(arr) < maxNum
 	})
 
 	if !sortByKey {

--- a/pkg/core/native/native_test/common_test.go
+++ b/pkg/core/native/native_test/common_test.go
@@ -50,9 +50,9 @@ func testGetSet(t *testing.T, c *neotest.ContractInvoker, name string, defaultVa
 	if maxValue != 0 {
 		t.Run("set, too large value", func(t *testing.T) {
 			// use big.Int because max can be `math.MaxInt64`
-			max := big.NewInt(maxValue)
-			max.Add(max, big.NewInt(1))
-			committeeInvoker.InvokeFail(t, "", setName, max)
+			m := big.NewInt(maxValue)
+			m.Add(m, big.NewInt(1))
+			committeeInvoker.InvokeFail(t, "", setName, m)
 		})
 	}
 

--- a/pkg/core/stateroot/module.go
+++ b/pkg/core/stateroot/module.go
@@ -81,16 +81,16 @@ func (s *Module) GetState(root util.Uint256, key []byte) ([]byte, error) {
 }
 
 // FindStates returns a set of key-value pairs with keys matching the prefix starting
-// from the `prefix`+`start` path from MPT with the specified root. `max` is
+// from the `prefix`+`start` path from MPT with the specified root. `maxNum` is
 // the maximum number of elements to be returned. If nil `start` is specified, then the
 // item with the key equal to the prefix is included into the result; if empty `start` is specified,
 // then the item with the key equal to the prefix is not included into the result.
 // In case there are no results (prefix is unused, start is after the last available
 // element) mpt.ErrNotFound is returned.
-func (s *Module) FindStates(root util.Uint256, prefix, start []byte, max int) ([]storage.KeyValue, error) {
+func (s *Module) FindStates(root util.Uint256, prefix, start []byte, maxNum int) ([]storage.KeyValue, error) {
 	// Allow accessing old values, it's RO thing.
 	tr := mpt.NewTrie(mpt.NewHashNode(root), s.mode&^mpt.ModeGCFlag, storage.NewMemCachedStore(s.Store))
-	return tr.Find(prefix, start, max)
+	return tr.Find(prefix, start, maxNum)
 }
 
 // SeekStates traverses over contract storage with the state based on the

--- a/pkg/rpcclient/unwrap/unwrap.go
+++ b/pkg/rpcclient/unwrap/unwrap.go
@@ -83,15 +83,15 @@ func Int64(r *result.Invoke, err error) (int64, error) {
 // LimitedInt64 is similar to Int64 except it allows to set minimum and maximum
 // limits to be checked, so if it doesn't return an error the value is more than
 // min and less than max.
-func LimitedInt64(r *result.Invoke, err error, min int64, max int64) (int64, error) {
+func LimitedInt64(r *result.Invoke, err error, minI int64, maxI int64) (int64, error) {
 	i, err := Int64(r, err)
 	if err != nil {
 		return 0, err
 	}
-	if i < min {
+	if i < minI {
 		return 0, errors.New("too small value")
 	}
-	if i > max {
+	if i > maxI {
 		return 0, errors.New("too big value")
 	}
 	return i, nil

--- a/pkg/services/rpcsrv/client_test.go
+++ b/pkg/services/rpcsrv/client_test.go
@@ -1478,11 +1478,11 @@ func TestClient_IteratorSessions(t *testing.T) {
 	t.Run("traverse with max constraint", func(t *testing.T) {
 		sID, iID := prepareSession(t)
 		check := func(t *testing.T, start, end int) {
-			max := end - start
-			set, err := c.TraverseIterator(sID, iID, max)
+			maxNum := end - start
+			set, err := c.TraverseIterator(sID, iID, maxNum)
 			require.NoError(t, err)
-			require.Equal(t, max, len(set))
-			for i := 0; i < max; i++ {
+			require.Equal(t, maxNum, len(set))
+			for i := 0; i < maxNum; i++ {
 				// According to the Storage contract code.
 				require.Equal(t, expected[start+i], set[i].Value().([]byte), start+i)
 			}
@@ -1672,11 +1672,11 @@ func TestClient_Iterator_SessionConfigVariations(t *testing.T) {
 		require.True(t, ok)
 		require.NotEmpty(t, iterator.ID)
 		require.Empty(t, iterator.Values)
-		max := 84
-		actual, err := c.TraverseIterator(res.Session, *iterator.ID, max)
+		maxNum := 84
+		actual, err := c.TraverseIterator(res.Session, *iterator.ID, maxNum)
 		require.NoError(t, err)
-		require.Equal(t, max, len(actual))
-		for i := 0; i < max; i++ {
+		require.Equal(t, maxNum, len(actual))
+		for i := 0; i < maxNum; i++ {
 			// According to the Storage contract code.
 			require.Equal(t, expected[i], actual[i].Value().([]byte), i)
 		}


### PR DESCRIPTION
Linter is updated up to v1.60.1, the following issue is fixed:
```
predeclared  variable max has same name as predeclared identifier
```