### PR TITLE
*: add invocations to applicationlog

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1717,6 +1717,7 @@ func (bc *Blockchain) storeBlock(block *block.Block, txpool *mempool.Pool) error
 				Stack:          v.Estack().ToArray(),
 				Events:         systemInterop.Notifications,
 				FaultException: faultException,
+				Invocations:    systemInterop.InvocationCalls,
 			},
 		}
 		appExecResults = append(appExecResults, aer)

--- a/pkg/core/dao/dao_test.go
+++ b/pkg/core/dao/dao_test.go
@@ -193,7 +193,7 @@ func TestStoreAsTransaction(t *testing.T) {
 				Invocations: []state.ContractInvocation{{
 					Hash:   util.Uint160{},
 					Method: "fakeMethodCall",
-					Params: stackitem.NewArray([]stackitem.Item{
+					Arguments: stackitem.NewArray([]stackitem.Item{
 						stackitem.NewBool(false),
 					}),
 				}},

--- a/pkg/core/dao/dao_test.go
+++ b/pkg/core/dao/dao_test.go
@@ -180,8 +180,23 @@ func TestStoreAsTransaction(t *testing.T) {
 			Container: hash,
 			Execution: state.Execution{
 				Trigger: trigger.Application,
-				Events:  []state.NotificationEvent{},
-				Stack:   []stackitem.Item{},
+				Events: []state.NotificationEvent{
+					{
+						ScriptHash: util.Uint160{},
+						Name:       "fakeTransferEvent",
+						Item: stackitem.NewArray([]stackitem.Item{
+							stackitem.NewBool(false),
+						}),
+					},
+				},
+				Stack: []stackitem.Item{},
+				Invocations: []state.ContractInvocation{{
+					Hash:   util.Uint160{},
+					Method: "fakeMethodCall",
+					Params: stackitem.NewArray([]stackitem.Item{
+						stackitem.NewBool(false),
+					}),
+				}},
 			},
 		}
 		err := dao.StoreAsTransaction(tx, 0, aer)

--- a/pkg/core/interop/context.go
+++ b/pkg/core/interop/context.go
@@ -63,6 +63,7 @@ type Context struct {
 	VM               *vm.VM
 	Functions        []Function
 	Invocations      map[util.Uint160]int
+	InvocationCalls  []state.ContractInvocation
 	cancelFuncs      []context.CancelFunc
 	getContract      func(*dao.Simple, util.Uint160) (*state.Contract, error)
 	baseExecFee      int64

--- a/pkg/core/interop/contract/call.go
+++ b/pkg/core/interop/contract/call.go
@@ -71,9 +71,9 @@ func Call(ic *interop.Context) error {
 	hasReturn := md.ReturnType != smartcontract.VoidType
 
 	ic.InvocationCalls = append(ic.InvocationCalls, state.ContractInvocation{
-		Hash:   u,
-		Method: method,
-		Params: stackitem.NewArray(args),
+		Hash:      u,
+		Method:    method,
+		Arguments: stackitem.NewArray(args),
 	})
 	return callInternal(ic, cs, method, fs, hasReturn, args, true)
 }

--- a/pkg/core/interop/contract/call.go
+++ b/pkg/core/interop/contract/call.go
@@ -69,6 +69,12 @@ func Call(ic *interop.Context) error {
 		return fmt.Errorf("method not found: %s/%d", method, len(args))
 	}
 	hasReturn := md.ReturnType != smartcontract.VoidType
+
+	ic.InvocationCalls = append(ic.InvocationCalls, state.ContractInvocation{
+		Hash:   u,
+		Method: method,
+		Params: stackitem.NewArray(args),
+	})
 	return callInternal(ic, cs, method, fs, hasReturn, args, true)
 }
 

--- a/pkg/core/state/notification_event.go
+++ b/pkg/core/state/notification_event.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/trigger"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -18,6 +17,74 @@ type NotificationEvent struct {
 	ScriptHash util.Uint160     `json:"contract"`
 	Name       string           `json:"eventname"`
 	Item       *stackitem.Array `json:"state"`
+}
+
+type ContractInvocation struct {
+	Hash   util.Uint160     `json:"contract_hash"`
+	Method string           `json:"method"`
+	Params *stackitem.Array `json:"parameters"`
+}
+
+func (ci *ContractInvocation) DecodeBinary(r *io.BinReader) {
+	ci.Hash.DecodeBinary(r)
+	ci.Method = r.ReadString()
+	params := stackitem.DecodeBinary(r)
+	if r.Err != nil {
+		return
+	}
+	arr, ok := params.Value().([]stackitem.Item)
+	if !ok {
+		r.Err = errors.New("Array or Struct expected")
+		return
+	}
+	ci.Params = stackitem.NewArray(arr)
+}
+
+func (ci *ContractInvocation) EncodeBinaryWithContext(w *io.BinWriter, sc *stackitem.SerializationContext) {
+	ci.Hash.EncodeBinary(w)
+	w.WriteString(ci.Method)
+	b, err := sc.Serialize(ci.Params, false)
+	if err != nil {
+		w.Err = err
+		return
+	}
+	w.WriteBytes(b)
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (ci ContractInvocation) MarshalJSON() ([]byte, error) {
+	item, err := stackitem.ToJSONWithTypes(ci.Params)
+	if err != nil {
+		item = []byte(fmt.Sprintf(`"error: %v"`, err))
+	}
+	return json.Marshal(ContractInvocationAux{
+		Hash:   ci.Hash,
+		Method: ci.Method,
+		Params: item,
+	})
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (ci *ContractInvocation) UnmarshalJSON(data []byte) error {
+	aux := new(ContractInvocationAux)
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	params, err := stackitem.FromJSONWithTypes(aux.Params)
+	if err != nil {
+		return err
+	}
+	if t := params.Type(); t != stackitem.ArrayT {
+		return fmt.Errorf("failed to convert invocation state of type %s to array", t.String())
+	}
+	ci.Params = params.(*stackitem.Array)
+	ci.Method = aux.Method
+	ci.Hash = aux.Hash
+	return nil
+}
+
+func (ci *ContractInvocation) EncodeBinary(w *io.BinWriter) {
+	ci.EncodeBinaryWithContext(w, stackitem.NewSerializationContext())
 }
 
 // AppExecResult represents the result of the script execution, gathering together
@@ -95,6 +162,10 @@ func (aer *AppExecResult) EncodeBinaryWithContext(w *io.BinWriter, sc *stackitem
 		aer.Events[i].EncodeBinaryWithContext(w, sc)
 	}
 	w.WriteVarBytes([]byte(aer.FaultException))
+	w.WriteVarUint(uint64(len(aer.Invocations)))
+	for i := range aer.Invocations {
+		aer.Invocations[i].EncodeBinaryWithContext(w, sc)
+	}
 }
 
 // DecodeBinary implements the Serializable interface.
@@ -120,6 +191,7 @@ func (aer *AppExecResult) DecodeBinary(r *io.BinReader) {
 	aer.Stack = arr
 	r.ReadArray(&aer.Events)
 	aer.FaultException = r.ReadString()
+	r.ReadArray(&aer.Invocations)
 }
 
 // notificationEventAux is an auxiliary struct for NotificationEvent JSON marshalling.
@@ -209,16 +281,24 @@ type Execution struct {
 	Stack          []stackitem.Item
 	Events         []NotificationEvent
 	FaultException string
+	Invocations    []ContractInvocation
+}
+
+type ContractInvocationAux struct {
+	Hash   util.Uint160    `json:"contract_hash"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"parameters"`
 }
 
 // executionAux represents an auxiliary struct for Execution JSON marshalling.
 type executionAux struct {
-	Trigger        string              `json:"trigger"`
-	VMState        string              `json:"vmstate"`
-	GasConsumed    int64               `json:"gasconsumed,string"`
-	Stack          json.RawMessage     `json:"stack"`
-	Events         []NotificationEvent `json:"notifications"`
-	FaultException *string             `json:"exception"`
+	Trigger        string               `json:"trigger"`
+	VMState        string               `json:"vmstate"`
+	GasConsumed    int64                `json:"gasconsumed,string"`
+	Stack          json.RawMessage      `json:"stack"`
+	Events         []NotificationEvent  `json:"notifications"`
+	FaultException *string              `json:"exception"`
+	Invocations    []ContractInvocation `json:"invocations"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -246,6 +326,7 @@ func (e Execution) MarshalJSON() ([]byte, error) {
 		Stack:          st,
 		Events:         e.Events,
 		FaultException: exception,
+		Invocations:    e.Invocations,
 	})
 }
 
@@ -287,6 +368,7 @@ func (e *Execution) UnmarshalJSON(data []byte) error {
 	if aux.FaultException != nil {
 		e.FaultException = *aux.FaultException
 	}
+	e.Invocations = aux.Invocations
 	return nil
 }
 

--- a/pkg/core/state/notification_event.go
+++ b/pkg/core/state/notification_event.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/trigger"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -20,30 +21,30 @@ type NotificationEvent struct {
 }
 
 type ContractInvocation struct {
-	Hash   util.Uint160     `json:"contract_hash"`
-	Method string           `json:"method"`
-	Params *stackitem.Array `json:"parameters"`
+	Hash      util.Uint160     `json:"contract_hash"`
+	Method    string           `json:"method"`
+	Arguments *stackitem.Array `json:"arguments"`
 }
 
 func (ci *ContractInvocation) DecodeBinary(r *io.BinReader) {
 	ci.Hash.DecodeBinary(r)
 	ci.Method = r.ReadString()
-	params := stackitem.DecodeBinary(r)
+	args := stackitem.DecodeBinary(r)
 	if r.Err != nil {
 		return
 	}
-	arr, ok := params.Value().([]stackitem.Item)
+	arr, ok := args.Value().([]stackitem.Item)
 	if !ok {
-		r.Err = errors.New("Array or Struct expected")
+		r.Err = errors.New("array or Struct expected")
 		return
 	}
-	ci.Params = stackitem.NewArray(arr)
+	ci.Arguments = stackitem.NewArray(arr)
 }
 
 func (ci *ContractInvocation) EncodeBinaryWithContext(w *io.BinWriter, sc *stackitem.SerializationContext) {
 	ci.Hash.EncodeBinary(w)
 	w.WriteString(ci.Method)
-	b, err := sc.Serialize(ci.Params, false)
+	b, err := sc.Serialize(ci.Arguments, false)
 	if err != nil {
 		w.Err = err
 		return
@@ -53,14 +54,14 @@ func (ci *ContractInvocation) EncodeBinaryWithContext(w *io.BinWriter, sc *stack
 
 // MarshalJSON implements the json.Marshaler interface.
 func (ci ContractInvocation) MarshalJSON() ([]byte, error) {
-	item, err := stackitem.ToJSONWithTypes(ci.Params)
+	item, err := stackitem.ToJSONWithTypes(ci.Arguments)
 	if err != nil {
 		item = []byte(fmt.Sprintf(`"error: %v"`, err))
 	}
 	return json.Marshal(ContractInvocationAux{
-		Hash:   ci.Hash,
-		Method: ci.Method,
-		Params: item,
+		Hash:      ci.Hash,
+		Method:    ci.Method,
+		Arguments: item,
 	})
 }
 
@@ -70,14 +71,14 @@ func (ci *ContractInvocation) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
 	}
-	params, err := stackitem.FromJSONWithTypes(aux.Params)
+	params, err := stackitem.FromJSONWithTypes(aux.Arguments)
 	if err != nil {
 		return err
 	}
 	if t := params.Type(); t != stackitem.ArrayT {
 		return fmt.Errorf("failed to convert invocation state of type %s to array", t.String())
 	}
-	ci.Params = params.(*stackitem.Array)
+	ci.Arguments = params.(*stackitem.Array)
 	ci.Method = aux.Method
 	ci.Hash = aux.Hash
 	return nil
@@ -285,9 +286,9 @@ type Execution struct {
 }
 
 type ContractInvocationAux struct {
-	Hash   util.Uint160    `json:"contract_hash"`
-	Method string          `json:"method"`
-	Params json.RawMessage `json:"parameters"`
+	Hash      util.Uint160    `json:"contract_hash"`
+	Method    string          `json:"method"`
+	Arguments json.RawMessage `json:"arguments"`
 }
 
 // executionAux represents an auxiliary struct for Execution JSON marshalling.


### PR DESCRIPTION
### Problem

https://github.com/neo-project/neo/issues/3386

### Solution

Implement as extension. Moved the discussion from Dora's backend [PR](https://github.com/CityOfZion/dora-server-NeoN3/pull/220) to here

### To do
- [ ] copy arguments to avoid modifications
- [ ] limit the total number of argument stack items in a single transaction (for safety)
- [ ] make this a configurable feature

Do we want to limit the stack item depth (think `MaxJSONDepth`) or are we content with just limiting the total stack arguments?
