### PR TITLE
.golangci.yml: add `intrange` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,7 @@ linters:
     - decorder
     - durationcheck
     - errorlint
+    - intrange
     - copyloopvar
     - gofmt
     - misspell

--- a/internal/testchain/address.go
+++ b/internal/testchain/address.go
@@ -142,7 +142,7 @@ func Sign(h hash.Hashable) []byte {
 // SignCommittee signs data by a majority of committee members.
 func SignCommittee(h hash.Hashable) []byte {
 	buf := io.NewBufBinWriter()
-	for i := 0; i < CommitteeSize()/2+1; i++ {
+	for i := range CommitteeSize()/2 + 1 {
 		pKey := PrivateKey(i)
 		sig := pKey.SignHashable(uint32(Network()), h)
 		if len(sig) != 64 {

--- a/pkg/core/blockchain_core_test.go
+++ b/pkg/core/blockchain_core_test.go
@@ -116,7 +116,7 @@ func TestRemoveOldTransfers(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, 0, len(log.Raw))
 
-	for i := uint32(0); i < 3; i++ {
+	for i := range uint32(3) {
 		log, err = bc.dao.GetTokenTransferLog(acc2, newer, i, false)
 		require.NoError(t, err)
 		require.NotEqual(t, 0, len(log.Raw))
@@ -130,7 +130,7 @@ func TestRemoveOldTransfers(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, 0, len(log.Raw))
 
-	for i := uint32(0); i < 2; i++ {
+	for i := range uint32(2) {
 		log, err = bc.dao.GetTokenTransferLog(acc3, newer, i, true)
 		require.NoError(t, err)
 		require.NotEqual(t, 0, len(log.Raw))

--- a/pkg/core/mpt/helpers.go
+++ b/pkg/core/mpt/helpers.go
@@ -13,17 +13,13 @@ func lcp(a, b []byte) []byte {
 		return lcp(b, a)
 	}
 
-	var i int
-	//nolint:intrange // if slices are the same (or one is a prefix for another
-	// one), `range` loop does not assign the latest index to the `i` var, and
-	// the func loses the latest element
-	for i = 0; i < len(b); i++ {
+	for i := range b {
 		if a[i] != b[i] {
-			break
+			return b[:i]
 		}
 	}
 
-	return a[:i]
+	return b
 }
 
 func lcpMany(kv []keyValue) []byte {

--- a/pkg/core/mpt/helpers.go
+++ b/pkg/core/mpt/helpers.go
@@ -14,6 +14,9 @@ func lcp(a, b []byte) []byte {
 	}
 
 	var i int
+	//nolint:intrange // if slices are the same (or one is a prefix for another
+	// one), `range` loop does not assign the latest index to the `i` var, and
+	// the func loses the latest element
 	for i = 0; i < len(b); i++ {
 		if a[i] != b[i] {
 			break

--- a/pkg/core/native/native_test/neo_test.go
+++ b/pkg/core/native/native_test/neo_test.go
@@ -821,7 +821,7 @@ func TestNEO_GetCandidates(t *testing.T) {
 		for i := range len(expected) + 1 {
 			w := io.NewBufBinWriter()
 			emit.AppCall(w.BinWriter, neoCommitteeInvoker.Hash, "getAllCandidates", callflag.All)
-			for j := 0; j < i+1; j++ {
+			for range i + 1 {
 				emit.Opcodes(w.BinWriter, opcode.DUP)
 				emit.Syscall(w.BinWriter, interopnames.SystemIteratorNext)
 				emit.Opcodes(w.BinWriter, opcode.DROP) // drop the value returned from Next.

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1860,7 +1860,7 @@ func (v *VM) ContractHasTryBlock() bool {
 		if ictx.sc != topctx.sc {
 			return false // Different contract -> no one cares.
 		}
-		for j := 0; j < ictx.tryStack.Len(); j++ {
+		for j := range ictx.tryStack.Len() {
 			eCtx := ictx.tryStack.Peek(j).Value().(*exceptionHandlingContext)
 			if eCtx.State == eTry {
 				return true


### PR DESCRIPTION
It checks that go 1.22's range-over-numbers feature is not skipped. Also, fix some warnings it found.
