### PR TITLE
neotest: don't collect coverage for contracts with empty DI

### DIFF
--- a/pkg/neotest/coverage.go
+++ b/pkg/neotest/coverage.go
@@ -203,6 +203,11 @@ func documentSeqPoints(di *compiler.DebugInfo, doc documentName) []compiler.Debu
 }
 
 func addScriptToCoverage(c *Contract) {
+	// Any garbage may be passed to deployment methods, filter out useless contracts
+	// to avoid misleading behaviour during coverage collection.
+	if c.DebugInfo == nil || c.Hash.Equals(util.Uint160{}) {
+		return
+	}
 	coverageLock.Lock()
 	defer coverageLock.Unlock()
 	if _, ok := rawCoverage[c.Hash]; !ok {


### PR DESCRIPTION
Users are allowed to provide any contract to neotest, including those contracts that don't have DebugInfo filled in. Neotest should filter them out, otherwise panic may occur on attempt to write coverage profile:
```
--- FAIL: TestDeploys (0.01s)
panic: runtime error: invalid memory address or nil pointer dereference
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xc6f5b5]

goroutine 1735 [running]:
testing.tRunner.func1.2({0xd7aa80, 0x1723f60})
	/usr/local/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1634 +0x377
panic({0xd7aa80?, 0x1723f60?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/nspcc-dev/neo-go/pkg/neotest.processCover()
	/home/anna/go/pkg/mod/github.com/nspcc-dev/neo-go@v0.106.4-0.20241007094345-11151938b9bd/pkg/neotest/coverage.go:143 +0xd5
github.com/nspcc-dev/neo-go/pkg/neotest.writeCoverageReport({0x10c6260, 0xc00033a378})
	/home/anna/go/pkg/mod/github.com/nspcc-dev/neo-go@v0.106.4-0.20241007094345-11151938b9bd/pkg/neotest/coverage.go:123 +0x4b
github.com/nspcc-dev/neo-go/pkg/neotest.reportCoverage({0x10db278, 0xc00021a000})
	/home/anna/go/pkg/mod/github.com/nspcc-dev/neo-go@v0.106.4-0.20241007094345-11151938b9bd/pkg/neotest/coverage.go:118 +0x165
github.com/nspcc-dev/neo-go/pkg/neotest.(*Executor).trackCoverage.func1()
	/home/anna/go/pkg/mod/github.com/nspcc-dev/neo-go@v0.106.4-0.20241007094345-11151938b9bd/pkg/neotest/basic.go:182 +0x1b
testing.(*common).Cleanup.func1()
	/usr/local/go/src/testing/testing.go:1175 +0x10f
testing.(*common).runCleanup(0xc00021a000, 0x58d7c0?)
	/usr/local/go/src/testing/testing.go:1353 +0xdb
testing.(*common).runCleanup.func2()
	/usr/local/go/src/testing/testing.go:1337 +0x47
panic({0xd7aa80?, 0x1723f60?})
```

An example of such partially-filled contract is:
https://github.com/nspcc-dev/neofs-contract/blob/a8d5e001a2e5a552676eecd40ef78629ecdfafa2/tests/deploys_test.go#L13 https://github.com/nspcc-dev/neofs-contract/blob/a8d5e001a2e5a552676eecd40ef78629ecdfafa2/contracts/contracts.go#L96