### PR TITLE
stackitem: extend ToJSON test

### DIFF
--- a/pkg/vm/stackitem/json_test.go
+++ b/pkg/vm/stackitem/json_test.go
@@ -203,6 +203,18 @@ func TestToJSONCornerCases(t *testing.T) {
 		m.Add(Make([]byte{0xe9}), Make(true))
 		testToJSON(t, ErrInvalidValue, m)
 	})
+	t.Run("circular reference", func(t *testing.T) {
+		m := NewMap()
+		m.Add(Make("one"), Make(true))
+
+		// No circular reference, ensure it can be properly serialized.
+		arr := NewArray([]Item{m, m})
+		testToJSON(t, nil, arr)
+
+		// With circular reference, error expected.
+		m.Add(Make("two"), arr)
+		testToJSON(t, ErrTooBig, arr)
+	})
 }
 
 // getBigArray returns array takes up a lot of storage when serialized.


### PR DESCRIPTION
Inspired by https://github.com/neo-project/neo/pull/3558, although this PR fixes different implementation of stackitem serializatior that is used outside of VM.