### PR TITLE
workflows: remove macos-12 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{matrix.os.name}}
     strategy:
       matrix:
-        os: [{ name: ubuntu-22.04, bin-name: linux }, { name: windows-2022, bin-name: windows }, { name: macos-12, bin-name: darwin }]
+        os: [{ name: ubuntu-22.04, bin-name: linux }, { name: windows-2022, bin-name: windows }, { name: macos-14, bin-name: darwin }]
         arch: [amd64, arm64]
         exclude:
           - os: { name: windows-2022, bin-name: windows }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,13 +168,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
+        os: [ubuntu-22.04, windows-2022, macos-14]
         go_versions: [ '1.22', '1.23' ]
         exclude:
           # Only latest Go version for Windows and MacOS.
           - os: windows-2022
-            go_versions: '1.22'
-          - os: macos-12
             go_versions: '1.22'
           - os: macos-14
             go_versions: '1.22'


### PR DESCRIPTION
Support for macos-12 will be deprecated 10/7/24 and the image will be fully unsupported by 12/3/24. Ref.
https://github.com/actions/runner-images/issues/10721.

Get rid of the build warning:
```
A brownout will take place on November 4, 14:00 UTC - November 5, 00:00
UTC to raise awareness of the upcoming macOS-12 environment removal.
```