### PR TITLE
io: specify Bytes() behavior a bit better for BufBinWriter

### DIFF
--- a/pkg/io/binaryBufWriter.go
+++ b/pkg/io/binaryBufWriter.go
@@ -29,6 +29,8 @@ func (bw *BufBinWriter) Len() int {
 }
 
 // Bytes returns the resulting buffer and makes future writes return an error.
+// Subsequent calls to it will return nil. You can reuse this instance of
+// [BufBinWriter] after [BufBinWriter.Reset].
 func (bw *BufBinWriter) Bytes() []byte {
 	if bw.Err != nil {
 		return nil


### PR DESCRIPTION
It's not immediately obvious.

