### PR TITLE
neotest: extend cached compiled contract identifier in CompileFile

### DIFF
--- a/pkg/neotest/compile.go
+++ b/pkg/neotest/compile.go
@@ -22,7 +22,8 @@ type Contract struct {
 	DebugInfo *compiler.DebugInfo
 }
 
-// contracts caches the compiled contracts from FS across multiple tests.
+// contracts caches the compiled contracts from FS across multiple tests. The key is a
+// concatenation of the source file path and the config file path split by | symbol.
 var contracts = make(map[string]*Contract)
 
 // CompileSource compiles a contract from the reader and returns its NEF, manifest and hash.
@@ -49,8 +50,10 @@ func CompileSource(t testing.TB, sender util.Uint160, src io.Reader, opts *compi
 }
 
 // CompileFile compiles a contract from the file and returns its NEF, manifest and hash.
+// It uses contracts cashes.
 func CompileFile(t testing.TB, sender util.Uint160, srcPath string, configPath string) *Contract {
-	if c, ok := contracts[srcPath]; ok {
+	cacheKey := srcPath + "|" + configPath
+	if c, ok := contracts[cacheKey]; ok {
 		return c
 	}
 
@@ -84,6 +87,6 @@ func CompileFile(t testing.TB, sender util.Uint160, srcPath string, configPath s
 		Manifest:  m,
 		DebugInfo: di,
 	}
-	contracts[srcPath] = c
+	contracts[cacheKey] = c
 	return c
 }

--- a/pkg/neotest/compile_test.go
+++ b/pkg/neotest/compile_test.go
@@ -1,0 +1,28 @@
+package neotest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileFileCashedIdentifiers(t *testing.T) {
+	sender := util.Uint160{}
+	tmpDir := t.TempDir()
+
+	srcPath := "../../internal/basicchain/testdata/test_contract.go"
+	configPath1 := "../../internal/basicchain/testdata/test_contract.yml"
+	bytesRead, err := os.ReadFile(configPath1)
+	require.NoError(t, err)
+
+	configPath2 := filepath.Join(tmpDir, "test_contract_2.yml")
+	err = os.WriteFile(configPath2, bytesRead, 0755)
+	require.NoError(t, err)
+
+	contract1 := CompileFile(t, sender, srcPath, configPath1)
+	contract2 := CompileFile(t, sender, srcPath, configPath2)
+	require.NotEqual(t, contract1, contract2)
+}


### PR DESCRIPTION

Close #3542