### PR TITLE
Dockerfile: migrate to AS keyword usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Builder image
 # Keep go version in sync with Build GA job.
-FROM golang:1.23-alpine as builder
+FROM golang:1.23-alpine AS builder
 
 # Display go version for information purposes.
 RUN go version

--- a/Dockerfile.wsc
+++ b/Dockerfile.wsc
@@ -1,6 +1,6 @@
 # Builder image
 # Keep go version in sync with Build GA job.
-FROM golang:1.23.0-windowsservercore-ltsc2022 as builder
+FROM golang:1.23.0-windowsservercore-ltsc2022 AS builder
 
 COPY . /neo-go
 


### PR DESCRIPTION
Fix the following Docker image build warning that stops privnet image build:
```
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
```