### PR TITLE
config: enable hardforks for default NeoFS testnet config

### DIFF
--- a/config/protocol.testnet.neofs.yml
+++ b/config/protocol.testnet.neofs.yml
@@ -24,6 +24,11 @@ ProtocolConfiguration:
   - morph7.t5.fs.neo.org:50333
   VerifyTransactions: true
   P2PSigExtensions: true
+  Hardforks:
+    Aspidochelone: 0
+    Basilisk: 0
+    Cockatrice: 0
+    Domovoi: 0
 
 ApplicationConfiguration:
   SkipBlockVerification: false


### PR DESCRIPTION
Otherwise all hardforks enabled by default from genesis which leads to errors like this if we introduce new hardfork:
```
Dec 04 02:46:46 titan1 neofs-node[157390]: warn        client/multi.go:43        could not establish connection to RPC node        {"endpoint": "wss://rpc.morph.t5.fs.neo.org/ws", "error": "WS client initialization: failed to get network magic: unexpected hardfork: Echidna"}
```