### PR TITLE
network: fix "unexpected empty payload: CMDVersion"

### DIFF
--- a/pkg/network/message.go
+++ b/pkg/network/message.go
@@ -99,6 +99,9 @@ func (m *Message) Decode(br *io.BinReader) error {
 	m.Flags = MessageFlag(br.ReadB())
 	m.Command = CommandType(br.ReadB())
 	l := br.ReadVarUint()
+	if br.Err != nil {
+		return br.Err
+	}
 	// check the length first in order not to allocate memory
 	// for an empty compressed payload
 	if l == 0 {


### PR DESCRIPTION
We can have _a lot_ of these in the log, but the only reason they happen is because we're trying to interpret length before checking for reader error, CMDVersion is just 0.