### PR TITLE
services: fix defer function in `retry` of NeoFSBlockFetcher

### DIFF
--- a/pkg/services/blockfetcher/blockfetcher.go
+++ b/pkg/services/blockfetcher/blockfetcher.go
@@ -518,7 +518,10 @@ func (bfs *Service) retry(action func() error) error {
 	)
 	defer func() {
 		if !timer.Stop() {
-			<-timer.C
+			select {
+			case <-timer.C:
+			default:
+			}
 		}
 	}()
 


### PR DESCRIPTION
Close #3734