### PR TITLE
Improve compiler error reporting

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -913,7 +913,8 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 	case *ast.StarExpr:
 		_, ok := c.getStruct(c.typeOf(n.X))
 		if !ok {
-			c.prog.Err = errors.New("dereferencing is only supported on structs")
+			pos := c.buildInfo.config.Fset.Position(n.Pos())
+			c.prog.Err = fmt.Errorf("%s: dereferencing is only supported on structs", pos)
 			return nil
 		}
 		ast.Walk(c, n.X)
@@ -1158,7 +1159,8 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 				c.convertStruct(lit, true)
 				return nil
 			}
-			c.prog.Err = fmt.Errorf("'&' can be used only with struct literals")
+			pos := c.buildInfo.config.Fset.Position(n.Pos())
+			c.prog.Err = fmt.Errorf("%s: '&' can be used only with struct literals", pos)
 			return nil
 		}
 


### PR DESCRIPTION
### Problem
The compiler may fail without informing where the error is coming from. I found at least two places that can be fixed.

### Solution
Include the file line and position of the error message

Output example:
```
error while trying to compile smart contract file: .../abstract.go:101:9: '&' can be used only with struct literals
```

Note: I didn't find test cases covering this error so I didn't add any new test.