### PR TITLE
rpcbindings: fix missing return item

### DIFF
--- a/cli/smartcontract/testdata/rpcbindings/nft-nd/rpcbindings.out
+++ b/cli/smartcontract/testdata/rpcbindings/nft-nd/rpcbindings.out
@@ -266,13 +266,13 @@ func (res *NftRoyaltyRecipientShare) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray(res.Address.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Address: %w", err)
+		return nil, fmt.Errorf("field Address: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Share), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Share: %w", err)
+		return nil, fmt.Errorf("field Share: %w", err)
 	}
 	items = append(items, itm)
 

--- a/cli/smartcontract/testdata/rpcbindings/nft-nd/rpcbindings_dynamic_hash.out
+++ b/cli/smartcontract/testdata/rpcbindings/nft-nd/rpcbindings_dynamic_hash.out
@@ -261,13 +261,13 @@ func (res *NftRoyaltyRecipientShare) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray(res.Address.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Address: %w", err)
+		return nil, fmt.Errorf("field Address: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Share), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Share: %w", err)
+		return nil, fmt.Errorf("field Share: %w", err)
 	}
 	items = append(items, itm)
 

--- a/cli/smartcontract/testdata/rpcbindings/notifications/rpcbindings_extended.out
+++ b/cli/smartcontract/testdata/rpcbindings/notifications/rpcbindings_extended.out
@@ -248,13 +248,13 @@ func (res *CrazyStruct) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = (*stackitem.BigInteger)(res.I), error(nil)
 	if err != nil {
-		return fmt.Errorf("field I: %w", err)
+		return nil, fmt.Errorf("field I: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewBool(res.B), error(nil)
 	if err != nil {
-		return fmt.Errorf("field B: %w", err)
+		return nil, fmt.Errorf("field B: %w", err)
 	}
 	items = append(items, itm)
 
@@ -318,7 +318,7 @@ func (res *SimpleStruct) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = (*stackitem.BigInteger)(res.I), error(nil)
 	if err != nil {
-		return fmt.Errorf("field I: %w", err)
+		return nil, fmt.Errorf("field I: %w", err)
 	}
 	items = append(items, itm)
 

--- a/cli/smartcontract/testdata/rpcbindings/notifications/rpcbindings_guessed.out
+++ b/cli/smartcontract/testdata/rpcbindings/notifications/rpcbindings_guessed.out
@@ -248,13 +248,13 @@ func (res *Unnamed) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = (*stackitem.BigInteger)(res.I), error(nil)
 	if err != nil {
-		return fmt.Errorf("field I: %w", err)
+		return nil, fmt.Errorf("field I: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewBool(res.B), error(nil)
 	if err != nil {
-		return fmt.Errorf("field B: %w", err)
+		return nil, fmt.Errorf("field B: %w", err)
 	}
 	items = append(items, itm)
 
@@ -318,7 +318,7 @@ func (res *UnnamedX) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = (*stackitem.BigInteger)(res.I), error(nil)
 	if err != nil {
-		return fmt.Errorf("field I: %w", err)
+		return nil, fmt.Errorf("field I: %w", err)
 	}
 	items = append(items, itm)
 

--- a/cli/smartcontract/testdata/rpcbindings/structs/rpcbindings.out
+++ b/cli/smartcontract/testdata/rpcbindings/structs/rpcbindings.out
@@ -311,61 +311,61 @@ func (res *LedgerBlock) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray(res.Hash.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Hash: %w", err)
+		return nil, fmt.Errorf("field Hash: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Version), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Version: %w", err)
+		return nil, fmt.Errorf("field Version: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.PrevHash.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field PrevHash: %w", err)
+		return nil, fmt.Errorf("field PrevHash: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.MerkleRoot.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field MerkleRoot: %w", err)
+		return nil, fmt.Errorf("field MerkleRoot: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Timestamp), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Timestamp: %w", err)
+		return nil, fmt.Errorf("field Timestamp: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Nonce), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Nonce: %w", err)
+		return nil, fmt.Errorf("field Nonce: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Index), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Index: %w", err)
+		return nil, fmt.Errorf("field Index: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.PrimaryIndex), error(nil)
 	if err != nil {
-		return fmt.Errorf("field PrimaryIndex: %w", err)
+		return nil, fmt.Errorf("field PrimaryIndex: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.NextConsensus.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field NextConsensus: %w", err)
+		return nil, fmt.Errorf("field NextConsensus: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.TransactionsLength), error(nil)
 	if err != nil {
-		return fmt.Errorf("field TransactionsLength: %w", err)
+		return nil, fmt.Errorf("field TransactionsLength: %w", err)
 	}
 	items = append(items, itm)
 
@@ -491,49 +491,49 @@ func (res *LedgerTransaction) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray(res.Hash.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Hash: %w", err)
+		return nil, fmt.Errorf("field Hash: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Version), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Version: %w", err)
+		return nil, fmt.Errorf("field Version: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Nonce), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Nonce: %w", err)
+		return nil, fmt.Errorf("field Nonce: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Sender.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Sender: %w", err)
+		return nil, fmt.Errorf("field Sender: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.SysFee), error(nil)
 	if err != nil {
-		return fmt.Errorf("field SysFee: %w", err)
+		return nil, fmt.Errorf("field SysFee: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.NetFee), error(nil)
 	if err != nil {
-		return fmt.Errorf("field NetFee: %w", err)
+		return nil, fmt.Errorf("field NetFee: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.ValidUntilBlock), error(nil)
 	if err != nil {
-		return fmt.Errorf("field ValidUntilBlock: %w", err)
+		return nil, fmt.Errorf("field ValidUntilBlock: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Script), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Script: %w", err)
+		return nil, fmt.Errorf("field Script: %w", err)
 	}
 	items = append(items, itm)
 
@@ -643,7 +643,7 @@ func (res *ManagementABI) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Methods)
 	if err != nil {
-		return fmt.Errorf("field Methods: %w", err)
+		return nil, fmt.Errorf("field Methods: %w", err)
 	}
 	items = append(items, itm)
 
@@ -663,7 +663,7 @@ func (res *ManagementABI) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Events)
 	if err != nil {
-		return fmt.Errorf("field Events: %w", err)
+		return nil, fmt.Errorf("field Events: %w", err)
 	}
 	items = append(items, itm)
 
@@ -761,31 +761,31 @@ func (res *ManagementContract) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = (*stackitem.BigInteger)(res.ID), error(nil)
 	if err != nil {
-		return fmt.Errorf("field ID: %w", err)
+		return nil, fmt.Errorf("field ID: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.UpdateCounter), error(nil)
 	if err != nil {
-		return fmt.Errorf("field UpdateCounter: %w", err)
+		return nil, fmt.Errorf("field UpdateCounter: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Hash.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Hash: %w", err)
+		return nil, fmt.Errorf("field Hash: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.NEF), error(nil)
 	if err != nil {
-		return fmt.Errorf("field NEF: %w", err)
+		return nil, fmt.Errorf("field NEF: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = res.Manifest.ToStackItem()
 	if err != nil {
-		return fmt.Errorf("field Manifest: %w", err)
+		return nil, fmt.Errorf("field Manifest: %w", err)
 	}
 	items = append(items, itm)
 
@@ -877,7 +877,7 @@ func (res *ManagementEvent) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray([]byte(res.Name)), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Name: %w", err)
+		return nil, fmt.Errorf("field Name: %w", err)
 	}
 	items = append(items, itm)
 
@@ -897,7 +897,7 @@ func (res *ManagementEvent) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Params)
 	if err != nil {
-		return fmt.Errorf("field Params: %w", err)
+		return nil, fmt.Errorf("field Params: %w", err)
 	}
 	items = append(items, itm)
 
@@ -977,13 +977,13 @@ func (res *ManagementGroup) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray(res.PublicKey.Bytes()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field PublicKey: %w", err)
+		return nil, fmt.Errorf("field PublicKey: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Signature), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Signature: %w", err)
+		return nil, fmt.Errorf("field Signature: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1205,7 +1205,7 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray([]byte(res.Name)), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Name: %w", err)
+		return nil, fmt.Errorf("field Name: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1225,7 +1225,7 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Groups)
 	if err != nil {
-		return fmt.Errorf("field Groups: %w", err)
+		return nil, fmt.Errorf("field Groups: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1249,7 +1249,7 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 		return m, nil
 	}(res.Features)
 	if err != nil {
-		return fmt.Errorf("field Features: %w", err)
+		return nil, fmt.Errorf("field Features: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1269,13 +1269,13 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.SupportedStandards)
 	if err != nil {
-		return fmt.Errorf("field SupportedStandards: %w", err)
+		return nil, fmt.Errorf("field SupportedStandards: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = res.ABI.ToStackItem()
 	if err != nil {
-		return fmt.Errorf("field ABI: %w", err)
+		return nil, fmt.Errorf("field ABI: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1295,7 +1295,7 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Permissions)
 	if err != nil {
-		return fmt.Errorf("field Permissions: %w", err)
+		return nil, fmt.Errorf("field Permissions: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1315,13 +1315,13 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Trusts)
 	if err != nil {
-		return fmt.Errorf("field Trusts: %w", err)
+		return nil, fmt.Errorf("field Trusts: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.TryMake(res.Extra)
 	if err != nil {
-		return fmt.Errorf("field Extra: %w", err)
+		return nil, fmt.Errorf("field Extra: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1431,7 +1431,7 @@ func (res *ManagementMethod) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray([]byte(res.Name)), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Name: %w", err)
+		return nil, fmt.Errorf("field Name: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1451,25 +1451,25 @@ func (res *ManagementMethod) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Params)
 	if err != nil {
-		return fmt.Errorf("field Params: %w", err)
+		return nil, fmt.Errorf("field Params: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.ReturnType), error(nil)
 	if err != nil {
-		return fmt.Errorf("field ReturnType: %w", err)
+		return nil, fmt.Errorf("field ReturnType: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Offset), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Offset: %w", err)
+		return nil, fmt.Errorf("field Offset: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewBool(res.Safe), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Safe: %w", err)
+		return nil, fmt.Errorf("field Safe: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1548,13 +1548,13 @@ func (res *ManagementParameter) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray([]byte(res.Name)), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Name: %w", err)
+		return nil, fmt.Errorf("field Name: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Type), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Type: %w", err)
+		return nil, fmt.Errorf("field Type: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1656,7 +1656,7 @@ func (res *ManagementPermission) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray(res.Contract.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Contract: %w", err)
+		return nil, fmt.Errorf("field Contract: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1676,7 +1676,7 @@ func (res *ManagementPermission) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Methods)
 	if err != nil {
-		return fmt.Errorf("field Methods: %w", err)
+		return nil, fmt.Errorf("field Methods: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1944,55 +1944,55 @@ func (res *StructsInternal) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewBool(res.Bool), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Bool: %w", err)
+		return nil, fmt.Errorf("field Bool: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Int), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Int: %w", err)
+		return nil, fmt.Errorf("field Int: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Bytes), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Bytes: %w", err)
+		return nil, fmt.Errorf("field Bytes: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray([]byte(res.String)), error(nil)
 	if err != nil {
-		return fmt.Errorf("field String: %w", err)
+		return nil, fmt.Errorf("field String: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.H160.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field H160: %w", err)
+		return nil, fmt.Errorf("field H160: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.H256.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field H256: %w", err)
+		return nil, fmt.Errorf("field H256: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.PK.Bytes()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field PK: %w", err)
+		return nil, fmt.Errorf("field PK: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.PubKey.Bytes()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field PubKey: %w", err)
+		return nil, fmt.Errorf("field PubKey: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Sign), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Sign: %w", err)
+		return nil, fmt.Errorf("field Sign: %w", err)
 	}
 	items = append(items, itm)
 
@@ -2012,7 +2012,7 @@ func (res *StructsInternal) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.ArrOfBytes)
 	if err != nil {
-		return fmt.Errorf("field ArrOfBytes: %w", err)
+		return nil, fmt.Errorf("field ArrOfBytes: %w", err)
 	}
 	items = append(items, itm)
 
@@ -2032,7 +2032,7 @@ func (res *StructsInternal) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.ArrOfH160)
 	if err != nil {
-		return fmt.Errorf("field ArrOfH160: %w", err)
+		return nil, fmt.Errorf("field ArrOfH160: %w", err)
 	}
 	items = append(items, itm)
 
@@ -2070,19 +2070,19 @@ func (res *StructsInternal) ToStackItem() (stackitem.Item, error) {
 		return m, nil
 	}(res.Map)
 	if err != nil {
-		return fmt.Errorf("field Map: %w", err)
+		return nil, fmt.Errorf("field Map: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = res.Struct.ToStackItem()
 	if err != nil {
-		return fmt.Errorf("field Struct: %w", err)
+		return nil, fmt.Errorf("field Struct: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.UnexportedField), error(nil)
 	if err != nil {
-		return fmt.Errorf("field UnexportedField: %w", err)
+		return nil, fmt.Errorf("field UnexportedField: %w", err)
 	}
 	items = append(items, itm)
 

--- a/cli/smartcontract/testdata/rpcbindings/structs/rpcbindings_dynamic_hash.out
+++ b/cli/smartcontract/testdata/rpcbindings/structs/rpcbindings_dynamic_hash.out
@@ -307,61 +307,61 @@ func (res *LedgerBlock) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray(res.Hash.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Hash: %w", err)
+		return nil, fmt.Errorf("field Hash: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Version), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Version: %w", err)
+		return nil, fmt.Errorf("field Version: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.PrevHash.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field PrevHash: %w", err)
+		return nil, fmt.Errorf("field PrevHash: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.MerkleRoot.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field MerkleRoot: %w", err)
+		return nil, fmt.Errorf("field MerkleRoot: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Timestamp), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Timestamp: %w", err)
+		return nil, fmt.Errorf("field Timestamp: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Nonce), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Nonce: %w", err)
+		return nil, fmt.Errorf("field Nonce: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Index), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Index: %w", err)
+		return nil, fmt.Errorf("field Index: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.PrimaryIndex), error(nil)
 	if err != nil {
-		return fmt.Errorf("field PrimaryIndex: %w", err)
+		return nil, fmt.Errorf("field PrimaryIndex: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.NextConsensus.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field NextConsensus: %w", err)
+		return nil, fmt.Errorf("field NextConsensus: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.TransactionsLength), error(nil)
 	if err != nil {
-		return fmt.Errorf("field TransactionsLength: %w", err)
+		return nil, fmt.Errorf("field TransactionsLength: %w", err)
 	}
 	items = append(items, itm)
 
@@ -487,49 +487,49 @@ func (res *LedgerTransaction) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray(res.Hash.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Hash: %w", err)
+		return nil, fmt.Errorf("field Hash: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Version), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Version: %w", err)
+		return nil, fmt.Errorf("field Version: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Nonce), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Nonce: %w", err)
+		return nil, fmt.Errorf("field Nonce: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Sender.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Sender: %w", err)
+		return nil, fmt.Errorf("field Sender: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.SysFee), error(nil)
 	if err != nil {
-		return fmt.Errorf("field SysFee: %w", err)
+		return nil, fmt.Errorf("field SysFee: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.NetFee), error(nil)
 	if err != nil {
-		return fmt.Errorf("field NetFee: %w", err)
+		return nil, fmt.Errorf("field NetFee: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.ValidUntilBlock), error(nil)
 	if err != nil {
-		return fmt.Errorf("field ValidUntilBlock: %w", err)
+		return nil, fmt.Errorf("field ValidUntilBlock: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Script), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Script: %w", err)
+		return nil, fmt.Errorf("field Script: %w", err)
 	}
 	items = append(items, itm)
 
@@ -639,7 +639,7 @@ func (res *ManagementABI) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Methods)
 	if err != nil {
-		return fmt.Errorf("field Methods: %w", err)
+		return nil, fmt.Errorf("field Methods: %w", err)
 	}
 	items = append(items, itm)
 
@@ -659,7 +659,7 @@ func (res *ManagementABI) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Events)
 	if err != nil {
-		return fmt.Errorf("field Events: %w", err)
+		return nil, fmt.Errorf("field Events: %w", err)
 	}
 	items = append(items, itm)
 
@@ -757,31 +757,31 @@ func (res *ManagementContract) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = (*stackitem.BigInteger)(res.ID), error(nil)
 	if err != nil {
-		return fmt.Errorf("field ID: %w", err)
+		return nil, fmt.Errorf("field ID: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.UpdateCounter), error(nil)
 	if err != nil {
-		return fmt.Errorf("field UpdateCounter: %w", err)
+		return nil, fmt.Errorf("field UpdateCounter: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Hash.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Hash: %w", err)
+		return nil, fmt.Errorf("field Hash: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.NEF), error(nil)
 	if err != nil {
-		return fmt.Errorf("field NEF: %w", err)
+		return nil, fmt.Errorf("field NEF: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = res.Manifest.ToStackItem()
 	if err != nil {
-		return fmt.Errorf("field Manifest: %w", err)
+		return nil, fmt.Errorf("field Manifest: %w", err)
 	}
 	items = append(items, itm)
 
@@ -873,7 +873,7 @@ func (res *ManagementEvent) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray([]byte(res.Name)), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Name: %w", err)
+		return nil, fmt.Errorf("field Name: %w", err)
 	}
 	items = append(items, itm)
 
@@ -893,7 +893,7 @@ func (res *ManagementEvent) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Params)
 	if err != nil {
-		return fmt.Errorf("field Params: %w", err)
+		return nil, fmt.Errorf("field Params: %w", err)
 	}
 	items = append(items, itm)
 
@@ -973,13 +973,13 @@ func (res *ManagementGroup) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray(res.PublicKey.Bytes()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field PublicKey: %w", err)
+		return nil, fmt.Errorf("field PublicKey: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Signature), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Signature: %w", err)
+		return nil, fmt.Errorf("field Signature: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1201,7 +1201,7 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray([]byte(res.Name)), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Name: %w", err)
+		return nil, fmt.Errorf("field Name: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1221,7 +1221,7 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Groups)
 	if err != nil {
-		return fmt.Errorf("field Groups: %w", err)
+		return nil, fmt.Errorf("field Groups: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1245,7 +1245,7 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 		return m, nil
 	}(res.Features)
 	if err != nil {
-		return fmt.Errorf("field Features: %w", err)
+		return nil, fmt.Errorf("field Features: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1265,13 +1265,13 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.SupportedStandards)
 	if err != nil {
-		return fmt.Errorf("field SupportedStandards: %w", err)
+		return nil, fmt.Errorf("field SupportedStandards: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = res.ABI.ToStackItem()
 	if err != nil {
-		return fmt.Errorf("field ABI: %w", err)
+		return nil, fmt.Errorf("field ABI: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1291,7 +1291,7 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Permissions)
 	if err != nil {
-		return fmt.Errorf("field Permissions: %w", err)
+		return nil, fmt.Errorf("field Permissions: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1311,13 +1311,13 @@ func (res *ManagementManifest) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Trusts)
 	if err != nil {
-		return fmt.Errorf("field Trusts: %w", err)
+		return nil, fmt.Errorf("field Trusts: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.TryMake(res.Extra)
 	if err != nil {
-		return fmt.Errorf("field Extra: %w", err)
+		return nil, fmt.Errorf("field Extra: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1427,7 +1427,7 @@ func (res *ManagementMethod) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray([]byte(res.Name)), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Name: %w", err)
+		return nil, fmt.Errorf("field Name: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1447,25 +1447,25 @@ func (res *ManagementMethod) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Params)
 	if err != nil {
-		return fmt.Errorf("field Params: %w", err)
+		return nil, fmt.Errorf("field Params: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.ReturnType), error(nil)
 	if err != nil {
-		return fmt.Errorf("field ReturnType: %w", err)
+		return nil, fmt.Errorf("field ReturnType: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Offset), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Offset: %w", err)
+		return nil, fmt.Errorf("field Offset: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewBool(res.Safe), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Safe: %w", err)
+		return nil, fmt.Errorf("field Safe: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1544,13 +1544,13 @@ func (res *ManagementParameter) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray([]byte(res.Name)), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Name: %w", err)
+		return nil, fmt.Errorf("field Name: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Type), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Type: %w", err)
+		return nil, fmt.Errorf("field Type: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1652,7 +1652,7 @@ func (res *ManagementPermission) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewByteArray(res.Contract.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Contract: %w", err)
+		return nil, fmt.Errorf("field Contract: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1672,7 +1672,7 @@ func (res *ManagementPermission) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.Methods)
 	if err != nil {
-		return fmt.Errorf("field Methods: %w", err)
+		return nil, fmt.Errorf("field Methods: %w", err)
 	}
 	items = append(items, itm)
 
@@ -1940,55 +1940,55 @@ func (res *StructsInternal) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = stackitem.NewBool(res.Bool), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Bool: %w", err)
+		return nil, fmt.Errorf("field Bool: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.Int), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Int: %w", err)
+		return nil, fmt.Errorf("field Int: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Bytes), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Bytes: %w", err)
+		return nil, fmt.Errorf("field Bytes: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray([]byte(res.String)), error(nil)
 	if err != nil {
-		return fmt.Errorf("field String: %w", err)
+		return nil, fmt.Errorf("field String: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.H160.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field H160: %w", err)
+		return nil, fmt.Errorf("field H160: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.H256.BytesBE()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field H256: %w", err)
+		return nil, fmt.Errorf("field H256: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.PK.Bytes()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field PK: %w", err)
+		return nil, fmt.Errorf("field PK: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.PubKey.Bytes()), error(nil)
 	if err != nil {
-		return fmt.Errorf("field PubKey: %w", err)
+		return nil, fmt.Errorf("field PubKey: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewByteArray(res.Sign), error(nil)
 	if err != nil {
-		return fmt.Errorf("field Sign: %w", err)
+		return nil, fmt.Errorf("field Sign: %w", err)
 	}
 	items = append(items, itm)
 
@@ -2008,7 +2008,7 @@ func (res *StructsInternal) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.ArrOfBytes)
 	if err != nil {
-		return fmt.Errorf("field ArrOfBytes: %w", err)
+		return nil, fmt.Errorf("field ArrOfBytes: %w", err)
 	}
 	items = append(items, itm)
 
@@ -2028,7 +2028,7 @@ func (res *StructsInternal) ToStackItem() (stackitem.Item, error) {
 		return stackitem.NewArray(items), nil
 	}(res.ArrOfH160)
 	if err != nil {
-		return fmt.Errorf("field ArrOfH160: %w", err)
+		return nil, fmt.Errorf("field ArrOfH160: %w", err)
 	}
 	items = append(items, itm)
 
@@ -2066,19 +2066,19 @@ func (res *StructsInternal) ToStackItem() (stackitem.Item, error) {
 		return m, nil
 	}(res.Map)
 	if err != nil {
-		return fmt.Errorf("field Map: %w", err)
+		return nil, fmt.Errorf("field Map: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = res.Struct.ToStackItem()
 	if err != nil {
-		return fmt.Errorf("field Struct: %w", err)
+		return nil, fmt.Errorf("field Struct: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = (*stackitem.BigInteger)(res.UnexportedField), error(nil)
 	if err != nil {
-		return fmt.Errorf("field UnexportedField: %w", err)
+		return nil, fmt.Errorf("field UnexportedField: %w", err)
 	}
 	items = append(items, itm)
 

--- a/cli/smartcontract/testdata/rpcbindings/types/rpcbindings.out
+++ b/cli/smartcontract/testdata/rpcbindings/types/rpcbindings.out
@@ -426,7 +426,7 @@ func (res *Unnamed) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = (*stackitem.BigInteger)(res.I), error(nil)
 	if err != nil {
-		return fmt.Errorf("field I: %w", err)
+		return nil, fmt.Errorf("field I: %w", err)
 	}
 	items = append(items, itm)
 
@@ -496,13 +496,13 @@ func (res *UnnamedX) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = (*stackitem.BigInteger)(res.I), error(nil)
 	if err != nil {
-		return fmt.Errorf("field I: %w", err)
+		return nil, fmt.Errorf("field I: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewBool(res.B), error(nil)
 	if err != nil {
-		return fmt.Errorf("field B: %w", err)
+		return nil, fmt.Errorf("field B: %w", err)
 	}
 	items = append(items, itm)
 

--- a/cli/smartcontract/testdata/rpcbindings/types/rpcbindings_dynamic_hash.out
+++ b/cli/smartcontract/testdata/rpcbindings/types/rpcbindings_dynamic_hash.out
@@ -422,7 +422,7 @@ func (res *Unnamed) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = (*stackitem.BigInteger)(res.I), error(nil)
 	if err != nil {
-		return fmt.Errorf("field I: %w", err)
+		return nil, fmt.Errorf("field I: %w", err)
 	}
 	items = append(items, itm)
 
@@ -492,13 +492,13 @@ func (res *UnnamedX) ToStackItem() (stackitem.Item, error) {
 	)
 	itm, err = (*stackitem.BigInteger)(res.I), error(nil)
 	if err != nil {
-		return fmt.Errorf("field I: %w", err)
+		return nil, fmt.Errorf("field I: %w", err)
 	}
 	items = append(items, itm)
 
 	itm, err = stackitem.NewBool(res.B), error(nil)
 	if err != nil {
-		return fmt.Errorf("field B: %w", err)
+		return nil, fmt.Errorf("field B: %w", err)
 	}
 	items = append(items, itm)
 

--- a/pkg/smartcontract/rpcbinding/binding.go
+++ b/pkg/smartcontract/rpcbinding/binding.go
@@ -305,7 +305,7 @@ func (res *{{toTypeName $typ.Name}}) ToStackItem() (stackitem.Item, error) {
 {{- range $m := $typ.Fields}}
 	itm, err = {{goTypeConverter .ExtendedType (print "res." (upperFirst .Field))}}
 	if err != nil {
-		return fmt.Errorf("field {{ upperFirst .Field}}: %w", err)
+		return nil, fmt.Errorf("field {{ upperFirst .Field}}: %w", err)
 	}
 	items = append(items, itm)
 {{end}}


### PR DESCRIPTION
    ... not enough return values
        have (error)
        want (stackitem.Item, error)

An omission of 00e22b975179cb548444c11fb5531ed48ca11356.