### PR TITLE
rpcsrv: allow to configure subscription limit

### DIFF
--- a/docs/node-configuration.md
+++ b/docs/node-configuration.md
@@ -251,6 +251,7 @@ RPC:
   MaxRequestBodyBytes: 5242880
   MaxRequestHeaderBytes: 1048576
   MaxWebSocketClients: 64
+  MaxWebSocketFeeds: 16
   SessionEnabled: false
   SessionExpirationTime: 15
   SessionBackedByMPT: false
@@ -296,6 +297,9 @@ where:
   number (64 by default). Attempts to establish additional connections will
   lead to websocket handshake failures. Use "-1" to disable websocket
   connections (0 will lead to using the default value).
+- `MaxWebSocketFeeds` -- the maximum simultaneous event subscriptions number
+  for a single client (16 by default). Attemps to create additional subscriptions
+  will lead to error.
 - `SessionEnabled` denotes whether session-based iterator JSON-RPC API is enabled.
   If true, then all iterators got from `invoke*` calls will be stored as sessions
   on the server side available for further traverse. `traverseiterator` and

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -58,6 +58,9 @@ method. Upon successful subscription, clients receive subscription ID for
 subsequent management of this subscription. Subscription is only valid for
 connection lifetime, no long-term client identification is being made.
 
+The maximum number of simultaneous subscriptions can be set server-side
+via `MaxWebSocketFeeds` setting.
+
 Errors are not described down below, but they can be returned as standard
 JSON-RPC errors (most often caused by invalid parameters).
 

--- a/pkg/config/rpc_config.go
+++ b/pkg/config/rpc_config.go
@@ -19,6 +19,7 @@ type (
 		MaxRequestBodyBytes       int           `yaml:"MaxRequestBodyBytes"`
 		MaxRequestHeaderBytes     int           `yaml:"MaxRequestHeaderBytes"`
 		MaxWebSocketClients       int           `yaml:"MaxWebSocketClients"`
+		MaxWebSocketFeeds         int           `yaml:"MaxWebSocketFeeds"`
 		SessionEnabled            bool          `yaml:"SessionEnabled"`
 		SessionExpirationTime     int           `yaml:"SessionExpirationTime"`
 		SessionBackedByMPT        bool          `yaml:"SessionBackedByMPT"`

--- a/pkg/services/rpcsrv/subscription.go
+++ b/pkg/services/rpcsrv/subscription.go
@@ -23,7 +23,7 @@ type (
 		// cheaper doing it this way rather than creating a map),
 		// pointing to an EventID is an obvious overkill at the moment, but
 		// that's not for long.
-		feeds [maxFeeds]feed
+		feeds []feed
 	}
 	// feed stores subscriber's desired event ID with filter.
 	feed struct {
@@ -43,8 +43,8 @@ func (f feed) Filter() neorpc.SubscriptionFilter {
 }
 
 const (
-	// Maximum number of subscriptions per one client.
-	maxFeeds = 16
+	// The default maximum number of subscriptions per one client.
+	defaultMaxFeeds = 16
 
 	// This sets notification messages buffer depth. It may seem to be quite
 	// big, but there is a big gap in speed between internal event processing


### PR DESCRIPTION
We have already implemented this in our private fork, so it was being in use for some time.

Close #3823 