### PR TITLE
cli: adjust `upload-state` command to upload key-value pairs instead of full MPT traversal

### DIFF
--- a/cli/server/dump_bin.go
+++ b/cli/server/dump_bin.go
@@ -30,7 +30,7 @@ func dumpBin(ctx *cli.Context) error {
 	count := uint32(ctx.Uint("count"))
 	start := uint32(ctx.Uint("start"))
 
-	chain, _, prometheus, pprof, err := InitBCWithMetrics(cfg, log)
+	chain, prometheus, pprof, err := InitBCWithMetrics(cfg, log)
 	if err != nil {
 		return err
 	}

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -141,10 +141,10 @@ func newGraceContext() context.Context {
 }
 
 // InitBCWithMetrics initializes the blockchain with metrics with the given configuration.
-func InitBCWithMetrics(cfg config.Config, log *zap.Logger) (*core.Blockchain, storage.Store, *metrics.Service, *metrics.Service, error) {
-	chain, store, err := initBlockChain(cfg, log)
+func InitBCWithMetrics(cfg config.Config, log *zap.Logger) (*core.Blockchain, *metrics.Service, *metrics.Service, error) {
+	chain, _, err := initBlockChain(cfg, log)
 	if err != nil {
-		return nil, nil, nil, nil, cli.Exit(err, 1)
+		return nil, nil, nil, cli.Exit(err, 1)
 	}
 	prometheus := metrics.NewPrometheusService(cfg.ApplicationConfiguration.Prometheus, log)
 	pprof := metrics.NewPprofService(cfg.ApplicationConfiguration.Pprof, log)
@@ -152,14 +152,14 @@ func InitBCWithMetrics(cfg config.Config, log *zap.Logger) (*core.Blockchain, st
 	go chain.Run()
 	err = prometheus.Start()
 	if err != nil {
-		return nil, nil, nil, nil, cli.Exit(fmt.Errorf("failed to start Prometheus service: %w", err), 1)
+		return nil, nil, nil, cli.Exit(fmt.Errorf("failed to start Prometheus service: %w", err), 1)
 	}
 	err = pprof.Start()
 	if err != nil {
-		return nil, nil, nil, nil, cli.Exit(fmt.Errorf("failed to start Pprof service: %w", err), 1)
+		return nil, nil, nil, cli.Exit(fmt.Errorf("failed to start Pprof service: %w", err), 1)
 	}
 
-	return chain, store, prometheus, pprof, nil
+	return chain, prometheus, pprof, nil
 }
 
 func dumpDB(ctx *cli.Context) error {
@@ -190,7 +190,7 @@ func dumpDB(ctx *cli.Context) error {
 	defer outStream.Close()
 	writer := io.NewBinWriterFromIO(outStream)
 
-	chain, _, prometheus, pprof, err := InitBCWithMetrics(cfg, log)
+	chain, prometheus, pprof, err := InitBCWithMetrics(cfg, log)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func restoreDB(ctx *cli.Context) error {
 		cfg.ApplicationConfiguration.SaveStorageBatch = true
 	}
 
-	chain, _, prometheus, pprof, err := InitBCWithMetrics(cfg, log)
+	chain, prometheus, pprof, err := InitBCWithMetrics(cfg, log)
 	if err != nil {
 		return err
 	}
@@ -471,7 +471,7 @@ func startServer(ctx *cli.Context) error {
 		return cli.Exit(err, 1)
 	}
 
-	chain, _, prometheus, pprof, err := InitBCWithMetrics(cfg, log)
+	chain, prometheus, pprof, err := InitBCWithMetrics(cfg, log)
 	if err != nil {
 		return cli.Exit(err, 1)
 	}

--- a/cli/server/server_test.go
+++ b/cli/server/server_test.go
@@ -200,11 +200,11 @@ func TestInitBCWithMetrics(t *testing.T) {
 	})
 
 	t.Run("bad store", func(t *testing.T) {
-		_, _, _, _, err = InitBCWithMetrics(config.Config{}, logger)
+		_, _, _, err = InitBCWithMetrics(config.Config{}, logger)
 		require.Error(t, err)
 	})
 
-	chain, _, prometheus, pprof, err := InitBCWithMetrics(cfg, logger)
+	chain, prometheus, pprof, err := InitBCWithMetrics(cfg, logger)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		chain.Close()

--- a/cli/util/convert.go
+++ b/cli/util/convert.go
@@ -189,7 +189,7 @@ func NewCommands() []*cli.Command {
 				},
 				{
 					Name:      "upload-state",
-					Usage:     "Start the node, traverse MPT and upload MPT nodes to the NeoFS container at every StateSyncInterval number of blocks",
+					Usage:     "Start the node, traverse contract storage key-value pairs and upload them to the NeoFS container at every StateSyncInterval number of blocks",
 					UsageText: "neo-go util upload-state --fs-rpc-endpoint <address1>[,<address2>[...]] --container <cid> --state-attribute state --wallet <wallet> [--wallet-config <config>] [--address <address>] [--searchers <num>] [--retries <num>] [--debug] [--config-path path] [-p/-m/-t] [--config-file file] [--force-timestamp-logs]",
 					Action:    uploadState,
 					Flags:     uploadStateFlags,

--- a/cli/util/upload_state.go
+++ b/cli/util/upload_state.go
@@ -83,10 +83,10 @@ func uploadState(ctx *cli.Context) error {
 	stateModule := chain.GetStateModule()
 	currentHeight := int(stateModule.CurrentLocalHeight())
 	currentStateIndex := currentHeight / syncInterval
-	if currentStateIndex <= stateObjCount {
+	if currentStateIndex < stateObjCount {
 		log.Info("no new states to upload",
 			zap.Int("number of uploaded state objects", stateObjCount),
-			zap.Int("latest state is uploaded for block", stateObjCount*syncInterval),
+			zap.Int("latest state is uploaded for block", (stateObjCount-1)*syncInterval),
 			zap.Int("current height", currentHeight),
 			zap.Int("StateSyncInterval", syncInterval))
 		return nil
@@ -97,7 +97,7 @@ func uploadState(ctx *cli.Context) error {
 		zap.Int("current height", currentHeight),
 		zap.Int("StateSyncInterval", syncInterval),
 		zap.Int("number of states to upload", currentStateIndex-stateObjCount))
-	for state := stateObjCount; state < currentStateIndex; state++ {
+	for state := stateObjCount; state <= currentStateIndex; state++ {
 		height := uint32(state * syncInterval)
 		stateRoot, err := stateModule.GetStateRoot(height)
 		if err != nil {


### PR DESCRIPTION
Ref. https://github.com/nspcc-dev/neo-go/issues/3782