### PR TITLE
vm: Skip GetCurrentScriptHash() call unless onExec hook is provided

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -505,9 +505,9 @@ func (v *VM) Step() error {
 // step executes one instruction in the given context.
 func (v *VM) step(ctx *Context) error {
 	ip := ctx.nextip
-	scriptHash := v.GetCurrentScriptHash()
 	op, param, err := ctx.Next()
 	if v.hooks.onExec != nil {
+		scriptHash := v.GetCurrentScriptHash()
 		v.hooks.onExec(scriptHash, ip, op)
 	}
 	if err != nil {


### PR DESCRIPTION
No functional changes.

I was doing some long-long-script & many-many-keys tests to check boundary behaviour of my contract.
Then I see this thing in pprof: it is small, but noticeable.