### PR TITLE
scripts: increase dump index comparison range

### DIFF
--- a/scripts/compare-dumps/compare-dumps.go
+++ b/scripts/compare-dumps/compare-dumps.go
@@ -155,7 +155,7 @@ func cliMain(c *cli.Context) error {
 		return compare(a, b)
 	}
 	if astat.Mode().IsDir() && bstat.Mode().IsDir() {
-		for i := 0; i <= 6000000; i += 100000 {
+		for i := 0; i <= 20_000_000; i += 100000 {
 			dir := fmt.Sprintf("BlockStorage_%d", i)
 			fmt.Println("Processing directory", dir)
 			for j := i - 99000; j <= i; j += 1000 {


### PR DESCRIPTION
NeoFS chains don't fit 6M limit anymore as far as N3.