### PR TITLE
config: prohibit NeoFSStateSyncExtensions enabling

### DIFF
--- a/pkg/config/protocol_config.go
+++ b/pkg/config/protocol_config.go
@@ -170,6 +170,9 @@ func (p *ProtocolConfiguration) Validate() error {
 			}
 		}
 	}
+	if p.NeoFSStateSyncExtensions {
+		return fmt.Errorf("NeoFSStateSyncExtensions implementation is not finished yet, please disable this option")
+	}
 	return nil
 }
 


### PR DESCRIPTION
This feature is not fully supported yet, #3793 is missing hence NeoFS-based state synchronisation from checkpoint won't work properly.