### PR TITLE
core: fix Echidna-dependent tests

### DIFF
--- a/pkg/core/blockchain_core_test.go
+++ b/pkg/core/blockchain_core_test.go
@@ -388,6 +388,7 @@ func TestNewBlockchain_InitHardforks(t *testing.T) {
 			config.HFBasilisk.String():      0,
 			config.HFCockatrice.String():    0,
 			config.HFDomovoi.String():       0,
+			config.HFEchidna.String():       0,
 		}, bc.GetConfig().Hardforks)
 	})
 	t.Run("empty set", func(t *testing.T) {

--- a/pkg/core/native/native_test/designate_test.go
+++ b/pkg/core/native/native_test/designate_test.go
@@ -34,7 +34,7 @@ func TestDesignate_DesignateAsRole(t *testing.T) {
 	pubs := keys.PublicKeys{priv.PublicKey()}
 
 	setNodesByRole(t, designateInvoker, false, 0xFF, pubs)
-	setNodesByRole(t, designateInvoker, true, noderoles.Oracle, pubs)
+	setNodesByRole(t, designateInvoker, true, noderoles.Oracle, pubs, nil)
 	index := e.Chain.BlockHeight() + 1
 	checkNodeRoles(t, designateInvoker, false, 0xFF, 0, nil)
 	checkNodeRoles(t, designateInvoker, false, noderoles.Oracle, 100500, nil)
@@ -44,14 +44,14 @@ func TestDesignate_DesignateAsRole(t *testing.T) {
 	priv1, err := keys.NewPrivateKey()
 	require.NoError(t, err)
 	pubs = keys.PublicKeys{priv1.PublicKey()}
-	setNodesByRole(t, designateInvoker, true, noderoles.StateValidator, pubs)
+	setNodesByRole(t, designateInvoker, true, noderoles.StateValidator, pubs, nil)
 	checkNodeRoles(t, designateInvoker, true, noderoles.StateValidator, e.Chain.BlockHeight()+1, pubs)
 
 	t.Run("neofs", func(t *testing.T) {
 		priv, err := keys.NewPrivateKey()
 		require.NoError(t, err)
 		pubs = keys.PublicKeys{priv.PublicKey()}
-		setNodesByRole(t, designateInvoker, true, noderoles.NeoFSAlphabet, pubs)
+		setNodesByRole(t, designateInvoker, true, noderoles.NeoFSAlphabet, pubs, nil)
 		checkNodeRoles(t, designateInvoker, true, noderoles.NeoFSAlphabet, e.Chain.BlockHeight()+1, pubs)
 	})
 }

--- a/pkg/core/native/native_test/policy_test.go
+++ b/pkg/core/native/native_test/policy_test.go
@@ -106,12 +106,13 @@ func TestPolicy_MillisecondsPerBlock(t *testing.T) {
 // TestPolicy_Initialize ensures that native Policy storage/cache initialization is
 // performed properly at Echidna fork.
 func TestPolicy_InitializeAtEchidna(t *testing.T) {
-	check := func(t *testing.T, f func(cfg *config.Blockchain), echidnaH int32) {
+	check := func(t *testing.T, f func(cfg *config.Blockchain)) {
 		c := newCustomNativeClient(t, nativenames.Policy, f)
 		committeeInvoker := c.WithSigners(c.Committee)
 		defaultTimePerBlock := uint32(c.Chain.GetConfig().TimePerBlock.Milliseconds())
 		genesisTimePerBlock := uint32(c.Chain.GetConfig().Genesis.TimePerBlock.Milliseconds())
 
+		echidnaH := int(c.Chain.GetConfig().Hardforks[config.HFEchidna.String()])
 		// Pre-Echidna blocks.
 		for range int(echidnaH) - 1 {
 			require.Equal(t, defaultTimePerBlock, c.Chain.GetMillisecondsPerBlock())
@@ -146,7 +147,7 @@ func TestPolicy_InitializeAtEchidna(t *testing.T) {
 		check(t, func(cfg *config.Blockchain) {
 			cfg.Hardforks = nil
 			cfg.Genesis.TimePerBlock = 123 * time.Millisecond
-		}, -1) // Echidna is not a stable fork for now.
+		})
 	})
 	t.Run("all hardforks explicitly enabled from genesis", func(t *testing.T) {
 		check(t, func(cfg *config.Blockchain) {
@@ -158,7 +159,7 @@ func TestPolicy_InitializeAtEchidna(t *testing.T) {
 				config.HFEchidna.String():       0,
 			}
 			cfg.Genesis.TimePerBlock = 123 * time.Millisecond
-		}, 0)
+		})
 	})
 	t.Run("Echidna enabled from 2", func(t *testing.T) {
 		check(t, func(cfg *config.Blockchain) {
@@ -170,7 +171,7 @@ func TestPolicy_InitializeAtEchidna(t *testing.T) {
 				config.HFEchidna.String():       2,
 			}
 			cfg.Genesis.TimePerBlock = 123 * time.Millisecond
-		}, 2)
+		})
 	})
 	t.Run("Domovoi and Echidna enabled from 2", func(t *testing.T) {
 		check(t, func(cfg *config.Blockchain) {
@@ -182,7 +183,7 @@ func TestPolicy_InitializeAtEchidna(t *testing.T) {
 				config.HFEchidna.String():       2,
 			}
 			cfg.Genesis.TimePerBlock = 123 * time.Millisecond
-		}, 2)
+		})
 	})
 	t.Run("Echidna enabled from 4", func(t *testing.T) {
 		check(t, func(cfg *config.Blockchain) {
@@ -194,7 +195,7 @@ func TestPolicy_InitializeAtEchidna(t *testing.T) {
 				config.HFEchidna.String():       4,
 			}
 			cfg.Genesis.TimePerBlock = 123 * time.Millisecond
-		}, 4)
+		})
 	})
 }
 


### PR DESCRIPTION
Echidna is a stable hardfork now, this commit should be a part of 23a78767acddec2d775f6f82718fd7c54fb5c08c.
