### PR TITLE
native: move CommitteeChanged event emission under Cockatrice

### DIFF
--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -462,11 +462,13 @@ func (n *NEO) OnPersist(ic *interop.Context) error {
 		// during the last epoch block handling or by initialization code).
 
 		var oldCommittee, newCommittee stackitem.Item
-		for i := range cache.committee {
-			if cache.newEpochCommittee[i].Key != cache.committee[i].Key ||
-				(i == 0 && len(cache.newEpochCommittee) != len(cache.committee)) {
-				oldCommittee, newCommittee = cache.committee.toNotificationItem(), cache.newEpochCommittee.toNotificationItem()
-				break
+		if ic.IsHardforkEnabled(config.HFCockatrice) {
+			for i := range cache.committee {
+				if cache.newEpochCommittee[i].Key != cache.committee[i].Key ||
+					(i == 0 && len(cache.newEpochCommittee) != len(cache.committee)) {
+					oldCommittee, newCommittee = cache.committee.toNotificationItem(), cache.newEpochCommittee.toNotificationItem()
+					break
+				}
 			}
 		}
 


### PR DESCRIPTION
Port https://github.com/neo-project/neo/pull/3234, should be a part of https://github.com/nspcc-dev/neo-go/pull/3351.