### PR TITLE
notary: do not make noise when there are no issues

### DIFF
--- a/pkg/services/notary/notary.go
+++ b/pkg/services/notary/notary.go
@@ -392,9 +392,11 @@ func (n *Notary) PostPersist() {
 				if nvb := fb.GetAttributes(transaction.NotValidBeforeT)[0].Value.(*transaction.NotValidBefore).Height; nvb <= currHeight {
 					// Ignore the error, wait for the next block to resend them
 					err := n.finalize(acc, fb, h)
-					n.Config.Log.Error("failed to finalize fallback transaction, waiting for the next block to retry",
-						zap.String("hash", fb.Hash().StringLE()),
-						zap.Error(err))
+					if err != nil {
+						n.Config.Log.Error("failed to finalize fallback transaction, waiting for the next block to retry",
+							zap.String("hash", fb.Hash().StringLE()),
+							zap.Error(err))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When err is nil we're fine and there is no need to log. Regression of 13b75c9d1af2b84cb1d89c1d0930e1249653c5f5.