### PR TITLE
*: use the built-in max/min to simplify the code and fix a bug

### DIFF
--- a/pkg/core/statesync/mptpool.go
+++ b/pkg/core/statesync/mptpool.go
@@ -54,10 +54,7 @@ func (mp *Pool) GetBatch(limit int) []util.Uint256 {
 	mp.lock.RLock()
 	defer mp.lock.RUnlock()
 
-	count := len(mp.hashes)
-	if count > limit {
-		count = limit
-	}
+	count := min(len(mp.hashes), limit)
 	result := make([]util.Uint256, 0, limit)
 	for h := range mp.hashes {
 		if count == 0 {

--- a/pkg/services/stateroot/signature.go
+++ b/pkg/services/stateroot/signature.go
@@ -62,10 +62,7 @@ func (r *incompleteRoot) isSenderNow() bool {
 	if r.root == nil || r.isSent || len(r.svList) == 0 {
 		return false
 	}
-	retries := r.retries
-	if retries < 0 {
-		retries = 0
-	}
+	retries := max(r.retries, 0)
 	ind := (int(r.root.Index) - retries) % len(r.svList)
 	if ind < 0 {
 		ind += len(r.svList)


### PR DESCRIPTION
### Problem

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

### Solution

...
