### PR TITLE
compiler: Support slice expressions for string

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -730,7 +730,7 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 
 	case *ast.SliceExpr:
 		if isCompoundSlice(c.typeOf(n.X).Underlying()) {
-			c.prog.Err = errors.New("subslices are supported only for []byte")
+			c.prog.Err = errors.New("subslices are supported only for []byte and string")
 			return nil
 		}
 
@@ -749,6 +749,9 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 		}
 
 		emit.Opcodes(c.prog.BinWriter, opcode.OVER, opcode.SUB, opcode.SUBSTR)
+		if isString(c.typeOf(n.X)) {
+			c.emitConvert(stackitem.ByteArrayT)
+		}
 
 		return nil
 

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -434,7 +434,7 @@ func TestSubsliceCompound(t *testing.T) {
 		return b
 	}`
 	_, err := compiler.Compile("foo.go", strings.NewReader(src))
-	require.Error(t, err)
+	require.ErrorContains(t, err, "subslices are supported only for []byte and string")
 }
 
 func TestSubsliceFromStructField(t *testing.T) {

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -132,6 +132,15 @@ var sliceTestCases = []testCase{
 		[]byte{2, 3},
 	},
 	{
+		"sub-slice of string is supported",
+		`func F%d() bool {
+			a := "oh my god"
+			return a[:2] == "oh"
+		}
+		`,
+		true,
+	},
+	{
 		"declare byte slice",
 		`func F%d() []byte {
 			var a []byte

--- a/pkg/compiler/slice_test.go
+++ b/pkg/compiler/slice_test.go
@@ -433,7 +433,7 @@ func TestSubsliceCompound(t *testing.T) {
 		b := a[1:3]
 		return b
 	}`
-	_, err := compiler.Compile("", strings.NewReader(src))
+	_, err := compiler.Compile("foo.go", strings.NewReader(src))
 	require.Error(t, err)
 }
 
@@ -470,7 +470,7 @@ func TestRemove(t *testing.T) {
 			util.Remove(a, 1)
 			return len(a)
 		}`
-		_, err := compiler.Compile("", strings.NewReader(src))
+		_, err := compiler.Compile("foo.go", strings.NewReader(src))
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
According to code, compiler currently supports slice expressions only for `[]byte` and triggers an error otherwise. However, using them with `string` type fails silently:
```
s := "abc"
return s[:2] == "ab" // oops, false!
```

This happens, because the resulting type for this operation is `Buffer`, but "ab" has type `ByteString`. So, we have 2 options:
- improve validation and trigger an error,
- or just support strings.

This commit implements the latter.