### PR TITLE
core: persist storeBlock cache atomically

### DIFF
--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1924,16 +1924,7 @@ func (bc *Blockchain) storeBlock(block *block.Block, txpool *mempool.Pool) error
 		bc.persistCond.Wait()
 	}
 
-	_, err = aerCache.Persist()
-	if err != nil {
-		bc.lock.Unlock()
-		return err
-	}
-	_, err = cache.Persist()
-	if err != nil {
-		bc.lock.Unlock()
-		return err
-	}
+	_ = bc.dao.PersistPrivate(aerCache, cache)
 
 	mpt.Store = bc.dao.Store
 	bc.stateRoot.UpdateCurrentLocal(mpt, sr)


### PR DESCRIPTION
`cache` and `aerCache` should be persisted to the underlying DAO cache atomically, otherwise it's possible that `persist()` routine will persist only `aerCache` content to the DB. Combined with node shutdown, it will lead to MPT initialization failure after restart since stateroot changes belong to `cache`.

Fixes the first problem described in #3082, ref. https://github.com/nspcc-dev/neo-go/issues/3082#issuecomment-2922888710. Close #3082 since the second problem is moved to a separate issue.