### PR TITLE
native: strip spases for StdLib's `base64Decode` and `base64UrlDecode`

### DIFF
--- a/pkg/core/native/std.go
+++ b/pkg/core/native/std.go
@@ -315,7 +315,7 @@ func (s *Std) base64Encode(_ *interop.Context, args []stackitem.Item) stackitem.
 }
 
 func (s *Std) base64Decode(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	src := s.toLimitedString(args[0])
+	src := stripSpaces(s.toLimitedString(args[0]))
 	result, err := base64.StdEncoding.DecodeString(src)
 	if err != nil {
 		panic(err)
@@ -332,7 +332,7 @@ func (s *Std) base64UrlEncode(_ *interop.Context, args []stackitem.Item) stackit
 }
 
 func (s *Std) base64UrlDecode(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	src := s.toLimitedString(args[0])
+	src := stripSpaces(s.toLimitedString(args[0]))
 	result, err := base64.URLEncoding.DecodeString(src)
 	if err != nil {
 		panic(err)
@@ -507,4 +507,17 @@ func (s *Std) toLimitedString(item stackitem.Item) string {
 		panic(ErrTooBigInput)
 	}
 	return src
+}
+
+// stripSpace removes all whitespace characters and tabulation characters from
+// string, ref. https://learn.microsoft.com/ru-ru/dotnet/api/system.convert.frombase64string?view=net-8.0#remarks.
+func stripSpaces(str string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\t':
+			return -1
+		default:
+			return r
+		}
+	}, str)
 }

--- a/pkg/core/native/std.go
+++ b/pkg/core/native/std.go
@@ -263,7 +263,7 @@ func (s *Std) itoa(_ *interop.Context, args []stackitem.Item) stackitem.Item {
 }
 
 func (s *Std) atoi10(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	num := s.toLimitedString(args[0])
+	num := toLimitedString(args[0])
 	res := s.atoi10Aux(num)
 	return stackitem.NewBigInteger(res)
 }
@@ -277,7 +277,7 @@ func (s *Std) atoi10Aux(num string) *big.Int {
 }
 
 func (s *Std) atoi(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	num := s.toLimitedString(args[0])
+	num := toLimitedString(args[0])
 	base := toBigInt(args[1])
 	if !base.IsInt64() {
 		panic(ErrInvalidBase)
@@ -308,14 +308,14 @@ func (s *Std) atoi(_ *interop.Context, args []stackitem.Item) stackitem.Item {
 }
 
 func (s *Std) base64Encode(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	src := s.toLimitedBytes(args[0])
+	src := toLimitedBytes(args[0])
 	result := base64.StdEncoding.EncodeToString(src)
 
 	return stackitem.NewByteArray([]byte(result))
 }
 
 func (s *Std) base64Decode(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	src := stripSpaces(s.toLimitedString(args[0]))
+	src := stripSpaces(toLimitedString(args[0]))
 	result, err := base64.StdEncoding.DecodeString(src)
 	if err != nil {
 		panic(err)
@@ -325,14 +325,14 @@ func (s *Std) base64Decode(_ *interop.Context, args []stackitem.Item) stackitem.
 }
 
 func (s *Std) base64UrlEncode(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	src := s.toLimitedBytes(args[0])
+	src := toLimitedBytes(args[0])
 	result := base64.URLEncoding.EncodeToString(src)
 
 	return stackitem.NewByteArray([]byte(result))
 }
 
 func (s *Std) base64UrlDecode(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	src := stripSpaces(s.toLimitedString(args[0]))
+	src := stripSpaces(toLimitedString(args[0]))
 	result, err := base64.URLEncoding.DecodeString(src)
 	if err != nil {
 		panic(err)
@@ -342,14 +342,14 @@ func (s *Std) base64UrlDecode(_ *interop.Context, args []stackitem.Item) stackit
 }
 
 func (s *Std) base58Encode(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	src := s.toLimitedBytes(args[0])
+	src := toLimitedBytes(args[0])
 	result := base58.Encode(src)
 
 	return stackitem.NewByteArray([]byte(result))
 }
 
 func (s *Std) base58Decode(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	src := s.toLimitedString(args[0])
+	src := toLimitedString(args[0])
 	result, err := base58.Decode(src)
 	if err != nil {
 		panic(err)
@@ -359,14 +359,14 @@ func (s *Std) base58Decode(_ *interop.Context, args []stackitem.Item) stackitem.
 }
 
 func (s *Std) base58CheckEncode(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	src := s.toLimitedBytes(args[0])
+	src := toLimitedBytes(args[0])
 	result := base58neogo.CheckEncode(src)
 
 	return stackitem.NewByteArray([]byte(result))
 }
 
 func (s *Std) base58CheckDecode(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	src := s.toLimitedString(args[0])
+	src := toLimitedString(args[0])
 	result, err := base58neogo.CheckDecode(src)
 	if err != nil {
 		panic(err)
@@ -376,29 +376,29 @@ func (s *Std) base58CheckDecode(_ *interop.Context, args []stackitem.Item) stack
 }
 
 func (s *Std) memoryCompare(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	s1 := s.toLimitedBytes(args[0])
-	s2 := s.toLimitedBytes(args[1])
+	s1 := toLimitedBytes(args[0])
+	s2 := toLimitedBytes(args[1])
 	return stackitem.NewBigInteger(big.NewInt(int64(bytes.Compare(s1, s2))))
 }
 
 func (s *Std) memorySearch2(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	mem := s.toLimitedBytes(args[0])
-	val := s.toLimitedBytes(args[1])
+	mem := toLimitedBytes(args[0])
+	val := toLimitedBytes(args[1])
 	index := s.memorySearchAux(mem, val, 0, false)
 	return stackitem.NewBigInteger(big.NewInt(int64(index)))
 }
 
 func (s *Std) memorySearch3(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	mem := s.toLimitedBytes(args[0])
-	val := s.toLimitedBytes(args[1])
+	mem := toLimitedBytes(args[0])
+	val := toLimitedBytes(args[1])
 	start := toUint32(args[2])
 	index := s.memorySearchAux(mem, val, int(start), false)
 	return stackitem.NewBigInteger(big.NewInt(int64(index)))
 }
 
 func (s *Std) memorySearch4(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	mem := s.toLimitedBytes(args[0])
-	val := s.toLimitedBytes(args[1])
+	mem := toLimitedBytes(args[0])
+	val := toLimitedBytes(args[1])
 	start := toUint32(args[2])
 	backward, err := args[3].TryBool()
 	if err != nil {
@@ -425,13 +425,13 @@ func (s *Std) memorySearchAux(mem, val []byte, start int, backward bool) int {
 }
 
 func (s *Std) stringSplit2(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	str := s.toLimitedString(args[0])
+	str := toLimitedString(args[0])
 	sep := toString(args[1])
 	return stackitem.NewArray(s.stringSplitAux(str, sep, false))
 }
 
 func (s *Std) stringSplit3(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	str := s.toLimitedString(args[0])
+	str := toLimitedString(args[0])
 	sep := toString(args[1])
 	removeEmpty, err := args[2].TryBool()
 	if err != nil {
@@ -455,7 +455,7 @@ func (s *Std) stringSplitAux(str, sep string, removeEmpty bool) []stackitem.Item
 }
 
 func (s *Std) strLen(_ *interop.Context, args []stackitem.Item) stackitem.Item {
-	str := s.toLimitedString(args[0])
+	str := toLimitedString(args[0])
 
 	return stackitem.NewBigInteger(big.NewInt(int64(utf8.RuneCountInString(str))))
 }
@@ -490,7 +490,7 @@ func (s *Std) ActiveIn() *config.Hardfork {
 	return nil
 }
 
-func (s *Std) toLimitedBytes(item stackitem.Item) []byte {
+func toLimitedBytes(item stackitem.Item) []byte {
 	src, err := item.TryBytes()
 	if err != nil {
 		panic(err)
@@ -501,7 +501,7 @@ func (s *Std) toLimitedBytes(item stackitem.Item) []byte {
 	return src
 }
 
-func (s *Std) toLimitedString(item stackitem.Item) string {
+func toLimitedString(item stackitem.Item) string {
 	src := toString(item)
 	if len(src) > stdMaxInputLength {
 		panic(ErrTooBigInput)

--- a/pkg/core/native/std_test.go
+++ b/pkg/core/native/std_test.go
@@ -227,6 +227,27 @@ func TestStdLibEncodeDecode(t *testing.T) {
 		})
 		require.Equal(t, stackitem.Make(original), actual)
 	})
+	t.Run("Decode64/compat", func(t *testing.T) {
+		t.Run("tx 9891b55c43a6e5054c59d9966a48b55084a9d8839b5bac2aeb6fd11df2910aa4", func(t *testing.T) {
+			// Ref. #3926, input with space:
+			in := " enIC6PJKUGGHR56RZ4PXXJizdmIHXDWlU75cQkOMK0pdQenvQphcuL/u0Borm4hecvZX3lNRxqxcnAjfU7HhVQ=="
+			expected, err := base64.StdEncoding.DecodeString(in[1:])
+			require.NoError(t, err)
+			require.NotPanics(t, func() {
+				actual = s.base64Decode(ic, []stackitem.Item{stackitem.Make(in)})
+			})
+			require.Equal(t, stackitem.Make(expected), actual)
+		})
+		t.Run("custom example", func(t *testing.T) {
+			in := "A \r Q \t I \n D"
+			expected, err := base64.StdEncoding.DecodeString("AQID")
+			require.NoError(t, err)
+			require.NotPanics(t, func() {
+				actual = s.base64Decode(ic, []stackitem.Item{stackitem.Make(in)})
+			})
+			require.Equal(t, stackitem.Make(expected), actual)
+		})
+	})
 	t.Run("Decode64/error", func(t *testing.T) {
 		require.Panics(t, func() {
 			_ = s.base64Decode(ic, []stackitem.Item{stackitem.Make(encoded64 + "%")})
@@ -242,6 +263,15 @@ func TestStdLibEncodeDecode(t *testing.T) {
 			actual = s.base64UrlDecode(ic, []stackitem.Item{stackitem.Make(encoded64Url)})
 		})
 		require.Equal(t, stackitem.Make(originalUrl), actual)
+	})
+	t.Run("Decode64Url/compat", func(t *testing.T) {
+		in := "U 3 \t V \n \riamVjdD10ZXN0QGV4YW1wbGUuY29tJklzc3Vlcj1odHRwczovL2V4YW1wbGUuY29t"
+		expected, err := base64.URLEncoding.DecodeString("U3ViamVjdD10ZXN0QGV4YW1wbGUuY29tJklzc3Vlcj1odHRwczovL2V4YW1wbGUuY29t")
+		require.NoError(t, err)
+		require.NotPanics(t, func() {
+			actual = s.base64UrlDecode(ic, []stackitem.Item{stackitem.Make(in)})
+		})
+		require.Equal(t, stackitem.Make(expected), actual)
 	})
 	t.Run("Decode64Url/error", func(t *testing.T) {
 		require.Panics(t, func() {


### PR DESCRIPTION
### Problem:

RFC 4648 specifies that non-alphabet characters must be rejected, but that other specifications that depend on RFC 4648 such as MIME (RFC 2045) and PEM (RFC 7468) may specify additional characters (e.g., whitespace) that are to be ignored. C# node uses Convert.FromBase64String that ignores tab, new line, carriage return and whitespace characters during decoding:
https://github.com/neo-project/neo/blob/9b9be47357e9065de524005755212ed54c3f6a11/src/Neo/SmartContract/Native/StdLib.cs#L132
See the behaviour remarks:
https://learn.microsoft.com/ru-ru/dotnet/api/system.convert.frombase64string?view=net-8.0#remarks

Standard Go library strictly follows RFC 4648 and ignores new line and carriage return characters by default, whereas other characters that are missing from decoder's alphabet lead to decoding error. base64 library doesn't allow to customize ignorable characters for now, but it may be merged eventually, the fix is rather trivial, ref.:
https://go-review.googlesource.com/c/go/+/532295
https://github.com/golang/go/issues/54054
https://github.com/golang/go/issues/53845

Ditto for Base64UrlEncoder.Decode.

### Solution:

For now, strip whitespaces and tabulations manually, close #3926.
