### PR TITLE
go.mod: use faster Bolt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/nspcc-dev/neo-go
 
 go 1.23
 
+replace go.etcd.io/bbolt v1.4.0 => github.com/nspcc-dev/bbolt v0.0.0-20250611091059-53975e370e68
+
 require (
 	github.com/chzyer/readline v1.5.1
 	github.com/consensys/gnark v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/nspcc-dev/bbolt v0.0.0-20250611091059-53975e370e68 h1:Wlb6FQvp+5uGSsham2BkMC/mmtD9fC78xVZswNAo48E=
+github.com/nspcc-dev/bbolt v0.0.0-20250611091059-53975e370e68/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 github.com/nspcc-dev/dbft v0.3.3-0.20250321140139-7462b47e4d2d h1:Mm0bp0YRAuGfoUDPbleQ9zByJc6HTCu3B4/UBoen9cQ=
 github.com/nspcc-dev/dbft v0.3.3-0.20250321140139-7462b47e4d2d/go.mod h1:msYlF5GIGwOZ9jUIHttBAAtiqJ29jzV8PPKKv1avXAI=
 github.com/nspcc-dev/go-ordered-json v0.0.0-20250226190835-fb3f82b1f468 h1:qOd9/UANpXOME/3RTSa/dJoSzdVwYOkD32XQah0xj1E=
@@ -228,8 +230,6 @@ github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGC
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
-go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 h1:jq9TW8u3so/bN+JPT166wjOI6/vQPF6Xe7nMNIltagk=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0/go.mod h1:p8pYQP+m5XfbZm9fxtSKAbM6oIllS7s2AfxrChvc7iw=
 go.opentelemetry.io/otel v1.32.0 h1:WnBN+Xjcteh0zdk01SVqV55d/m62NJLJdIyb4y/WO5U=


### PR DESCRIPTION
Similar to a1b2467850fd3d24a418c5aa88a8ae171dffbed5, but with a more stable and improved version now. The same one as in https://github.com/nspcc-dev/neofs-node/pull/3389