### PR TITLE
rpcclient: add missing GetBlockHeaderByIndex[Verbose] APIs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,3 +24,11 @@ APIs/commands/configurations will be removed and here is a list of scheduled
 breaking changes. Consider changing your code/scripts/configurations if you're
 using anything mentioned here.
 
+## GetBlockHeader and GetBlockHeaderVerbose methods of RPCClient
+
+GetBlockHeader and GetBlockHeaderVerbose were replaced by GetBlockHeaderByHash
+and GetBlockHeaderByHashVerbose methods respectively to follow RPCClient
+naming convention. No functional changes implied.
+
+Removal of GetBlockHeader and GetBlockHeaderVerbose methods is scheduled for
+0.112.0 release.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,12 +7,12 @@ functionality.
 ## Versions 0.7X.Y (as needed)
 * Neo 2.0 support (bug fixes, minor functionality additions)
 
-## Version 0.109.0 (~April 2025)
+## Version 0.111.0 (~Aug 2025)
  * protocol updates
  * bug fixes
  * NeoFS-based synchronization
 
-## Version 1.0 (2024, TBD)
+## Version 1.0 (2025, TBD)
  * stable version
 
 # Deprecated functionality

--- a/pkg/rpcclient/rpc.go
+++ b/pkg/rpcclient/rpc.go
@@ -154,9 +154,28 @@ func (c *Client) GetBlockHash(index uint32) (util.Uint256, error) {
 // GetBlockHeader returns the corresponding block header information from a serialized hex string
 // according to the specified script hash. In-header stateroot option must be
 // initialized with Init before calling this method.
+// Deprecated: Use GetBlockHeaderByHash instead.
 func (c *Client) GetBlockHeader(hash util.Uint256) (*block.Header, error) {
+	return c.GetBlockHeaderByHash(hash)
+}
+
+// GetBlockHeaderByHash returns the corresponding block header information from
+// a serialized base64 string according to the specified script hash. In-header
+// stateroot option must be initialized with Init before calling this method.
+func (c *Client) GetBlockHeaderByHash(hash util.Uint256) (*block.Header, error) {
+	return c.getHeader(hash.StringLE())
+}
+
+// GetBlockHeaderByIndex returns the corresponding block header information from
+// a serialized base64 string according to the specified index. In-header
+// stateroot option must be initialized with Init before calling this method.
+func (c *Client) GetBlockHeaderByIndex(index uint32) (*block.Header, error) {
+	return c.getHeader(index)
+}
+
+func (c *Client) getHeader(param any) (*block.Header, error) {
 	var (
-		params = []any{hash.StringLE()}
+		params = []any{param}
 		resp   []byte
 		h      *block.Header
 	)
@@ -189,9 +208,29 @@ func (c *Client) GetBlockHeaderCount() (uint32, error) {
 // GetBlockHeaderVerbose returns the corresponding block header information from a Json format string
 // according to the specified script hash. In-header stateroot option must be
 // initialized with Init before calling this method.
+// Deprecated: Use GetBlockHeaderByHashVerbose instead.
 func (c *Client) GetBlockHeaderVerbose(hash util.Uint256) (*result.Header, error) {
+	return c.GetBlockHeaderByHashVerbose(hash)
+}
+
+// GetBlockHeaderByHashVerbose returns the corresponding block header information from
+// a JSON format string according to the specified script hash. In-header
+// stateroot option must be initialized with Init before calling this method.
+func (c *Client) GetBlockHeaderByHashVerbose(hash util.Uint256) (*result.Header, error) {
+	return c.getHeaderVerbose(hash.StringLE())
+}
+
+// GetBlockHeaderByIndexVerbose returns the corresponding block header
+// information from a JSON format string according to the specified index.
+// In-header stateroot option must be initialized with Init before calling this
+// method.
+func (c *Client) GetBlockHeaderByIndexVerbose(index uint32) (*result.Header, error) {
+	return c.getHeaderVerbose(index)
+}
+
+func (c *Client) getHeaderVerbose(param any) (*result.Header, error) {
 	var (
-		params = []any{hash.StringLE(), 1}
+		params = []any{param, 1}
 		resp   = &result.Header{}
 	)
 	if err := c.performRequest("getblockheader", params, resp); err != nil {

--- a/pkg/rpcclient/rpc.go
+++ b/pkg/rpcclient/rpc.go
@@ -151,9 +151,9 @@ func (c *Client) GetBlockHash(index uint32) (util.Uint256, error) {
 	return resp, nil
 }
 
-// GetBlockHeader returns the corresponding block header information from a serialized hex string
-// according to the specified script hash. In-header stateroot option must be
-// initialized with Init before calling this method.
+// GetBlockHeader returns the corresponding block header information from
+// a serialized base64 string according to the specified script hash. In-header
+// stateroot option must be initialized with Init before calling this method.
 // Deprecated: Use GetBlockHeaderByHash instead.
 func (c *Client) GetBlockHeader(hash util.Uint256) (*block.Header, error) {
 	return c.GetBlockHeaderByHash(hash)
@@ -205,9 +205,9 @@ func (c *Client) GetBlockHeaderCount() (uint32, error) {
 	return resp, nil
 }
 
-// GetBlockHeaderVerbose returns the corresponding block header information from a Json format string
-// according to the specified script hash. In-header stateroot option must be
-// initialized with Init before calling this method.
+// GetBlockHeaderVerbose returns the corresponding block header information from
+// a JSON format string according to the specified script hash. In-header
+// stateroot option must be initialized with Init before calling this method.
 // Deprecated: Use GetBlockHeaderByHashVerbose instead.
 func (c *Client) GetBlockHeaderVerbose(hash util.Uint256) (*result.Header, error) {
 	return c.GetBlockHeaderByHashVerbose(hash)


### PR DESCRIPTION
Requested by @carpawell, will be useful for NeoFS node.