### PR TITLE
cli: allow to skip index files during container audit

### DIFF
--- a/cli/util/audit-bin.go
+++ b/cli/util/audit-bin.go
@@ -30,6 +30,7 @@ func auditBin(ctx *cli.Context) error {
 	debug := ctx.Bool("debug")
 	dryRun := ctx.Bool("dry-run")
 	blockAttr := ctx.String("block-attribute")
+	skip := ctx.Int("skip")
 
 	acc, _, err := options.GetAccFromContext(ctx)
 	if err != nil {
@@ -56,8 +57,11 @@ func auditBin(ctx *cli.Context) error {
 		return cli.Exit(fmt.Errorf("failed to get container %s: %w", containerID, err), 1)
 	}
 
+	if skip > 0 {
+		fmt.Fprintf(ctx.App.Writer, "Skipping %d index files\n", skip)
+	}
 	filters := object.NewSearchFilters()
-	filters.AddFilter(indexAttrKey, fmt.Sprintf("%d", 0), object.MatchNumGE)
+	filters.AddFilter(indexAttrKey, fmt.Sprintf("%d", skip), object.MatchNumGE)
 	results, errs := neofs.ObjectSearch(ctx.Context, neoFSPool, acc.PrivateKey(), containerID, filters, []string{indexAttrKey})
 
 	var (

--- a/cli/util/convert.go
+++ b/cli/util/convert.go
@@ -121,6 +121,17 @@ func NewCommands() []*cli.Command {
 			Usage: "If set, the command will not delete any objects, but will print the list of objects to be deleted",
 			Value: false,
 		},
+		&cli.IntFlag{
+			Name:  "skip",
+			Usage: "Number of index files to skip audit for",
+			Value: 0,
+			Action: func(context *cli.Context, i int) error {
+				if i < 0 {
+					return cli.Exit("negative --skip", 1)
+				}
+				return nil
+			},
+		},
 		options.Debug,
 		options.ForceTimestampLogs,
 	}, neoFSFlags...)


### PR DESCRIPTION
Try to avoid network-dependent failures in the middle of the process:
```
Processing index file 25 (Fht7B2N6gTHcS3wm7WhYrNDsV39HxKe5gUe7gwxJj4Nt)
failed to remove block duplicates: failed to search objects: connection: no healthy client

real    34m48,582s
```