### PR TITLE
rpcclient: fix local client panic

### DIFF
--- a/pkg/rpcclient/local.go
+++ b/pkg/rpcclient/local.go
@@ -66,14 +66,11 @@ eventloop:
 	}
 	close(c.readerDone)
 	c.ctxCancel()
-	// ctx is cancelled, server is notified and will finish soon.
-drainloop:
+	// ctx is cancelled, server is notified and will close c.events soon.
 	for {
-		select {
-		case <-c.events:
-		default:
-			break drainloop
+		_, ok := <-c.events
+		if !ok {
+			break
 		}
 	}
-	close(c.events)
 }

--- a/pkg/rpcclient/local_test.go
+++ b/pkg/rpcclient/local_test.go
@@ -1,18 +1,38 @@
-package rpcclient
+package rpcclient_test
 
 import (
 	"context"
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/internal/testcli"
+	"github.com/nspcc-dev/neo-go/pkg/config"
 	"github.com/nspcc-dev/neo-go/pkg/neorpc"
+	"github.com/nspcc-dev/neo-go/pkg/rpcclient"
 	"github.com/stretchr/testify/require"
 )
 
 func TestInternalClientClose(t *testing.T) {
-	icl, err := NewInternal(context.TODO(), func(ctx context.Context, ch chan<- neorpc.Notification) func(*neorpc.Request) (*neorpc.Response, error) {
+	icl, err := rpcclient.NewInternal(context.TODO(), func(ctx context.Context, ch chan<- neorpc.Notification) func(*neorpc.Request) (*neorpc.Response, error) {
 		return nil
 	})
 	require.NoError(t, err)
+	icl.Close()
+	require.NoError(t, icl.GetError())
+}
+
+func TestInternalClientCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	bc, rpcSrv, netSrv := testcli.NewTestChain(t, func(c *config.Config) {
+		c.ApplicationConfiguration.Consensus.UnlockWallet.Path = "../../cli/testdata/wallet1_solo.json"
+	}, true)
+	t.Cleanup(func() {
+		netSrv.Shutdown()
+		rpcSrv.Shutdown()
+		bc.Close()
+	})
+	icl, err := rpcclient.NewInternal(ctx, rpcSrv.RegisterLocal)
+	require.NoError(t, err)
+	cancel()
 	icl.Close()
 	require.NoError(t, icl.GetError())
 }

--- a/pkg/services/rpcsrv/server.go
+++ b/pkg/services/rpcsrv/server.go
@@ -564,7 +564,8 @@ func (s *Server) handleHTTPRequest(w http.ResponseWriter, httpRequest *http.Requ
 	s.writeHTTPServerResponse(req, w, resp)
 }
 
-// RegisterLocal performs local client registration.
+// RegisterLocal performs local client registration. Events channel will be
+// closed by server once context is done or server is closed.
 func (s *Server) RegisterLocal(ctx context.Context, events chan<- neorpc.Notification) func(*neorpc.Request) (*neorpc.Response, error) {
 	subChan := make(chan intEvent, notificationBufSize)
 	subscr := &subscriber{writer: subChan, feeds: make([]feed, s.config.MaxWebSocketFeeds)}


### PR DESCRIPTION
Looks like this existed since a55a01d45658a778e9b2edb1f0dd4c61e131ca90 and I have no idea why we haven't seen this before https://github.com/nspcc-dev/neofs-node/pull/3456 which is totally unrelated. But what we have in the end is

    panic: close of closed channel

    goroutine 182 [running]:
    github.com/nspcc-dev/neo-go/pkg/services/rpcsrv.(*Server).handleLocalNotifications(0xc00033aa08, {0x1557f10, 0xc0002283c0}, 0xc00020d180, 0xc000206700, 0xc00011c7b0)
    	github.com/nspcc-dev/neo-go@v0.110.0/pkg/services/rpcsrv/server.go:679 +0x105
    created by github.com/nspcc-dev/neo-go/pkg/services/rpcsrv.(*Server).RegisterLocal in goroutine 1
    	github.com/nspcc-dev/neo-go@v0.110.0/pkg/services/rpcsrv/server.go:574 +0x193

and that's exactly true, we're closing it both sides. Solve it by making client wait for server to finish.