### PR TITLE
cli:  db download-contract command

### DIFF
--- a/cli/nep_test/nep11_test.go
+++ b/cli/nep_test/nep11_test.go
@@ -431,7 +431,7 @@ func TestNEP11_D_OwnerOf_BalanceOf_Transfer(t *testing.T) {
 		require.Equal(t, 2, len(aer[0].Events))
 		nfsoMintEvent := aer[0].Events[1]
 		require.Equal(t, "Transfer", nfsoMintEvent.Name)
-		tokenID, err := z[3].TryBytes()
+		tokenID, err := nfsoMintEvent.Item.Value().([]stackitem.Item)[3].TryBytes()
 		require.NoError(t, err)
 		require.NotNil(t, tokenID)
 		return tokenID

--- a/cli/nep_test/nep11_test.go
+++ b/cli/nep_test/nep11_test.go
@@ -431,7 +431,7 @@ func TestNEP11_D_OwnerOf_BalanceOf_Transfer(t *testing.T) {
 		require.Equal(t, 2, len(aer[0].Events))
 		nfsoMintEvent := aer[0].Events[1]
 		require.Equal(t, "Transfer", nfsoMintEvent.Name)
-		tokenID, err := nfsoMintEvent.Item.Value().([]stackitem.Item)[3].TryBytes()
+		tokenID, err := z[3].TryBytes()
 		require.NoError(t, err)
 		require.NotNil(t, tokenID)
 		return tokenID

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -776,8 +776,11 @@ func downloadContract(ctx *cli.Context) error {
 
 	force := ctx.Bool("force")
 	existingState := chain.GetContractState(ch)
-	if existingState != nil && !force {
-		return cli.Exit(fmt.Errorf("contract already exists in the chain. Use --force to overwrite"), 1)
+	if existingState != nil {
+		if !force {
+			return cli.Exit(fmt.Errorf("contract already exists in the chain. Use --force to overwrite"), 1)
+		}
+		contractState.ID = existingState.ID
 	}
 
 	d := dao.NewSimple(store, cfg.ProtocolConfiguration.StateRootInHeader)

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -804,7 +804,7 @@ func PutContractState(d *dao.Simple, cs *state.Contract) error {
 
 // TODO: check with nspcc if we can update PutContractState with an extra param
 // or else how to have the cache for ManagementContract initialized such that it doesn't panic
-// trying to run markUpdated()
+// trying to run markUpdated().
 func PutContractStateNoCache(d *dao.Simple, cs *state.Contract) error {
 	return putContractState(d, cs, false)
 }
@@ -869,7 +869,7 @@ func checkScriptAndMethods(ic *interop.Context, script []byte, methods []manifes
 }
 
 // TODO: decide how to best expose. There are too many options that for the time I picked a duplicate
-// function to have something working and let nspcc decide their preferred exposing option
+// function to have something working and let nspcc decide their preferred exposing option.
 func GetNextContractID(d *dao.Simple) (int32, error) {
 	si := d.GetStorageItem(ManagementContractID, keyNextAvailableID)
 	if si == nil {

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -802,6 +802,13 @@ func PutContractState(d *dao.Simple, cs *state.Contract) error {
 	return putContractState(d, cs, true)
 }
 
+// TODO: check with nspcc if we can update PutContractState with an extra param
+// or else how to have the cache for ManagementContract initialized such that it doesn't panic
+// trying to run markUpdated()
+func PutContractStateNoCache(d *dao.Simple, cs *state.Contract) error {
+	return putContractState(d, cs, false)
+}
+
 // putContractState is an internal PutContractState representation.
 func putContractState(d *dao.Simple, cs *state.Contract, updateCache bool) error {
 	key := MakeContractKey(cs.Hash)
@@ -859,4 +866,18 @@ func checkScriptAndMethods(ic *interop.Context, script []byte, methods []manifes
 	}
 
 	return nil
+}
+
+// TODO: decide how to best expose. There are too many options that for the time I picked a duplicate
+// function to have something working and let nspcc decide their preferred exposing option
+func GetNextContractID(d *dao.Simple) (int32, error) {
+	si := d.GetStorageItem(ManagementContractID, keyNextAvailableID)
+	if si == nil {
+		return 0, errors.New("nextAvailableID is not initialized")
+	}
+	id := bigint.FromBytes(si)
+	ret := int32(id.Int64())
+	id.Add(id, intOne)
+	d.PutBigInt(ManagementContractID, keyNextAvailableID, id)
+	return ret, nil
 }


### PR DESCRIPTION
### Problem

#2406

 We (coz) have used the feature (in neo-express) for a couple of years now and have learned that 
- multi-node support really isn't worth supporting
- not knowing contract child dependencies so far hasn't been an issue (point `3.` of original issue)
- similarly point `4.` of the original issue is theoretically a "problem" but in practice not yet encountered. So again can be ignored for the time being. 
- in our experience the ability to only overwrite the contract storage or only the contract state (options in neo-express) is hardly used (more on this below)

### Solution

The still relevant parts are addressed with this PR, being the basic functionality of fetching a contract state from a remote chain and storing it locally. From practice this was always done when the node was not running, so I implemented it as a subcommand of `neo-go db`.

The most relevant discussion imo is how to handle the persisting to storage, specifically around contract IDs. In neo-express I [implemented](https://github.com/neo-project/neo-express/blob/b7c10b26cf7fb23bf1b4a365c9a8717e883caec6/src/neoxp/Node/NodeUtility.cs#L351) it as follows
1. if the remote contract hash does not exist, persist 1:1
2. if it does exist, overwrite the state if `--force` is specified (but keep the local contract ID)

This PR is slightly different where for `1.` we do an additional check to see if the the remote contract ID is not already in use locally. 


### open things to address
1. after running the `db download-contract` command, the first time the node is started the new contract cannot be found (via the `getcontractstate` RPC method). Only after a shutdown and starting again it can be found. It's unclear to me why
2. the 2 TODOs in the code. I'm sure there is an opinion from your side how to expose the required data. I didn't want to guess, so took the easiest approach for me to start the discussion.

