### PR TITLE
workflows: don't build Dockers in PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     needs: build_cli
     name: Build and push docker image
     runs-on: ubuntu-22.04
-
+    if: ${{ github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -124,7 +124,7 @@ jobs:
     needs: build_cli
     name: Build and push docker image (Windows Server Core)
     runs-on: windows-2022
-
+    if: ${{ github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The only thing it does in PR is ensures that Docker images can be built, they're not pushed into any registry, so they can't be used and no one needs the result. Building in master is sufficient for the purpose of finding failed Docker builds (they don't break often), but we better avoid doing it in PRs since it takes a considerable amount of time blocking runners available to project/organization.

See https://github.com/nspcc-dev/neofs-node/pull/3490 also.
