### PR TITLE
config: fix Faun stringer

### DIFF
--- a/pkg/config/hardfork.go
+++ b/pkg/config/hardfork.go
@@ -52,7 +52,7 @@ const (
 	HFEchidna // Echidna
 	// HFFaun represents hard-fork introduced in #3931, it's currently
 	// under development and doesn't introduce any new functionality yet.
-	HFFaun
+	HFFaun // Faun
 	// hfLast denotes the end of hardforks enum. Consider adding new hardforks
 	// before hfLast.
 	hfLast

--- a/pkg/config/hardfork_string.go
+++ b/pkg/config/hardfork_string.go
@@ -23,7 +23,7 @@ const (
 	_Hardfork_name_1 = "Cockatrice"
 	_Hardfork_name_2 = "Domovoi"
 	_Hardfork_name_3 = "Echidna"
-	_Hardfork_name_4 = "HFFaun"
+	_Hardfork_name_4 = "Faun"
 	_Hardfork_name_5 = "hfLast"
 )
 


### PR DESCRIPTION
The name of this HF is "Faun", not "HF_Faun". Discovered during NeoBench run:
```
2025/09/05 17:21:36 Used [sharp-node:20331] rpc addresses
2025/09/05 17:21:36 could not receive RPC Node version: could not unmarshal result body: "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tcpport\":20332,\"nonce\":28927739,\"useragent\":\"/Neo:3.8.1/\",\"rpc\":{\"maxiteratorresultitems\":100,\"sessionenabled\":false},\"protocol\":{\"addressversion\":53,\"network\":56753,\"validatorscount\":4,\"msperblock\":5000,\"maxtraceableblocks\":2102400,\"maxvaliduntilblockincrement\":5760,\"maxtransactionsperblock\":65535,\"memorypoolmaxtransactions\":50000,\"initialgasdistribution\":5200000000000000,\"hardforks\":[{\"name\":\"Aspidochelone\",\"blockheight\":0},{\"name\":\"Basilisk\",\"blockheight\":0},{\"name\":\"Cockatrice\",\"blockheight\":0},{\"name\":\"Domovoi\",\"blockheight\":0},{\"name\":\"Echidna\",\"blockheight\":0},{\"name\":\"Faun\",\"blockheight\":5}],\"standbycommittee\":[\"02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2\",\"02103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e\",\"03d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee699\",\"02a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd62\"],\"seedlist\":[\"node_one:20333\",\"node_two:20334\",\"node_three:20335\",\"node_four:20336\"]}}}" unexpected hardfork: Faun
```