### PR TITLE
refactor: use the built-in max to simplify the code

### DIFF
--- a/pkg/services/rpcsrv/subscription_test.go
+++ b/pkg/services/rpcsrv/subscription_test.go
@@ -749,10 +749,7 @@ func doSomeWSRequest(t *testing.T, ws *websocket.Conn) {
 
 func TestWSClientsLimit(t *testing.T) {
 	for tname, limit := range map[string]int{"8": 8, "disabled": -1} {
-		effectiveClients := limit
-		if limit < 0 {
-			effectiveClients = 0
-		}
+		effectiveClients := max(limit, 0)
 		t.Run(tname, func(t *testing.T) {
 			_, _, httpSrv := initClearServerWithCustomConfig(t, func(cfg *config.Config) {
 				cfg.ApplicationConfiguration.RPC.MaxWebSocketClients = limit


### PR DESCRIPTION
### Problem

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


### Solution


...
