### PR TITLE
rpcbinding: fix bindings using NEP-22/NEP-31 modules

### DIFF
--- a/cli/smartcontract/testdata/rpcbindings/nft-d/rpcbindings.out
+++ b/cli/smartcontract/testdata/rpcbindings/nft-d/rpcbindings.out
@@ -55,5 +55,5 @@ func New(actor Actor) *Contract {
 	var hash = Hash
 	var nep11dt = nep11.NewDivisible(actor, hash)
 	var nep24t = nep24.NewRoyaltyReader(actor, hash)
-	return &Contract{ContractReader{nep11dt.DivisibleReader, *nep24t, actor, hash}, nep11dt.DivisibleWriter, nep22.NewContract(actor, hash), nep31.NewContract(actor, hash), actor, hash}
+	return &Contract{ContractReader{nep11dt.DivisibleReader, *nep24t, actor, hash}, nep11dt.DivisibleWriter, *nep22.NewContract(actor, hash), *nep31.NewContract(actor, hash), actor, hash}
 }

--- a/cli/smartcontract/testdata/rpcbindings/nft-d/rpcbindings_dynamic_hash.out
+++ b/cli/smartcontract/testdata/rpcbindings/nft-d/rpcbindings_dynamic_hash.out
@@ -50,5 +50,5 @@ func NewReader(invoker Invoker, hash util.Uint160) *ContractReader {
 func New(actor Actor, hash util.Uint160) *Contract {
 	var nep11dt = nep11.NewDivisible(actor, hash)
 	var nep24t = nep24.NewRoyaltyReader(actor, hash)
-	return &Contract{ContractReader{nep11dt.DivisibleReader, *nep24t, actor, hash}, nep11dt.DivisibleWriter, nep22.NewContract(actor, hash), nep31.NewContract(actor, hash), actor, hash}
+	return &Contract{ContractReader{nep11dt.DivisibleReader, *nep24t, actor, hash}, nep11dt.DivisibleWriter, *nep22.NewContract(actor, hash), *nep31.NewContract(actor, hash), actor, hash}
 }

--- a/cli/smartcontract/testdata/rpcbindings/nft-nd/rpcbindings.out
+++ b/cli/smartcontract/testdata/rpcbindings/nft-nd/rpcbindings.out
@@ -74,7 +74,7 @@ func New(actor Actor) *Contract {
 	var hash = Hash
 	var nep11ndt = nep11.NewNonDivisible(actor, hash)
 	var nep24t = nep24.NewRoyaltyReader(actor, hash)
-	return &Contract{ContractReader{nep11ndt.NonDivisibleReader, *nep24t, actor, hash}, nep11ndt.BaseWriter, nep22.NewContract(actor, hash), nep31.NewContract(actor, hash), actor, hash}
+	return &Contract{ContractReader{nep11ndt.NonDivisibleReader, *nep24t, actor, hash}, nep11ndt.BaseWriter, *nep22.NewContract(actor, hash), *nep31.NewContract(actor, hash), actor, hash}
 }
 
 func (c *Contract) scriptForSetRoyaltyInfo(ctx any, tokenID []byte, recipients []*NftRoyaltyRecipientShare) ([]byte, error) {

--- a/cli/smartcontract/testdata/rpcbindings/nft-nd/rpcbindings_dynamic_hash.out
+++ b/cli/smartcontract/testdata/rpcbindings/nft-nd/rpcbindings_dynamic_hash.out
@@ -69,7 +69,7 @@ func NewReader(invoker Invoker, hash util.Uint160) *ContractReader {
 func New(actor Actor, hash util.Uint160) *Contract {
 	var nep11ndt = nep11.NewNonDivisible(actor, hash)
 	var nep24t = nep24.NewRoyaltyReader(actor, hash)
-	return &Contract{ContractReader{nep11ndt.NonDivisibleReader, *nep24t, actor, hash}, nep11ndt.BaseWriter, nep22.NewContract(actor, hash), nep31.NewContract(actor, hash), actor, hash}
+	return &Contract{ContractReader{nep11ndt.NonDivisibleReader, *nep24t, actor, hash}, nep11ndt.BaseWriter, *nep22.NewContract(actor, hash), *nep31.NewContract(actor, hash), actor, hash}
 }
 
 func (c *Contract) scriptForSetRoyaltyInfo(ctx any, tokenID []byte, recipients []*NftRoyaltyRecipientShare) ([]byte, error) {

--- a/pkg/smartcontract/rpcbinding/binding.go
+++ b/pkg/smartcontract/rpcbinding/binding.go
@@ -246,8 +246,8 @@ func New(actor Actor{{- if not (len .Hash) -}}, hash util.Uint160{{- end -}}) *C
 		{{- if .IsNep11D}}nep11dt.DivisibleWriter, {{end -}}
 		{{- if .IsNep11ND}}nep11ndt.BaseWriter, {{end -}}
 		{{- if .IsNep17}}nep17t.TokenWriter, {{end -}}
-		{{- if .IsNep22}}nep22.NewContract(actor, hash), {{end -}}
-		{{- if .IsNep31}}nep31.NewContract(actor, hash), {{end -}}
+		{{- if .IsNep22}}*nep22.NewContract(actor, hash), {{end -}}
+		{{- if .IsNep31}}*nep31.NewContract(actor, hash), {{end -}}
 		actor, hash}
 }
 {{end -}}


### PR DESCRIPTION
An attempt to use some autogenerated binding quickly results in

    rpc/netmap/rpcbinding.go:128:48: cannot use nep22.NewContract(actor, hash) (value of type *nep22.Contract) as nep22.Contract value in struct literal

because of type mismatch. Defect of a3bea1f0f0abf4505dda0599c73e976f8a8ef6dd and 89c00915b4f4f5b2a42a22718bee9d4eacc749bf.
