### PR TITLE
refactor: use maps.Copy and maps.Clone to simplify the code

### DIFF
--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	iocore "io"
+	"maps"
 	"math/big"
 	"sync"
 
@@ -1051,9 +1052,7 @@ func (dao *Simple) PersistSync() (int, error) {
 // It does NO checks for nativeCachePS is not nil.
 func (dao *Simple) persistNativeCache() {
 	lower := dao.nativeCachePS
-	for id, nativeCache := range dao.nativeCache {
-		lower.nativeCache[id] = nativeCache
-	}
+	maps.Copy(lower.nativeCache, dao.nativeCache)
 	dao.nativeCache = nil
 }
 

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"math/big"
 	"unicode/utf8"
@@ -71,21 +72,12 @@ var (
 // Copy implements NativeContractCache interface.
 func (c *ManagementCache) Copy() dao.NativeContractCache {
 	cp := &ManagementCache{
-		contracts: make(map[util.Uint160]*state.Contract),
-		nep11:     make(map[util.Uint160]struct{}),
-		nep17:     make(map[util.Uint160]struct{}),
-	}
-	// Copy the whole set of contracts is too expensive. We will create a separate map
-	// holding the same set of pointers to contracts, and in case if some contract is
-	// supposed to be changed, Management will create the copy in-place.
-	for hash, ctr := range c.contracts {
-		cp.contracts[hash] = ctr
-	}
-	for hash := range c.nep17 {
-		cp.nep17[hash] = struct{}{}
-	}
-	for hash := range c.nep11 {
-		cp.nep11[hash] = struct{}{}
+		// Copy the whole set of contracts is too expensive. We will create a separate map
+		// holding the same set of pointers to contracts, and in case if some contract is
+		// supposed to be changed, Management will create the copy in-place.
+		contracts: maps.Clone(c.contracts),
+		nep11:     maps.Clone(c.nep11),
+		nep17:     maps.Clone(c.nep17),
 	}
 	return cp
 }

--- a/pkg/services/oracle/request.go
+++ b/pkg/services/oracle/request.go
@@ -3,6 +3,7 @@ package oracle
 import (
 	"context"
 	"errors"
+	"maps"
 	"mime"
 	"net/http"
 	"net/url"
@@ -66,9 +67,7 @@ func (o *Oracle) AddRequests(reqs map[uint64]*state.OracleRequest) {
 
 	o.respMtx.Lock()
 	if !o.running {
-		for id, r := range reqs {
-			o.pending[id] = r
-		}
+		maps.Copy(o.pending, reqs)
 		o.respMtx.Unlock()
 		return
 	}
@@ -79,9 +78,7 @@ func (o *Oracle) AddRequests(reqs map[uint64]*state.OracleRequest) {
 	default:
 		select {
 		case old := <-o.requestMap:
-			for id, r := range old {
-				reqs[id] = r
-			}
+			maps.Copy(reqs, old)
 		default:
 		}
 		o.requestMap <- reqs


### PR DESCRIPTION
### Problem

There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

### Solution

...
