### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/cli/nep_test/nep11_test.go
+++ b/cli/nep_test/nep11_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/internal/testcli"
@@ -181,17 +182,18 @@ func TestNEP11_ND_OwnerOf_BalanceOf_Transfer(t *testing.T) {
 		e.CheckNextLine(t, "^\\s*HASHY:\\s+HASHY NFT \\("+h.StringLE()+"\\)")
 
 		// Hashes can be ordered in any way, so make a regexp for them.
-		var tokstring = "("
+		var tokstring strings.Builder
+		tokstring.WriteString("(")
 		for i, id := range ids {
 			if i > 0 {
-				tokstring += "|"
+				tokstring.WriteString("|")
 			}
-			tokstring += hex.EncodeToString(id)
+			tokstring.WriteString(hex.EncodeToString(id))
 		}
-		tokstring += ")"
+		tokstring.WriteString(")")
 
 		for range ids {
-			e.CheckNextLine(t, "^\\s*Token: "+tokstring+"\\s*$")
+			e.CheckNextLine(t, "^\\s*Token: "+tokstring.String()+"\\s*$")
 			e.CheckNextLine(t, "^\\s*Amount: 1\\s*$")
 			e.CheckNextLine(t, "^\\s*Updated: [0-9]+\\s*$")
 		}

--- a/pkg/core/native/native_test/ledger_test.go
+++ b/pkg/core/native/native_test/ledger_test.go
@@ -233,21 +233,21 @@ func TestLedger_GetTransactionSignersInteropAPI(t *testing.T) {
 	c.CheckHalt(t, tx.Hash(), stackitem.Make(e.Chain.BlockHeight()-1))
 
 	var (
-		hashStr string
-		accStr  string
+		hashStr strings.Builder
+		accStr  strings.Builder
 		txHash  = tx.Hash().BytesBE()
 		acc     = c.Committee.ScriptHash().BytesBE()
 	)
 	for i := range util.Uint256Size {
-		hashStr += fmt.Sprintf("%#x", txHash[i])
+		fmt.Fprintf(&hashStr, "%#x", txHash[i])
 		if i != util.Uint256Size-1 {
-			hashStr += ", "
+			hashStr.WriteString(", ")
 		}
 	}
 	for i := range util.Uint160Size {
-		accStr += fmt.Sprintf("%#x", acc[i])
+		fmt.Fprintf(&accStr, "%#x", acc[i])
 		if i != util.Uint160Size-1 {
-			accStr += ", "
+			accStr.WriteString(", ")
 		}
 	}
 
@@ -259,12 +259,12 @@ func TestLedger_GetTransactionSignersInteropAPI(t *testing.T) {
 			"github.com/nspcc-dev/neo-go/pkg/interop/util"
 		)
 		func CallLedger(accessValue bool) int {
-			signers := ledger.GetTransactionSigners(interop.Hash256{` + hashStr + `})
+			signers := ledger.GetTransactionSigners(interop.Hash256{` + hashStr.String() + `})
 			if len(signers) != 1 {
 				panic("bad length")
 			}
 			s0 := signers[0]
-			expectedAcc := interop.Hash160{` + accStr + `}
+			expectedAcc := interop.Hash160{` + accStr.String() + `}
 			if !util.Equals(string(s0.Account), string(expectedAcc)) {
 				panic("bad account")
 			}

--- a/pkg/core/native/native_test/neo_test.go
+++ b/pkg/core/native/native_test/neo_test.go
@@ -519,11 +519,11 @@ func TestNEO_GetAccountStateInteropAPI(t *testing.T) {
 	advanceChain(t)
 	neoValidatorInvoker.WithSigners(acc).Invoke(t, true, "transfer", acc.ScriptHash(), acc.ScriptHash(), amount, nil)
 
-	var hashAStr string
+	var hashAStr strings.Builder
 	for i := range util.Uint160Size {
-		hashAStr += fmt.Sprintf("%#x", acc.ScriptHash()[i])
+		fmt.Fprintf(&hashAStr, "%#x", acc.ScriptHash()[i])
 		if i != util.Uint160Size-1 {
-			hashAStr += ", "
+			hashAStr.WriteString(", ")
 		}
 	}
 	src := `package testaccountstate
@@ -532,7 +532,7 @@ func TestNEO_GetAccountStateInteropAPI(t *testing.T) {
 		  "github.com/nspcc-dev/neo-go/pkg/interop"
 	  )
 	  func GetLastGasPerVote() int {
-		  accState := neo.GetAccountState(interop.Hash160{` + hashAStr + `})
+		  accState := neo.GetAccountState(interop.Hash160{` + hashAStr.String() + `})
 		  if accState == nil {
 			  panic("nil state")
 		  }

--- a/pkg/smartcontract/binding/generate.go
+++ b/pkg/smartcontract/binding/generate.go
@@ -230,17 +230,17 @@ func scTypeToGo(name string, typ smartcontract.ParamType, cfg *Config) (string, 
 // and type conversion function. It assumes manifest to be present in the
 // configuration and assumes it to be correct (passing IsValid check).
 func TemplateFromManifest(cfg Config, scTypeConverter func(string, smartcontract.ParamType, *Config) (string, string)) ContractTmpl {
-	var hStr string
+	var hStr strings.Builder
 	if !cfg.Hash.Equals(util.Uint160{}) {
 		for _, b := range cfg.Hash.BytesBE() {
-			hStr += fmt.Sprintf("\\x%02x", b)
+			fmt.Fprintf(&hStr, "\\x%02x", b)
 		}
 	}
 
 	ctr := ContractTmpl{
 		PackageName:  cfg.Package,
 		ContractName: cfg.Manifest.Name,
-		Hash:         hStr,
+		Hash:         hStr.String(),
 	}
 	if ctr.PackageName == "" {
 		buf := bytes.NewBuffer(make([]byte, 0, len(cfg.Manifest.Name)))


### PR DESCRIPTION
### Problem

strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)


### Solution

...
