### PR TITLE
compiler: Support more assignment operators

### DIFF
--- a/pkg/compiler/assign_test.go
+++ b/pkg/compiler/assign_test.go
@@ -136,6 +136,46 @@ var assignTestCases = []testCase{
 		`,
 		big.NewInt(1024),
 	},
+	{
+		"left shift and assignment",
+		`func F%d() int {
+			x := 4
+			x <<= 20
+			return x
+		}
+		`,
+		big.NewInt(4194304),
+	},
+	{
+		"right shift and assignment",
+		`func F%d() int {
+			x := 4194304
+			x >>= 20
+			return x
+		}
+		`,
+		big.NewInt(4),
+	},
+	{
+		"AND and assignment",
+		`func F%d() int {
+			x := 0b_1010_1010
+			x &= 0b_1111_0000
+			return x
+		}
+		`,
+		big.NewInt(0b_1010_0000),
+	},
+	{
+		"OR and assignment",
+		`func F%d() int {
+			x := 0b_1010_1010
+			x |= 0b_1111_0000
+			return x
+		}
+		`,
+		big.NewInt(0b_1111_1010),
+	},
 }
 
 func TestAssignments(t *testing.T) {

--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -2339,13 +2339,13 @@ func convertToken(tok token.Token, typ types.Type) (opcode.Opcode, error) {
 		return opcode.INC, nil
 	case token.NOT:
 		return opcode.NOT, nil
-	case token.AND:
+	case token.AND, token.AND_ASSIGN:
 		return opcode.AND, nil
-	case token.OR:
+	case token.OR, token.OR_ASSIGN:
 		return opcode.OR, nil
-	case token.SHL:
+	case token.SHL, token.SHL_ASSIGN:
 		return opcode.SHL, nil
-	case token.SHR:
+	case token.SHR, token.SHR_ASSIGN:
 		return opcode.SHR, nil
 	case token.XOR:
 		return opcode.XOR, nil


### PR DESCRIPTION
`^=` and `&^=` are not covered. I can support them in the same way 