### PR TITLE
Fix flaky test `TestDefaultDiscoverer`

### DIFF
--- a/pkg/network/discovery_test.go
+++ b/pkg/network/discovery_test.go
@@ -122,7 +122,6 @@ func TestDefaultDiscoverer(t *testing.T) {
 		select {
 		case a := <-ts.dialCh:
 			dialled = append(dialled, a)
-			d.RegisterConnected(&fakeAPeer{addr: a, peer: a})
 		case <-time.After(time.Second):
 			t.Fatalf("timeout expecting for transport dial")
 		}


### PR DESCRIPTION
### Problem

`TestDefaultDiscoverer` is flaky with `go1.25`. Just try to run the test many times 

```bash
go test ./pkg/network -timeout 30s -run ^TestDefaultDiscoverer$ -count=1 -v
```

```
=== RUN   TestDefaultDiscoverer
    discovery_test.go:199: timeout expecting for transport dial; i: 1, j: 1
```
Sometimes it hits this `require`

```go
// Unregistering connected should work.
	for _, addr := range set1 {
		d.UnregisterConnected(&fakeAPeer{addr: addr, peer: addr}, false)
	}
	assert.Equal(t, 2, len(d.UnconnectedPeers())) // They're re-added automatically.
	assert.Equal(t, 0, len(d.BadPeers()))
	assert.Equal(t, len(set1), len(d.GoodPeers()))
	require.Equal(t, 2, d.PoolCount()) // FAILS HERE
```

### Solution

`RegisterConnected` has been removed:
- This step is unnecessary. `registerConnected` is already invoked within asynchronious call `tryAddress`;
- `a := <-ts.dialCh` does not guarantee `tryAddress` completion as it works out only on `Dial` call;
- Thus, `d.RegisterConnected` invocation causes a race condition that makes `tryAddress` wait for the mutex lock. That is why the test is flaky.
