### PR TITLE
config: adjust prometheus/pprof ports for mainnet config

### DIFF
--- a/config/protocol.mainnet.yml
+++ b/config/protocol.mainnet.yml
@@ -96,11 +96,11 @@ ApplicationConfiguration:
   Prometheus:
     Enabled: true
     Addresses:
-      - ":2112"
+      - ":1112"
   Pprof:
     Enabled: false
     Addresses:
-      - ":2113"
+      - ":1113"
   NeoFSBlockFetcher:
     Enabled: true
     Addresses:


### PR DESCRIPTION
Adjust these ports so that it's possible to run mainnet and testnet nodes at a single host without conflicts. All other mainnet node ports start with 1, so use the same rule for prometheus/pprof.

@roman-khimov, this change is quite invasive, we did never change these ports, but it's an issue I face every time when trying to run both nodes on my host, so I think it's worth changing.