### PR TITLE
compiler: Fix expression `switch` with non-last `default`

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -878,6 +878,14 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 		c.currentSwitch = label
 		c.pushStackLabel(label, 1)
 
+		last := len(n.Body.List) - 1
+		for i := range last {
+			if n.Body.List[i].(*ast.CaseClause).List == nil { // early default
+				n.Body.List[i], n.Body.List[last] = n.Body.List[last], n.Body.List[i]
+				break
+			}
+		}
+
 		startLabels := make([]uint16, len(n.Body.List))
 		for i := range startLabels {
 			startLabels[i] = c.newLabel()

--- a/pkg/compiler/switch_test.go
+++ b/pkg/compiler/switch_test.go
@@ -123,6 +123,46 @@ var switchTestCases = []testCase{
 		big.NewInt(1),
 	},
 	{
+		"case after first default",
+		`func F%d() int {
+			a := 5
+			switch a {
+			default: return 4
+			case 5: return 2
+			}
+		}
+		`,
+		big.NewInt(2),
+	},
+	{
+		"case after intermediate default",
+		`func F%d() int {
+			a := 6
+			switch a {
+			case 5: return 2
+			default: return 4
+			case 6:
+			}
+			return 1
+		}
+		`,
+		big.NewInt(1),
+	},
+	{
+		"intermediate default",
+		`func F%d() int {
+			a := 3
+			switch a {
+			case 5: return 2
+			default: return 4
+			case 6:
+			}
+			return 1
+		}
+		`,
+		big.NewInt(4),
+	},
+	{
 		"expression in case clause",
 		`func F%d() int {
 			a := 6


### PR DESCRIPTION
### Problem
i encountered this once while debugging a contract and spent a lot of time searching for the problem

### Solution
first, swapping expressions as the most obvious. But it changes the input, and mutation is possible. Cloning is an option, but im gonna think about it some more
