### PR TITLE
util: fix deadlock on audit exit

### DIFF
--- a/cli/util/audit-bin.go
+++ b/cli/util/audit-bin.go
@@ -45,6 +45,7 @@ func auditBin(ctx *cli.Context) error {
 					break
 				}
 			}
+			wg.Done()
 		}()
 	}
 


### PR DESCRIPTION
goroutine 1 [sync.WaitGroup.Wait, 2 minutes]:
sync.runtime_SemacquireWaitGroup(0x414a40?, 0x0?)
        runtime/sema.go:114 +0x2e
sync.(*WaitGroup).Wait(0xc0001c0fc0)
        sync/waitgroup.go:206 +0x85
github.com/nspcc-dev/neo-go/cli/util.auditBin(0xc0000f9340)
        github.com/nspcc-dev/neo-go/cli/util/audit-bin.go:53 +0x154
github.com/urfave/cli/v2.(*Command).Run(0xc0001ba160, 0xc0000f9340, {0xc000195e00, 0x10, 0x10})
        github.com/urfave/cli/v2@v2.27.7/command.go:276 +0x7c2
github.com/urfave/cli/v2.(*Command).Run(0xc0001b9600, 0xc0000f9240, {0xc00003e7e0, 0x11, 0x11})
        github.com/urfave/cli/v2@v2.27.7/command.go:269 +0xa30
github.com/urfave/cli/v2.(*Command).Run(0xc0001badc0, 0xc0000f9100, {0xc00003e120, 0x12, 0x12})
        github.com/urfave/cli/v2@v2.27.7/command.go:269 +0xa30
github.com/urfave/cli/v2.(*App).RunContext(0xc0001a2200, {0x1608c10, 0x1fbc560}, {0xc00003e120, 0x12, 0x12})
        github.com/urfave/cli/v2@v2.27.7/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(0x0?, {0xc00003e120?, 0x70?, 0x0?})
        github.com/urfave/cli/v2@v2.27.7/app.go:307 +0x2f
main.main()
        ./main.go:13 +0x32

Defect of 63530663ecafde11655497f0a19261a3f10c2a04. The code was originally written using Go 1.25+ wg.Go(), really missing it.