### PR TITLE
rpcbinding: use aliases for named contract standards

### DIFF
--- a/cli/smartcontract/rpcbindings/nft-d/dynamic_hash/rpcbindings_test.go
+++ b/cli/smartcontract/rpcbindings/nft-d/dynamic_hash/rpcbindings_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 // NEP22Contract is an alias for nep22.Contract.
-type NEP22Contract nep22.Contract
+type NEP22Contract = nep22.Contract
 
 // NEP31Contract is an alias for nep31.Contract.
-type NEP31Contract nep31.Contract
+type NEP31Contract = nep31.Contract
 
 // Invoker is used by ContractReader to call various safe methods.
 type Invoker interface {

--- a/cli/smartcontract/rpcbindings/nft-d/rpcbindings_test.go
+++ b/cli/smartcontract/rpcbindings/nft-d/rpcbindings_test.go
@@ -15,10 +15,10 @@ import (
 var Hash = util.Uint160{0x33, 0x22, 0x11, 0x0, 0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x0}
 
 // NEP22Contract is an alias for nep22.Contract.
-type NEP22Contract nep22.Contract
+type NEP22Contract = nep22.Contract
 
 // NEP31Contract is an alias for nep31.Contract.
-type NEP31Contract nep31.Contract
+type NEP31Contract = nep31.Contract
 
 // Invoker is used by ContractReader to call various safe methods.
 type Invoker interface {

--- a/cli/smartcontract/rpcbindings/nft-nd/dynamic_hash/rpcbindings_test.go
+++ b/cli/smartcontract/rpcbindings/nft-nd/dynamic_hash/rpcbindings_test.go
@@ -18,10 +18,10 @@ import (
 )
 
 // NEP22Contract is an alias for nep22.Contract.
-type NEP22Contract nep22.Contract
+type NEP22Contract = nep22.Contract
 
 // NEP31Contract is an alias for nep31.Contract.
-type NEP31Contract nep31.Contract
+type NEP31Contract = nep31.Contract
 
 // NftRoyaltyRecipientShare is a contract-specific nft.RoyaltyRecipientShare type used by its methods.
 type NftRoyaltyRecipientShare struct {

--- a/cli/smartcontract/rpcbindings/nft-nd/rpcbindings_test.go
+++ b/cli/smartcontract/rpcbindings/nft-nd/rpcbindings_test.go
@@ -21,10 +21,10 @@ import (
 var Hash = util.Uint160{0x33, 0x22, 0x11, 0x0, 0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x0}
 
 // NEP22Contract is an alias for nep22.Contract.
-type NEP22Contract nep22.Contract
+type NEP22Contract = nep22.Contract
 
 // NEP31Contract is an alias for nep31.Contract.
-type NEP31Contract nep31.Contract
+type NEP31Contract = nep31.Contract
 
 // NftRoyaltyRecipientShare is a contract-specific nft.RoyaltyRecipientShare type used by its methods.
 type NftRoyaltyRecipientShare struct {

--- a/pkg/smartcontract/rpcbinding/binding.go
+++ b/pkg/smartcontract/rpcbinding/binding.go
@@ -127,7 +127,7 @@ var Hash = {{ .Hash }}
 {{end -}}
 {{- range $index, $name := .ContractWriterStandards }}
 // {{toTypeNameUpper $name}}Contract is an alias for {{toTypeNameLower $name}}.Contract.
-type {{toTypeNameUpper $name}}Contract {{toTypeNameLower $name}}.Contract
+type {{toTypeNameUpper $name}}Contract = {{toTypeNameLower $name}}.Contract
 {{end -}}
 {{- range $index, $typ := .NamedTypes }}
 // {{toTypeName $typ.Name}} is a contract-specific {{$typ.Name}} type used by its methods.


### PR DESCRIPTION
Close #4085. This fix is valid until there are no conflicting methods in the standards.