### PR TITLE
util: add newline to error output from threads

### DIFF
--- a/cli/util/audit-bin.go
+++ b/cli/util/audit-bin.go
@@ -57,7 +57,7 @@ drainErrors:
 	for {
 		select {
 		case anotherErr := <-errs:
-			fmt.Fprintf(ctx.App.Writer, "error in worker thread: %s", anotherErr)
+			fmt.Fprintf(ctx.App.Writer, "error in worker thread: %s\n", anotherErr)
 			haveErrors = true
 		default:
 			break drainErrors


### PR DESCRIPTION
Otherwise it becomes a mess, Fprintf is not Println.
