### PR TITLE
config: fix mainnet MaxBlockSystemFee

### DIFF
--- a/config/protocol.mainnet.yml
+++ b/config/protocol.mainnet.yml
@@ -1,5 +1,6 @@
 ProtocolConfiguration:
   Magic: 860833102
+  MaxBlockSystemFee: 150000000000
   MaxTraceableBlocks: 2102400
   InitialGASSupply: 52000000
   TimePerBlock: 15s


### PR DESCRIPTION
Initially https://github.com/neo-project/neo-modules/pull/688 (plus https://github.com/neo-project/neo-modules/pull/703) was supposed to be testnet-only, but looks like this is what mainnet is using as well now at least for MaxBlockSystemFee.

Related to https://github.com/neo-project/neo/issues/4333