### PR TITLE
Optimize neotest in coverage mode

### DIFF
--- a/pkg/neotest/client.go
+++ b/pkg/neotest/client.go
@@ -64,7 +64,7 @@ func (c *ContractInvoker) TestInvokeScript(t testing.TB, script []byte, signers 
 	t.Cleanup(ic.Finalize)
 
 	if c.collectCoverage {
-		ic.VM.SetOnExecHook(coverageHook)
+		ic.VM.SetOnExecHook(c.coverageHook)
 	}
 
 	ic.VM.LoadWithFlags(tx.Script, callflag.All)
@@ -83,7 +83,7 @@ func (c *ContractInvoker) TestInvoke(t testing.TB, method string, args ...any) (
 	t.Cleanup(ic.Finalize)
 
 	if c.collectCoverage {
-		ic.VM.SetOnExecHook(coverageHook)
+		ic.VM.SetOnExecHook(c.coverageHook)
 	}
 
 	ic.VM.LoadWithFlags(tx.Script, callflag.All)


### PR DESCRIPTION
Previously, each `Executor` acquired global lock on each VM instruction. This led to test slowdowns as the number of Executor instances increased. Also, filling out the coverage file was scheduled by every `DeployContractBy()` / `DeployContractCheckFAULT()` call incl. sub-test calls.

This introduces two changes to the process:
 1. Each `Executor` schedules report once on cleanup of the test this instance is created for.
 2. Each `Executor` collects coverage data within itself, then merges collected data into global space on report.

For example, this reduced duration of current NeoFS contract tests was from ~12m to ~7s.

Closes #3558.