### PR TITLE
core: export native serializators

### DIFF
--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -370,6 +370,31 @@ func (dao *Simple) PutStorageItem(id int32, key []byte, si state.StorageItem) {
 	dao.Store.Put(stKey, si)
 }
 
+// GetStorageConvertible deserializes the [stackitem.Convertible] entry retrieved by
+// the provided key from the contract storage.
+func (dao *Simple) GetStorageConvertible(id int32, key []byte, conv stackitem.Convertible) error {
+	si := dao.GetStorageItem(id, key)
+	if si == nil {
+		return storage.ErrKeyNotFound
+	}
+	return stackitem.DeserializeConvertible(si, conv)
+}
+
+// PutStorageConvertible serializes the provided [stackitem.Convertible] using
+// DAO's serialization context and puts it to the specified contract storage.
+func (dao *Simple) PutStorageConvertible(id int32, key []byte, conv stackitem.Convertible) error {
+	item, err := conv.ToStackItem()
+	if err != nil {
+		return err
+	}
+	data, err := dao.GetItemCtx().Serialize(item, false)
+	if err != nil {
+		return err
+	}
+	dao.PutStorageItem(id, key, data)
+	return nil
+}
+
 // PutBigInt serializaed and puts the given integer for the given id with the given
 // key into the given store.
 func (dao *Simple) PutBigInt(id int32, key []byte, n *big.Int) {

--- a/pkg/core/native/designate.go
+++ b/pkg/core/native/designate.go
@@ -425,7 +425,7 @@ func (s *Designate) DesignateAsRole(ic *interop.Context, r noderoles.Role, pubs 
 	slices.SortFunc(pubs, (*keys.PublicKey).Cmp)
 	nl := NodeList(pubs)
 
-	err := putConvertibleToDAO(s.ID, ic.DAO, key, &nl)
+	err := ic.DAO.PutStorageConvertible(s.ID, key, &nl)
 	if err != nil {
 		return err
 	}

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -806,7 +806,7 @@ func PutContractState(d *dao.Simple, managementID int32, cs *state.Contract) err
 // putContractState is an internal PutContractState representation.
 func putContractState(d *dao.Simple, managementID int32, cs *state.Contract, updateCache bool) error {
 	key := MakeContractKey(cs.Hash)
-	if err := putConvertibleToDAO(managementID, d, key, cs); err != nil {
+	if err := d.PutStorageConvertible(managementID, key, cs); err != nil {
 		return err
 	}
 	if updateCache {

--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -895,7 +895,7 @@ func (n *NEO) RegisterCandidateInternal(ic *interop.Context, pub *keys.PublicKey
 		emitEvent = !c.Registered
 		c.Registered = true
 	}
-	err := putConvertibleToDAO(n.ID, ic.DAO, key, c)
+	err := ic.DAO.PutStorageConvertible(n.ID, key, c)
 	if err != nil {
 		return err
 	}
@@ -946,7 +946,7 @@ func (n *NEO) UnregisterCandidateInternal(ic *interop.Context, pub *keys.PublicK
 	c.Registered = false
 	ok := n.dropCandidateIfZero(ic.DAO, cache, pub, c)
 	if !ok {
-		err = putConvertibleToDAO(n.ID, ic.DAO, key, c)
+		err = ic.DAO.PutStorageConvertible(n.ID, key, c)
 	}
 	if err != nil {
 		return err
@@ -1093,7 +1093,7 @@ func (n *NEO) ModifyAccountVotes(acc *state.NEOBalance, d *dao.Simple, value *bi
 				return nil
 			}
 		}
-		return putConvertibleToDAO(n.ID, d, key, cd)
+		return d.PutStorageConvertible(n.ID, key, cd)
 	}
 	return nil
 }

--- a/pkg/core/native/notary.go
+++ b/pkg/core/native/notary.go
@@ -448,7 +448,7 @@ func (n *Notary) setMaxNotValidBeforeDelta(ic *interop.Context, args []stackitem
 func (n *Notary) GetDepositFor(dao *dao.Simple, acc util.Uint160) *state.Deposit {
 	key := append([]byte{prefixDeposit}, acc.BytesBE()...)
 	deposit := new(state.Deposit)
-	err := getConvertibleFromDAO(n.ID, dao, key, deposit)
+	err := dao.GetStorageConvertible(n.ID, key, deposit)
 	if err == nil {
 		return deposit
 	}
@@ -461,7 +461,7 @@ func (n *Notary) GetDepositFor(dao *dao.Simple, acc util.Uint160) *state.Deposit
 // putDepositFor puts the deposit on the balance of the specified account in the storage.
 func (n *Notary) putDepositFor(dao *dao.Simple, deposit *state.Deposit, acc util.Uint160) error {
 	key := append([]byte{prefixDeposit}, acc.BytesBE()...)
-	return putConvertibleToDAO(n.ID, dao, key, deposit)
+	return dao.PutStorageConvertible(n.ID, key, deposit)
 }
 
 // removeDepositFor removes the deposit from the storage.

--- a/pkg/core/native/util.go
+++ b/pkg/core/native/util.go
@@ -4,34 +4,12 @@ import (
 	"math/big"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/dao"
-	"github.com/nspcc-dev/neo-go/pkg/core/storage"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
 var intOne = big.NewInt(1)
 var intTwo = big.NewInt(2)
-
-func getConvertibleFromDAO(id int32, d *dao.Simple, key []byte, conv stackitem.Convertible) error {
-	si := d.GetStorageItem(id, key)
-	if si == nil {
-		return storage.ErrKeyNotFound
-	}
-	return stackitem.DeserializeConvertible(si, conv)
-}
-
-func putConvertibleToDAO(id int32, d *dao.Simple, key []byte, conv stackitem.Convertible) error {
-	item, err := conv.ToStackItem()
-	if err != nil {
-		return err
-	}
-	data, err := d.GetItemCtx().Serialize(item, false)
-	if err != nil {
-		return err
-	}
-	d.PutStorageItem(id, key, data)
-	return nil
-}
 
 func setIntWithKey(id int32, dao *dao.Simple, key []byte, value int64) {
 	dao.PutBigInt(id, key, big.NewInt(value))


### PR DESCRIPTION
PutConvertibleToDAO and GetConvertibleFromDAO can be used by custom native contracts, ref.
https://github.com/nspcc-dev/neofs-node/pull/3742#discussion_r2628963125.
