### PR TITLE
util: add a debug message for audit searches

### DIFF
--- a/cli/util/audit-bin.go
+++ b/cli/util/audit-bin.go
@@ -138,6 +138,10 @@ func auditBinInt(ctx *cli.Context, tasks chan func() error, errs chan error) err
 			return cli.Exit(fmt.Errorf("search block objects: %w", err), 1)
 		}
 
+		if debug {
+			fmt.Fprintf(ctx.App.Writer, "search returned %d results, previous height %d\n", len(page), prevH)
+		}
+
 		for _, itm := range page {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
It takes some time to walk through 6M of objects, so it'd be nice to have some visibility into the process.
