### PR TITLE
native: revoke votes of block account starting from Faun

### DIFF
--- a/pkg/core/native/native_test/policy_test.go
+++ b/pkg/core/native/native_test/policy_test.go
@@ -322,7 +322,11 @@ func TestPolicy_AttributeFeeCache(t *testing.T) {
 }
 
 func TestPolicy_BlockedAccounts(t *testing.T) {
-	c := newPolicyClient(t)
+	c := newCustomNativeClient(t, nativenames.Policy, func(cfg *config.Blockchain) {
+		cfg.Hardforks = map[string]uint32{
+			config.HFFaun.String(): 0,
+		}
+	})
 	e := c.Executor
 	randomInvoker := c.WithSigners(c.NewAccount(t))
 	committeeInvoker := c.WithSigners(c.Committee)

--- a/pkg/core/native/policy.go
+++ b/pkg/core/native/policy.go
@@ -642,7 +642,9 @@ func (p *Policy) BlockAccountInternal(ic *interop.Context, hash util.Uint160) bo
 	if blocked {
 		return false
 	}
-	var _ = p.NEO.RevokeVotes(ic, hash) // ignore error, as in the reference.
+	if ic.IsHardforkEnabled(config.HFFaun) {
+		var _ = p.NEO.RevokeVotes(ic, hash) // ignore error, as in the reference.
+	}
 	key := append([]byte{blockedAccountPrefix}, hash.BytesBE()...)
 	ic.DAO.PutStorageItem(p.ID, key, state.StorageItem{})
 	cache := ic.DAO.GetRWCache(p.ID).(*PolicyCache)


### PR DESCRIPTION
The behaviour was changed in https://github.com/neo-project/neo/pull/4385. Should be a part of #4115.

Close #4140.