### PR TITLE
chore: fix incorrect comment for TestWalletConvert function

### DIFF
--- a/cli/wallet/wallet_test.go
+++ b/cli/wallet/wallet_test.go
@@ -1099,7 +1099,7 @@ func TestWalletDumpKeys(t *testing.T) {
 	})
 }
 
-// Testcase is the wallet of privnet validator.
+// TestWalletConvert tests the conversion of the legacy wallet format to N3 wallet format.
 func TestWalletConvert(t *testing.T) {
 	tmpDir := t.TempDir()
 	e := testcli.NewExecutor(t, false)


### PR DESCRIPTION
### Problem

...

### Solution

The comment previously stated "Testcase is the wallet of privnet validator" which was misleading. Updated it to accurately describe that this test validates the conversion of NEO2 wallet format to NEO3 wallet format, which is what the test actually does.
