### PR TITLE
native: export default Neo implementation

### DIFF
--- a/pkg/core/native/contract.go
+++ b/pkg/core/native/contract.go
@@ -235,7 +235,7 @@ func NewDefaultContracts(cfg config.ProtocolConfiguration) []interop.Contract {
 	ledger := NewLedger()
 
 	gas := newGAS(int64(cfg.InitialGASSupply))
-	neo := newNEO(cfg)
+	neo := NewNEO(cfg)
 	policy := NewPolicy()
 	neo.GAS = gas
 	neo.Policy = policy

--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -165,8 +165,8 @@ func makeValidatorKey(key *keys.PublicKey) []byte {
 	return b
 }
 
-// newNEO returns NEO native contract.
-func newNEO(cfg config.ProtocolConfiguration) *NEO {
+// NewNEO returns NeoToken native contract.
+func NewNEO(cfg config.ProtocolConfiguration) *NEO {
 	n := &NEO{}
 	defer n.BuildHFSpecificMD(n.ActiveIn())
 


### PR DESCRIPTION
Required for initial version of Meta native contracts constructor, ref. https://github.com/nspcc-dev/neofs-node/pull/3759.