### PR TITLE
wallet: support signing for custom verification scripts

### DIFF
--- a/pkg/neotest/basic.go
+++ b/pkg/neotest/basic.go
@@ -330,7 +330,7 @@ func AddNetworkFee(t testing.TB, bc *core.Blockchain, tx *transaction.Transactio
 	for _, sgr := range signers {
 		csgr, ok := sgr.(SingleSigner)
 		if ok && csgr.Account().Contract.InvocationBuilder != nil {
-			sc, err := csgr.Account().Contract.InvocationBuilder(tx)
+			sc, err := csgr.Account().Contract.InvocationBuilder(true, tx)
 			require.NoError(t, err)
 
 			txCopy := *tx

--- a/pkg/neotest/signer.go
+++ b/pkg/neotest/signer.go
@@ -192,7 +192,7 @@ func NewContractSigner(h util.Uint160, getInvParams func(tx *transaction.Transac
 		Address: address.Uint160ToString(h),
 		Contract: &wallet.Contract{
 			Deployed: true,
-			InvocationBuilder: func(tx *transaction.Transaction) ([]byte, error) {
+			InvocationBuilder: func(testInvoke bool, tx *transaction.Transaction) ([]byte, error) {
 				params := getInvParams(tx)
 				script := io.NewBufBinWriter()
 				for i := range params {

--- a/pkg/rpcclient/actor/maker.go
+++ b/pkg/rpcclient/actor/maker.go
@@ -191,12 +191,11 @@ func (a *Actor) MakeUnsignedUncheckedRun(script []byte, sysFee int64, attrs []tr
 	for i := range a.signers {
 		if !a.signers[i].Account.Contract.Deployed {
 			tx.Scripts[i].VerificationScript = a.signers[i].Account.Contract.Script
-			continue
 		}
 		if build := a.signers[i].Account.Contract.InvocationBuilder; build != nil {
-			invoc, err := build(tx)
+			invoc, err := build(true, tx)
 			if err != nil {
-				return nil, fmt.Errorf("building witness for contract signer: %w", err)
+				return nil, fmt.Errorf("building dummy invocation script for signer #%d (%s): %w", i, a.signers[i].Account.Address, err)
 			}
 			tx.Scripts[i].InvocationScript = invoc
 		}


### PR DESCRIPTION
### Problem

`calculatenetworkfee` can't infer parameters for custom verification scripts, and there's no option to mock invocation script or custom verification script in Actor prior to a call to `calculatenetworkfee`:
https://github.com/nspcc-dev/neo-go/blob/bd4708d03e2f2c74d1ccb5c7c2e707d65bed38bb/pkg/rpcclient/actor/maker.go#L190-L206

### Solution

Allow to use (Contract).InvocationBuilder not only for deployed contracts, but also for custom verification scripts that contain parameters.