### PR TITLE
Fix flaky `TestAwaitUtilCancelTx`

### DIFF
--- a/cli/util/util_test.go
+++ b/cli/util/util_test.go
@@ -211,8 +211,8 @@ func TestAwaitUtilCancelTx(t *testing.T) {
 		require.Equal(t, "Conflicting transaction accepted", response)
 		resHash, _ := e.CheckAwaitableTxPersisted(t)
 		require.NotEqual(t, resHash, txHash)
-	case strings.Contains(err.Error(), fmt.Sprintf("target transaction %s is accepted", txHash)) ||
-		strings.Contains(err.Error(), fmt.Sprintf("failed to send conflicting transaction: Invalid transaction attribute (-507) - invalid attribute: conflicting transaction %s is already on chain", txHash)):
+	case strings.Contains(err.Error(), fmt.Sprintf("target transaction %s is accepted", txHash.StringLE())) ||
+		strings.Contains(err.Error(), fmt.Sprintf("failed to send conflicting transaction: Invalid transaction attribute (-507) - invalid attribute: conflicting transaction %s is already on chain", txHash.StringLE())):
 		tx, _ := e.GetTransaction(t, txHash)
 		aer, err := e.Chain.GetAppExecResults(tx.Hash(), trigger.Application)
 		require.NoError(t, err)


### PR DESCRIPTION
The error can be reproduced if run this many times:
```bash
go clean -testcache && go test -race -timeout 15m -v -run ^TestAwaitUtilCancelTx$ ./cli/util 2>&1 | tee test_results.log
```

The reason:
`Uint256` implements `Stringer` with `StringBE()` but the error "conflicting transaction <tx> is already on chain" uses `StringLE()`.

For now the test pass if the error occurs: 

```
    logger.go:146: 2026-01-27T19:20:48.455+0300 DEBUG   processing rpc request  {"method": "sendrawtransaction", "params": "[AKT/X0sAAAAAAAAAAPXGEgAAAAAABAAAAAHYzFqQTVJvyabKtVugLJpv54nJVgEBIblFJZKYNzieZjUop6SBy3w7yfhXvqPmTzR3XHi4kCOLAUABQgxAWpVUFAKf8fWp5fnuqXeKcW9tKHToWRh+21ZGWiTlmFqcflD/7kXv7RnNxsg/ryN0OE8TbTb25c9TGF1uVjRrbyoRDCECs2Ir9AF73+MXxYrtX0x1PyBrfbiWBG+n13S7xL9/jcIRQZ7Q3Do=]"}
    logger.go:146: 2026-01-27T19:20:48.455+0300 INFO    Error encountered with rpc request      {"code": -507, "cause": "invalid attribute: conflicting transaction 8b2390b8785c77344fe6a3be57f8c93b7ccb81a4a72835669e383798922545b9 is already on chain", "method": "sendrawtransaction", "params": "[AKT/X0sAAAAAAAAAAPXGEgAAAAAABAAAAAHYzFqQTVJvyabKtVugLJpv54nJVgEBIblFJZKYNzieZjUop6SBy3w7yfhXvqPmTzR3XHi4kCOLAUABQgxAWpVUFAKf8fWp5fnuqXeKcW9tKHToWRh+21ZGWiTlmFqcflD/7kXv7RnNxsg/ryN0OE8TbTb25c9TGF1uVjRrbyoRDCECs2Ir9AF73+MXxYrtX0x1PyBrfbiWBG+n13S7xL9/jcIRQZ7Q3Do=]"}
failed to send conflicting transaction: Invalid transaction attribute (-507) - invalid attribute: conflicting transaction 8b2390b8785c77344fe6a3be57f8c93b7ccb81a4a72835669e383798922545b9 is already on chain
    logger.go:146: 2026-01-27T19:20:48.457+0300 INFO    shutting down RPC server        {"endpoint": "127.0.0.1:40259"}
    logger.go:146: 2026-01-27T19:20:48.458+0300 INFO    persisted to disk       {"blocks": 2, "keys": 155, "headerHeight": 2, "blockHeight": 2, "took": "237.704µs"}
--- PASS: TestAwaitUtilCancelTx (0.13s)
PASS
ok      github.com/nspcc-dev/neo-go/cli/util    1.172s
```
