### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/cli/smartcontract/contract_test.go
+++ b/cli/smartcontract/contract_test.go
@@ -1441,7 +1441,7 @@ func TestContractCompile_NEFSizeCheck(t *testing.T) {
 	in := filepath.Join(tmpDir, "main.go")
 	cfg := filepath.Join(tmpDir, "main.yml")
 	require.NoError(t, os.WriteFile(cfg, []byte("name: main"), os.ModePerm))
-	require.NoError(t, os.WriteFile(in, []byte(fmt.Sprintf(src, data)), os.ModePerm))
+	require.NoError(t, os.WriteFile(in, fmt.Appendf(nil, src, data), os.ModePerm))
 
 	e.RunWithError(t, "neo-go", "contract", "compile", "--in", in)
 	require.NoFileExists(t, filepath.Join(tmpDir, "main.nef"))

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -458,7 +458,7 @@ require (
 		return cli.Exit(err, 1)
 	}
 
-	data := []byte(fmt.Sprintf(smartContractTmpl, contractName))
+	data := fmt.Appendf(nil, smartContractTmpl, contractName)
 	if err := os.WriteFile(filepath.Join(basePath, fileName), data, 0644); err != nil {
 		return cli.Exit(err, 1)
 	}

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -101,7 +101,7 @@ func TestCompiler(t *testing.T) {
 					data[i] = byte('a')
 				}
 				in := filepath.Join(tmp, "src.go")
-				require.NoError(t, os.WriteFile(in, []byte(fmt.Sprintf(src, data)), os.ModePerm))
+				require.NoError(t, os.WriteFile(in, fmt.Appendf(nil, src, data), os.ModePerm))
 				out := filepath.Join(tmp, "test.nef")
 				_, err := compiler.CompileAndSave(in, &compiler.Options{Outfile: out})
 				require.Error(t, err)

--- a/pkg/core/native/native_test/cryptolib_test.go
+++ b/pkg/core/native/native_test/cryptolib_test.go
@@ -567,7 +567,7 @@ func TestCryptoLib_RecoverSecp256K1_EIP2098Compat(t *testing.T) {
 			sigYParityAndS: "939c6d6b623b42da56557e5e734a43dc83345ddfadec52cbe24d0cc64f550793",
 		},
 	} {
-		msg := append([]byte{0x19}, []byte(fmt.Sprintf("Ethereum Signed Message:\n%d%s", len(tc.msg), tc.msg))...) // rules of Ethereum message hashing.
+		msg := append([]byte{0x19}, fmt.Appendf(nil, "Ethereum Signed Message:\n%d%s", len(tc.msg), tc.msg)...) // rules of Ethereum message hashing.
 		msgH := native.Keccak256(msg)
 		privBytes, err := hex.DecodeString(tc.priv)
 		require.NoError(t, err)

--- a/pkg/core/state/notification_event.go
+++ b/pkg/core/state/notification_event.go
@@ -159,7 +159,7 @@ type notificationEventAux struct {
 func (ne NotificationEvent) MarshalJSON() ([]byte, error) {
 	item, err := stackitem.ToJSONWithTypes(ne.Item)
 	if err != nil {
-		item = []byte(fmt.Sprintf(`"error: %v"`, err))
+		item = fmt.Appendf(nil, `"error: %v"`, err)
 	}
 	return json.Marshal(&notificationEventAux{
 		ScriptHash: ne.ScriptHash,
@@ -256,7 +256,7 @@ func (e Execution) MarshalJSON() ([]byte, error) {
 	for i := range arr {
 		data, err := stackitem.ToJSONWithTypes(e.Stack[i])
 		if err != nil {
-			data = []byte(fmt.Sprintf(`"error: %v"`, err))
+			data = fmt.Appendf(nil, `"error: %v"`, err)
 		}
 		arr[i] = data
 	}

--- a/pkg/services/rpcsrv/params/param_test.go
+++ b/pkg/services/rpcsrv/params/param_test.go
@@ -339,12 +339,12 @@ func TestGetWitness(t *testing.T) {
 func TestParamGetUint256(t *testing.T) {
 	gas := "602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7"
 	u256, _ := util.Uint256DecodeStringLE(gas)
-	p := Param{RawMessage: []byte(fmt.Sprintf(`"%s"`, gas))}
+	p := Param{RawMessage: fmt.Appendf(nil, `"%s"`, gas)}
 	u, err := p.GetUint256()
 	assert.Equal(t, u256, u)
 	require.Nil(t, err)
 
-	p = Param{RawMessage: []byte(fmt.Sprintf(`"0x%s"`, gas))}
+	p = Param{RawMessage: fmt.Appendf(nil, `"0x%s"`, gas)}
 	u, err = p.GetUint256()
 	require.NoError(t, err)
 	assert.Equal(t, u256, u)
@@ -361,7 +361,7 @@ func TestParamGetUint256(t *testing.T) {
 func TestParamGetUint160FromHex(t *testing.T) {
 	in := "50befd26fdf6e4d957c11e078b24ebce6291456f"
 	u160, _ := util.Uint160DecodeStringLE(in)
-	p := Param{RawMessage: []byte(fmt.Sprintf(`"%s"`, in))}
+	p := Param{RawMessage: fmt.Appendf(nil, `"%s"`, in)}
 	u, err := p.GetUint160FromHex()
 	assert.Equal(t, u160, u)
 	require.Nil(t, err)
@@ -378,7 +378,7 @@ func TestParamGetUint160FromHex(t *testing.T) {
 func TestParamGetUint160FromAddress(t *testing.T) {
 	in := "NPAsqZkx9WhNd4P72uhZxBhLinSuNkxfB8"
 	u160, _ := address.StringToUint160(in)
-	p := Param{RawMessage: []byte(fmt.Sprintf(`"%s"`, in))}
+	p := Param{RawMessage: fmt.Appendf(nil, `"%s"`, in)}
 	u, err := p.GetUint160FromAddress()
 	assert.Equal(t, u160, u)
 	require.Nil(t, err)
@@ -397,14 +397,14 @@ func TestParam_GetUint160FromAddressOrHex(t *testing.T) {
 	inHex, _ := address.StringToUint160(in)
 
 	t.Run("Address", func(t *testing.T) {
-		p := Param{RawMessage: []byte(fmt.Sprintf(`"%s"`, in))}
+		p := Param{RawMessage: fmt.Appendf(nil, `"%s"`, in)}
 		u, err := p.GetUint160FromAddressOrHex()
 		require.NoError(t, err)
 		require.Equal(t, inHex, u)
 	})
 
 	t.Run("Hex", func(t *testing.T) {
-		p := Param{RawMessage: []byte(fmt.Sprintf(`"%s"`, inHex.StringLE()))}
+		p := Param{RawMessage: fmt.Appendf(nil, `"%s"`, inHex.StringLE())}
 		u, err := p.GetUint160FromAddressOrHex()
 		require.NoError(t, err)
 		require.Equal(t, inHex, u)
@@ -471,7 +471,7 @@ func TestParamGetFuncParamPair(t *testing.T) {
 func TestParamGetBytesHex(t *testing.T) {
 	in := "602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7"
 	inb, _ := hex.DecodeString(in)
-	p := Param{RawMessage: []byte(fmt.Sprintf(`"%s"`, in))}
+	p := Param{RawMessage: fmt.Appendf(nil, `"%s"`, in)}
 	bh, err := p.GetBytesHex()
 	assert.Equal(t, inb, bh)
 	require.Nil(t, err)
@@ -490,7 +490,7 @@ func TestParamGetBytesBase64(t *testing.T) {
 	in := "Aj4A8DoW6HB84EXrQu6A05JFFUHuUQ3BjhyL77rFTXQm"
 	inb, err := base64.StdEncoding.DecodeString(in)
 	require.NoError(t, err)
-	p := Param{RawMessage: []byte(fmt.Sprintf(`"%s"`, in))}
+	p := Param{RawMessage: fmt.Appendf(nil, `"%s"`, in)}
 	bh, err := p.GetBytesBase64()
 	assert.Equal(t, inb, bh)
 	require.Nil(t, err)
@@ -530,7 +530,7 @@ func TestParamGetSigners(t *testing.T) {
 	u1 := util.Uint160{1, 2, 3, 4}
 	u2 := util.Uint160{5, 6, 7, 8}
 	t.Run("from hashes", func(t *testing.T) {
-		p := Param{RawMessage: []byte(fmt.Sprintf(`["%s", "%s"]`, u1.StringLE(), u2.StringLE()))}
+		p := Param{RawMessage: fmt.Appendf(nil, `["%s", "%s"]`, u1.StringLE(), u2.StringLE())}
 		actual, _, err := p.GetSignersWithWitnesses()
 		require.NoError(t, err)
 		require.Equal(t, 2, len(actual))
@@ -568,7 +568,7 @@ func TestParamGetUUID(t *testing.T) {
 	})
 	t.Run("compat", func(t *testing.T) {
 		expected := "2107da59-4f9c-462c-9c51-7666842519a9"
-		p := Param{RawMessage: []byte(fmt.Sprintf(`"%s"`, expected))}
+		p := Param{RawMessage: fmt.Appendf(nil, `"%s"`, expected)}
 		id, err := p.GetUUID()
 		require.NoError(t, err)
 		require.Equal(t, id.String(), expected)

--- a/pkg/smartcontract/manifest/permission_test.go
+++ b/pkg/smartcontract/manifest/permission_test.go
@@ -107,7 +107,7 @@ func TestPermissionDesc_MarshalJSON(t *testing.T) {
 	t.Run("uint160 with 0x", func(t *testing.T) {
 		u := random.Uint160()
 		s := u.StringLE()
-		js := []byte(fmt.Sprintf(`"0x%s"`, s))
+		js := fmt.Appendf(nil, `"0x%s"`, s)
 		d := new(PermissionDesc)
 		require.NoError(t, json.Unmarshal(js, d))
 		require.Equal(t, u, d.Value.(util.Uint160))
@@ -116,10 +116,10 @@ func TestPermissionDesc_MarshalJSON(t *testing.T) {
 	t.Run("invalid uint160", func(t *testing.T) {
 		d := new(PermissionDesc)
 		s := random.String(util.Uint160Size * 2)
-		js := []byte(fmt.Sprintf(`"ok%s"`, s))
+		js := fmt.Appendf(nil, `"ok%s"`, s)
 		require.Error(t, json.Unmarshal(js, d))
 
-		js = []byte(fmt.Sprintf(`"%s"`, s))
+		js = fmt.Appendf(nil, `"%s"`, s)
 		require.Error(t, json.Unmarshal(js, d))
 	})
 
@@ -127,7 +127,7 @@ func TestPermissionDesc_MarshalJSON(t *testing.T) {
 		d := new(PermissionDesc)
 		s := random.String(65)
 		s = "k" + s // not a hex
-		js := []byte(fmt.Sprintf(`"%s"`, s))
+		js := fmt.Appendf(nil, `"%s"`, s)
 		require.Error(t, json.Unmarshal(js, d))
 	})
 


### PR DESCRIPTION
### Problem

 I modified the return statement to utilize fmt.Appendf instead of fmt.Sprintf for creating the formatted byte slice. 
 
 This change enhances performance by directly appending the formatted string to the byte slice, avoiding the need for intermediate memory allocation created by fmt.Sprintf. 
 
 The resulting code is cleaner and more efficient, maintaining the same functionality while improving resource usage.
 
 More info can see https://github.com/golang/go/issues/47579



### Solution

...
