### PR TITLE
.github: cancel pending/running workflows on PR update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,10 @@ on:
         required: false
         default: 'false'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_cli:
     name: Build CLI

--- a/.github/workflows/contribution_guidelines.yml
+++ b/.github/workflows/contribution_guidelines.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   commits_check_job:
     name: DCO check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,10 @@ on:
       - '**/*.md'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: 'Lint: NeoGo'


### PR DESCRIPTION
### Problem

Run out of GA runners on frequent PR update leads to long results awaiting. Whereas previous runs become useless in fact.

### Solution

Use
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency to cancel previous ongoing and pending workflow runs on a subsequent PR update. It allows to get workflow results faster on frequent PRs update since there's a limit on the number of concurrently running GA runners.

It will probably be useful to port it to another repos in the org.
