### PR TITLE
docs: improve TimePerBlock related documentation

### DIFF
--- a/docs/node-configuration.md
+++ b/docs/node-configuration.md
@@ -480,8 +480,8 @@ protocol-related settings described in the table below.
 | StandbyCommittee | `[]string` | [] | List of public keys of standby committee validators are chosen from. | The list of keys is not required to be sorted, but it must be exactly the same within the configuration files of all the nodes in the network. |
 | StateRootInHeader | `bool` | `false` | Enables storing state root in block header. | Experimental protocol extension! |
 | StateSyncInterval | `int` | `40000` | The number of blocks between state heights available for MPT state data synchronization. | `P2PStateExchangeExtensions` should be enabled to use this setting. |
-| TimePerBlock | `Duration` | `15s` | Minimal (and targeted for) time interval between blocks if MaxTimePerBlock is not set. Must be an integer number of milliseconds. This setting is replaced by [`Genesis`-level](#Genesis-Configuration) `TimePerBlock` protocol configuration setting and corresponding Policy value starting from `Echidna` hardfork. |
-| MaxTimePerBlock | `Duration` | `0s` | Maximum (and targeted for) time interval between blocks for cases when there's no transactions in the node's memory pool. Must be an integer number of milliseconds. If set, time interval between blocks will vary from TimePerBlock (when there are some transactions in the network) and MaxTimePerBlock. | An extension of NeoGo node that enables dynamic block time as described in https://github.com/neo-project/neo/issues/4018. |
+| TimePerBlock | `Duration` | `15s` | Minimal (and targeted for) time interval between blocks if MaxTimePerBlock is not set. Sub-milliseconds precision is not supported. This setting is replaced by [`Genesis`-level](#Genesis-Configuration) `TimePerBlock` protocol configuration setting and corresponding Policy value starting from `Echidna` hardfork. |
+| MaxTimePerBlock | `Duration` | `0s` | Maximum (and targeted for) time interval between blocks for cases when there's no transactions in the node's memory pool. Sub-milliseconds precision is not supported. If set, time interval between blocks will vary from TimePerBlock (when there are some transactions in the network) and MaxTimePerBlock. | An extension of NeoGo node that enables dynamic block time as described in https://github.com/neo-project/neo/issues/4018. |
 | ValidatorsCount | `uint32` | `0` | Number of validators set for the whole network lifetime, can't be set if `ValidatorsHistory` setting is used. |
 | ValidatorsHistory | map[uint32]uint32 | none | Number of consensus nodes to use after given height (see `CommitteeHistory` also). Heights where the change occurs must be divisible by the number of committee members at that height. Can't be used with `ValidatorsCount` not equal to zero. Initial validators count for genesis block must always be specified. |
 | VerifyTransactions | `bool` | `false` | Denotes whether to verify transactions in the received blocks. |
@@ -550,7 +550,7 @@ where:
   performed in some non-genesis hardfork). By default, no roles are designated.
 
 - `TimePerBlock` is a minimal (and targeted for) time interval between blocks.
-  It has the `Duration` type and must be an integer number of milliseconds. This
+  It has the `Duration` type. Sub-milliseconds precision is not supported. This
   setting is used to initialize `MillisecondsPerBlock` value of native Policy contract at
   `Echidna` hardfork. If not set, then `ProtocolConfiguration`-level `TimePerBlock`
   setting is used as the default value.

--- a/pkg/config/genesis_extensions.go
+++ b/pkg/config/genesis_extensions.go
@@ -29,7 +29,7 @@ type Genesis struct {
 	// disabled on the public Neo N3 networks.
 	Roles map[noderoles.Role]keys.PublicKeys
 	// TimePerBlock is the minimum time interval between blocks that consensus
-	// nodes work with. It must be an integer number of milliseconds. It differs
+	// nodes work with. Sub-milliseconds precision is not supported. It differs
 	// from Protocol level configuration in that this value is used starting
 	// from HFEchidna to initialize MillisecondsPerBlock value of native Policy
 	// contract.

--- a/pkg/config/protocol_config.go
+++ b/pkg/config/protocol_config.go
@@ -62,12 +62,12 @@ type (
 		// It is valid only if P2PStateExchangeExtensions are enabled.
 		StateSyncInterval int `yaml:"StateSyncInterval"`
 		// TimePerBlock is the minimum time interval between blocks that consensus nodes work with.
-		// It must be an integer number of milliseconds. This value is applicable till
+		// Sub-milliseconds precision is not supported. This value is applicable till
 		// HFEchidna; use Genesis-level configuration to set up further block acceptance
 		// interval.
 		TimePerBlock time.Duration `yaml:"TimePerBlock"`
 		// MaxTimePerBlock is the maximum time interval between blocks that will pass if there is
-		// no pending transactions in the node's pool. It must be an integer number of milliseconds.
+		// no pending transactions in the node's pool. Sub-milliseconds precision is not supported.
 		MaxTimePerBlock time.Duration `yaml:"MaxTimePerBlock"`
 		ValidatorsCount uint32        `yaml:"ValidatorsCount"`
 		// Validators stores history of changes to consensus node number (height: number).


### PR DESCRIPTION
"Must be an integer number of milliseconds" confuses external developers.