### PR TITLE
core, vm: fix System.Contract.CallNative async callbacks and RET processing

### DIFF
--- a/cli/vm/cli.go
+++ b/cli/vm/cli.go
@@ -1160,7 +1160,7 @@ func handleRun(c *cli.Context) error {
 			breaks := v.Context().BreakPoints() // We ensure that there's a context loaded.
 			ic.ReuseVM(v)
 			v.SetGasLimit(gasLimit)
-			v.LoadNEFMethod(&cs.NEF, &cs.Manifest, util.Uint160{}, cs.Hash, callflag.All, hasRet, offset, initOff, nil, false)
+			v.LoadNEFMethod(&cs.NEF, &cs.Manifest, util.Uint160{}, cs.Hash, callflag.All, hasRet, offset, initOff, nil, nil, false)
 			for _, bp := range breaks {
 				v.AddBreakPoint(bp)
 			}

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -3362,7 +3362,7 @@ func (bc *Blockchain) InitVerificationContext(ic *interop.Context, hash util.Uin
 		}
 		ic.Invocations[cs.Hash]++
 		ic.VM.LoadNEFMethod(&cs.NEF, &cs.Manifest, util.Uint160{}, hash, callflag.ReadOnly,
-			true, verifyOffset, initOffset, nil, false)
+			true, verifyOffset, initOffset, nil, nil, false)
 	}
 	if len(witness.InvocationScript) != 0 {
 		err := scparser.IsScriptCorrect(witness.InvocationScript, nil)

--- a/pkg/core/custom_native_test.go
+++ b/pkg/core/custom_native_test.go
@@ -97,8 +97,10 @@ func (g *gas) PostPersist(*interop.Context) error {
 func (g *gas) BalanceOf(d *dao.Simple, acc util.Uint160) *big.Int {
 	return big.NewInt(1)
 }
-func (g *gas) Burn(ic *interop.Context, h util.Uint160, amount *big.Int)                     {}
-func (g *gas) Mint(ic *interop.Context, h util.Uint160, amount *big.Int, callOnPayment bool) {}
+func (g *gas) Burn(ic *interop.Context, h util.Uint160, amount *big.Int) {
+}
+func (g *gas) MintDeferrable(ic *interop.Context, h util.Uint160, amount *big.Int, callOnPayment bool, continuation func()) {
+}
 func (g *gas) getInt(ic *interop.Context, args []stackitem.Item) stackitem.Item {
 	// An example of how cross-native methods may be used:
 	if g.policy.IsBlocked(ic.DAO, ic.Container.(*transaction.Transaction).Sender()) {
@@ -167,7 +169,9 @@ func (n *neo) CheckAlmostFullCommittee(ic *interop.Context) bool {
 func (n *neo) getBool(ic *interop.Context, args []stackitem.Item) stackitem.Item {
 	return stackitem.NewBool(true)
 }
-func (n *neo) RevokeVotes(ic *interop.Context, acc util.Uint160) error { return nil }
+func (n *neo) RevokeVotesDeferrable(ic *interop.Context, acc util.Uint160, continuation func()) (bool, error) {
+	return true, nil
+}
 
 func newPolicy() *policy {
 	p := &policy{}
@@ -202,9 +206,10 @@ func (p *policy) GetMaxValidUntilBlockIncrementFromCache(d *dao.Simple) uint32 {
 func (p *policy) GetAttributeFeeInternal(d *dao.Simple, attrType transaction.AttrType) int64 {
 	return 1
 }
-func (p *policy) CheckPolicy(d *dao.Simple, tx *transaction.Transaction) error      { return nil }
-func (p *policy) GetFeePerByteInternal(d *dao.Simple) int64                         { return 1 }
-func (p *policy) BlockAccountInternal(ic *interop.Context, hash util.Uint160) bool  { return false }
+func (p *policy) CheckPolicy(d *dao.Simple, tx *transaction.Transaction) error { return nil }
+func (p *policy) GetFeePerByteInternal(d *dao.Simple) int64                    { return 1 }
+func (p *policy) BlockAccountInternalDeferrable(ic *interop.Context, hash util.Uint160, handleRes func(bool)) {
+}
 func (p *policy) IsBlocked(dao *dao.Simple, hash util.Uint160) bool                 { return false }
 func (p *policy) WhitelistedFee(d *dao.Simple, hash util.Uint160, offset int) int64 { return -1 }
 func (p *policy) CleanWhitelist(ic *interop.Context, h util.Uint160) error          { return nil }

--- a/pkg/core/interop/context.go
+++ b/pkg/core/interop/context.go
@@ -173,8 +173,18 @@ type Function struct {
 	RequiredFlags callflag.CallFlag
 }
 
-// Method is a signature for a native method.
-type Method = func(ic *Context, args []stackitem.Item) stackitem.Item
+type (
+	// Method is a signature for a synchronous native method that does not imply
+	// any fully qualified side contract calls.
+	Method = func(ic *Context, args []stackitem.Item) stackitem.Item
+	// DeferrableMethod is a signature for an asynchronous native method.
+	// popArgsPushRes is a callback that may be called either during native
+	// method processing (if no side contract call is encountered during
+	// execution flow) or may be scheduled to be called later after the spawned
+	// child's context is unloaded from VM. Passing nil callback is a no-op and
+	// will lead to invalid VM behaviour.
+	DeferrableMethod = func(ic *Context, args []stackitem.Item, popArgsPushRes func(res stackitem.Item))
+)
 
 // MethodAndPrice is a generic hardfork-independent native contract method descriptor.
 type MethodAndPrice struct {
@@ -184,13 +194,22 @@ type MethodAndPrice struct {
 }
 
 // HFSpecificMethodAndPrice is a hardfork-specific native contract method descriptor.
+// It has either Func or DeferrableFunc set, not both.
 type HFSpecificMethodAndPrice struct {
-	Func          Method
-	MD            *manifest.Method
-	CPUFee        int64
-	StorageFee    int64
-	SyscallOffset int
-	RequiredFlags callflag.CallFlag
+	// Func is the synchronous method handler that doesn't contain any nested
+	// contract calls.
+	Func Method
+	// DeferrableFunc is the method handler that contains a nested contract call, the
+	// result of which may (optionally) be required to continue execution of
+	// DeferrableFunc. Depending on the latter, the execution of the contract's
+	// method handler may either be finished or scheduled to be finished later
+	// after the spawned child's context is unloaded from VM.
+	DeferrableFunc DeferrableMethod
+	MD             *manifest.Method
+	CPUFee         int64
+	StorageFee     int64
+	SyscallOffset  int
+	RequiredFlags  callflag.CallFlag
 }
 
 // Event is a generic hardfork-independent native contract event descriptor.

--- a/pkg/core/interop/contract/call.go
+++ b/pkg/core/interop/contract/call.go
@@ -108,12 +108,19 @@ func callInternal(ic *interop.Context, cs *state.Contract, md *manifest.Method, 
 			return errors.New("disallowed method call")
 		}
 	}
-	return callExFromNative(ic, ic.VM.GetCurrentScriptHash(), cs, md.Name, args, f, hasReturn, isDynamic, false)
+	return callExFromNative(ic, ic.VM.GetCurrentScriptHash(), cs, md.Name, args, f, hasReturn, isDynamic)
 }
 
-// callExFromNative calls a contract with flags using the provided calling hash.
+// callExFromNative creates a new execution context with the specified contract
+// call using the provided flags and calling hash and pushes this context to the
+// invocation stack. onUnloaded callback must be provided iff called directly
+// from the native contract.
 func callExFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contract,
-	name string, args []stackitem.Item, f callflag.CallFlag, hasReturn bool, isDynamic bool, callFromNative bool) error {
+	name string, args []stackitem.Item, f callflag.CallFlag, hasReturn bool, isDynamic bool, onUnloaded ...func(v *vm.VM)) error {
+	if isDynamic && len(onUnloaded) != 0 {
+		panic("program bug: onUnloaded callback must not be used for dynamic contract calls")
+	}
+	callFromNative := len(onUnloaded) != 0
 	md := cs.Manifest.ABI.GetMethod(name, len(args))
 	if md == nil {
 		return fmt.Errorf("method '%s' not found", name)
@@ -162,7 +169,7 @@ func callExFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contra
 					return fmt.Errorf("failed to persist changes %w", err)
 				}
 			} else {
-				ic.Notifications = ic.Notifications[:baseNtfCount] // Rollback all notification changes made by current context.
+				ic.Notifications = ic.Notifications[:baseNtfCount] // rollback all notification changes made by the current context and its possible spawned children contexts.
 			}
 			ic.DAO = baseDAO
 		}
@@ -174,8 +181,12 @@ func callExFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contra
 		}
 		return nil
 	}
+	var onUnloadedF func(v *vm.VM)
+	if len(onUnloaded) != 0 {
+		onUnloadedF = onUnloaded[0]
+	}
 	ic.VM.LoadNEFMethod(&cs.NEF, &cs.Manifest, caller, cs.Hash, f,
-		hasReturn, methodOff, initOff, onUnload, whitelisted)
+		hasReturn, methodOff, initOff, onUnload, onUnloadedF, whitelisted)
 
 	for e, i := ic.VM.Estack(), len(args)-1; i >= 0; i-- {
 		e.PushItem(args[i])
@@ -183,25 +194,13 @@ func callExFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contra
 	return nil
 }
 
-// ErrNativeCall is returned for failed calls from native.
-var ErrNativeCall = errors.New("failed native call")
-
-// CallFromNative performs synchronous call from native contract.
-func CallFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contract, method string, args []stackitem.Item, hasReturn bool) error {
-	startSize := len(ic.VM.Istack())
-	if err := callExFromNative(ic, caller, cs, method, args, callflag.All, hasReturn, false, true); err != nil {
-		return err
-	}
-
-	for !ic.VM.HasStopped() && len(ic.VM.Istack()) > startSize {
-		if err := ic.VM.Step(); err != nil {
-			return fmt.Errorf("%w: %w", ErrNativeCall, err)
-		}
-	}
-	if ic.VM.HasFailed() {
-		return ErrNativeCall
-	}
-	return nil
+// CallFromNative performs an asynchronous call from native contract. It creates
+// a new context with the calling contract script and pushes this context to the
+// invocation stack. The actual invocation happens later, once the current
+// instruction processing is finished. onUnloaded callback will be called on
+// the current context unloading if no exception occurs.
+func CallFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contract, method string, args []stackitem.Item, hasReturn bool, onUnloaded ...func(v *vm.VM)) error {
+	return callExFromNative(ic, caller, cs, method, args, callflag.All, hasReturn, false, onUnloaded...)
 }
 
 // GetCallFlags returns current context calling flags.

--- a/pkg/core/interop/runtime/ext_test.go
+++ b/pkg/core/interop/runtime/ext_test.go
@@ -637,7 +637,7 @@ func TestNotify(t *testing.T) {
 		_, _, bc, cs := getDeployedInternal(t)
 		ic, err := bc.GetTestVM(trigger.Application, nil, nil)
 		require.NoError(t, err)
-		ic.VM.LoadNEFMethod(&cs.NEF, &cs.Manifest, caller, cs.Hash, callflag.NoneFlag, true, 0, -1, nil, false)
+		ic.VM.LoadNEFMethod(&cs.NEF, &cs.Manifest, caller, cs.Hash, callflag.NoneFlag, true, 0, -1, nil, nil, false)
 		ic.VM.Estack().PushVal(args)
 		ic.VM.Estack().PushVal(name)
 		return ic

--- a/pkg/core/native/contract.go
+++ b/pkg/core/native/contract.go
@@ -44,7 +44,7 @@ type (
 		// Methods required for proper cross-native communication.
 		CheckCommittee(ic *interop.Context) bool
 		CheckAlmostFullCommittee(ic *interop.Context) bool
-		RevokeVotes(ic *interop.Context, h util.Uint160) error
+		RevokeVotesDeferrable(ic *interop.Context, h util.Uint160, continuation func()) (bool, error)
 	}
 
 	// IGAS is an interface required from native GasToken contract for
@@ -55,7 +55,7 @@ type (
 
 		// Methods required for proper cross-native communication.
 		Burn(ic *interop.Context, h util.Uint160, amount *big.Int)
-		Mint(ic *interop.Context, h util.Uint160, amount *big.Int, callOnPayment bool)
+		IGASMinter
 	}
 
 	// IPolicy is an interface required from native PolicyContract contract for
@@ -75,7 +75,7 @@ type (
 		GetFeePerByteInternal(d *dao.Simple) int64
 
 		// Methods required for proper cross-native communication.
-		BlockAccountInternal(ic *interop.Context, hash util.Uint160) bool
+		BlockAccountInternalDeferrable(ic *interop.Context, hash util.Uint160, handleRes func(res bool))
 		GetMaxValidUntilBlockIncrementInternal(ic *interop.Context) uint32
 		CleanWhitelist(ic *interop.Context, hash util.Uint160) error
 		interop.PolicyChecker
@@ -235,9 +235,8 @@ func NewDefaultContracts(cfg config.ProtocolConfiguration) []interop.Contract {
 	ledger := NewLedger()
 
 	gas := newGAS(int64(cfg.InitialGASSupply))
-	neo := NewNEO(cfg)
+	neo := NewNEO(cfg, gas)
 	policy := NewPolicy()
-	neo.GAS = gas
 	neo.Policy = policy
 	gas.NEO = neo
 	gas.Policy = policy

--- a/pkg/core/native/interop.go
+++ b/pkg/core/native/interop.go
@@ -77,12 +77,19 @@ func Call(ic *interop.Context) error {
 	for i := range args {
 		args[i] = ic.VM.Estack().Peek(i).Item()
 	}
-	result := m.Func(ic, args)
-	for range m.MD.Parameters {
-		ic.VM.Estack().Pop()
+	popArgsPushRes := func(result stackitem.Item) {
+		for range m.MD.Parameters {
+			ctx.Estack().Pop()
+		}
+		if m.MD.ReturnType != smartcontract.VoidType {
+			ctx.Estack().PushItem(result)
+		}
 	}
-	if m.MD.ReturnType != smartcontract.VoidType {
-		ctx.Estack().PushItem(result)
+	if m.DeferrableFunc != nil {
+		m.DeferrableFunc(ic, args, popArgsPushRes)
+	} else {
+		result := m.Func(ic, args)
+		popArgsPushRes(result)
 	}
 	return nil
 }

--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -101,35 +101,35 @@ func NewManagement() *Management {
 	desc = NewDescriptor("deploy", smartcontract.ArrayType,
 		manifest.NewParameter("nefFile", smartcontract.ByteArrayType),
 		manifest.NewParameter("manifest", smartcontract.ByteArrayType))
-	md = NewMethodAndPrice(m.deploy, 0, callflag.All)
+	md = NewMethodAndPriceDeferrable(m.deployDeferrable, 0, callflag.All)
 	m.AddMethod(md, desc)
 
 	desc = NewDescriptor("deploy", smartcontract.ArrayType,
 		manifest.NewParameter("nefFile", smartcontract.ByteArrayType),
 		manifest.NewParameter("manifest", smartcontract.ByteArrayType),
 		manifest.NewParameter("data", smartcontract.AnyType))
-	md = NewMethodAndPrice(m.deployWithData, 0, callflag.All)
+	md = NewMethodAndPriceDeferrable(m.deployWithDataDeferrable, 0, callflag.All)
 	m.AddMethod(md, desc)
 
 	desc = NewDescriptor("update", smartcontract.VoidType,
 		manifest.NewParameter("nefFile", smartcontract.ByteArrayType),
 		manifest.NewParameter("manifest", smartcontract.ByteArrayType))
-	md = NewMethodAndPrice(m.update, 0, callflag.All)
+	md = NewMethodAndPriceDeferrable(m.updateDeferrable, 0, callflag.All)
 	m.AddMethod(md, desc)
 
 	desc = NewDescriptor("update", smartcontract.VoidType,
 		manifest.NewParameter("nefFile", smartcontract.ByteArrayType),
 		manifest.NewParameter("manifest", smartcontract.ByteArrayType),
 		manifest.NewParameter("data", smartcontract.AnyType))
-	md = NewMethodAndPrice(m.updateWithData, 0, callflag.All)
+	md = NewMethodAndPriceDeferrable(m.updateWithDataDeferrable, 0, callflag.All)
 	m.AddMethod(md, desc)
 
 	desc = NewDescriptor("destroy", smartcontract.VoidType)
-	md = NewMethodAndPrice(m.destroyV0, 1<<15, callflag.States|callflag.AllowNotify, config.HFDefault, config.HFGorgon)
+	md = NewMethodAndPriceDeferrable(m.destroyDeferrableV0, 1<<15, callflag.States|callflag.AllowNotify, config.HFDefault, config.HFGorgon)
 	m.AddMethod(md, desc)
 
 	desc = NewDescriptor("destroy", smartcontract.VoidType)
-	md = NewMethodAndPrice(m.destroyV1, 1<<15, callflag.States|callflag.AllowNotify, config.HFGorgon)
+	md = NewMethodAndPriceDeferrable(m.destroyDeferrableV1, 1<<15, callflag.States|callflag.AllowNotify, config.HFGorgon)
 	m.AddMethod(md, desc)
 
 	desc = NewDescriptor("getMinimumDeploymentFee", smartcontract.IntegerType)
@@ -351,14 +351,14 @@ func (m *Management) getNefAndManifestFromItems(ic *interop.Context, args []stac
 	return resNef, resManifest, nil
 }
 
-// deploy is an implementation of public 2-argument deploy method.
-func (m *Management) deploy(ic *interop.Context, args []stackitem.Item) stackitem.Item {
-	return m.deployWithData(ic, append(args, stackitem.Null{}))
+// deployDeferrable is an implementation of public 2-argument deploy method.
+func (m *Management) deployDeferrable(ic *interop.Context, args []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
+	m.deployWithDataDeferrable(ic, append(args, stackitem.Null{}), popArgsPushRes)
 }
 
-// deployWithData is an implementation of public 3-argument deploy method.
+// deployWithDataDeferrable is an implementation of public 3-argument deploy method.
 // It's run under VM protections, so it's OK for it to panic instead of returning errors.
-func (m *Management) deployWithData(ic *interop.Context, args []stackitem.Item) stackitem.Item {
+func (m *Management) deployWithDataDeferrable(ic *interop.Context, args []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
 	neff, manif, err := m.getNefAndManifestFromItems(ic, args, true)
 	if err != nil {
 		panic(err)
@@ -376,12 +376,14 @@ func (m *Management) deployWithData(ic *interop.Context, args []stackitem.Item) 
 	if err != nil {
 		panic(err)
 	}
-	m.callDeploy(ic, newcontract, args[2], false)
-	err = m.emitNotification(ic, contractDeployNotificationName, newcontract.Hash)
-	if err != nil {
-		panic(err)
-	}
-	return contractToStack(newcontract)
+	m.callDeployDeferrable(ic, newcontract, args[2], false, func(v *vm.VM) {
+		// _deploy returns void => no need to pop the result from the parent's stack.
+		err = m.emitNotification(ic, contractDeployNotificationName, newcontract.Hash)
+		if err != nil {
+			panic(err)
+		}
+		popArgsPushRes(contractToStack(newcontract))
+	})
 }
 
 func markUpdated(d *dao.Simple, managementID int32, hash util.Uint160, cs *state.Contract) {
@@ -433,13 +435,13 @@ func (m *Management) Deploy(ic *interop.Context, sender util.Uint160, neff *nef.
 	return newcontract, nil
 }
 
-func (m *Management) update(ic *interop.Context, args []stackitem.Item) stackitem.Item {
-	return m.updateWithData(ic, append(args, stackitem.Null{}))
+func (m *Management) updateDeferrable(ic *interop.Context, args []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
+	m.updateWithDataDeferrable(ic, append(args, stackitem.Null{}), popArgsPushRes)
 }
 
-// update is an implementation of public update method, it's run under
+// updateWithDataDeferrable is an implementation of public update method, it's run under
 // VM protections, so it's OK for it to panic instead of returning errors.
-func (m *Management) updateWithData(ic *interop.Context, args []stackitem.Item) stackitem.Item {
+func (m *Management) updateWithDataDeferrable(ic *interop.Context, args []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
 	neff, manif, err := m.getNefAndManifestFromItems(ic, args, false)
 	if err != nil {
 		panic(err)
@@ -451,12 +453,14 @@ func (m *Management) updateWithData(ic *interop.Context, args []stackitem.Item) 
 	if err != nil {
 		panic(err)
 	}
-	m.callDeploy(ic, contract, args[2], true)
-	err = m.emitNotification(ic, contractUpdateNotificationName, contract.Hash)
-	if err != nil {
-		panic(err)
-	}
-	return stackitem.Null{}
+	m.callDeployDeferrable(ic, contract, args[2], true, func(v *vm.VM) {
+		// _deploy returns void => no need to pop the result from the parent's stack.
+		err = m.emitNotification(ic, contractUpdateNotificationName, contract.Hash)
+		if err != nil {
+			panic(err)
+		}
+		popArgsPushRes(stackitem.Null{})
+	})
 }
 
 // Update updates contract's script and/or manifest in the given DAO.
@@ -505,67 +509,67 @@ func (m *Management) Update(ic *interop.Context, hash util.Uint160, neff *nef.Fi
 	return &contract, nil
 }
 
-// destroyV0 is a pre-Gorgon implementation of the public destroy method, it's
+// destroyDeferrableV0 is a pre-Gorgon implementation of the public destroy method, it's
 // run under VM protections, so it's OK for it to panic instead of returning errors.
-func (m *Management) destroyV0(ic *interop.Context, sis []stackitem.Item) stackitem.Item {
-	return m.destroyInternal(ic, sis, false)
+func (m *Management) destroyDeferrableV0(ic *interop.Context, sis []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
+	m.destroyInternalDeferrable(ic, sis, popArgsPushRes, false)
 }
 
-// destroyV1 is a post-Gorgon implementation of the public destroy method, it's
+// destroyDeferrableV1 is a post-Gorgon implementation of the public destroy method, it's
 // run under VM protections, so it's OK for it to panic instead of returning errors.
-func (m *Management) destroyV1(ic *interop.Context, sis []stackitem.Item) stackitem.Item {
-	return m.destroyInternal(ic, sis, true)
+func (m *Management) destroyDeferrableV1(ic *interop.Context, sis []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
+	m.destroyInternalDeferrable(ic, sis, popArgsPushRes, true)
 }
 
-// destroy is an implementation of the public destroy method, it's run under
+// destroyDeferrable is an implementation of the public destroy method, it's run under
 // VM protections, so it's OK for it to panic instead of returning errors.
-func (m *Management) destroyInternal(ic *interop.Context, sis []stackitem.Item, blockBeforeErase bool) stackitem.Item {
+func (m *Management) destroyInternalDeferrable(ic *interop.Context, _ []stackitem.Item, popArgsPushRes func(res stackitem.Item), blockBeforeErase bool) {
 	hash := ic.VM.GetCallingScriptHash()
-	_, err := m.Destroy(ic, hash, blockBeforeErase)
-	if err != nil {
-		panic(err)
-	}
-	err = m.emitNotification(ic, contractDestroyNotificationName, hash)
-	if err != nil {
-		panic(err)
-	}
-	return stackitem.Null{}
-}
-
-// Destroy drops the given contract from DAO along with its storage. It doesn't emit notification.
-func (m *Management) Destroy(ic *interop.Context, hash util.Uint160, blockBeforeErase bool) (*state.Contract, error) {
 	contract, err := GetContract(ic.DAO, m.ID, hash)
 	if err != nil {
-		return nil, err
+		panic(err)
+	}
+
+	erase := func() {
+		key := MakeContractKey(hash)
+		ic.DAO.DeleteStorageItem(m.ID, key)
+		key = putHashKey(key, contract.ID)
+		ic.DAO.DeleteStorageItem(m.ID, key)
+		ic.DAO.Seek(contract.ID, storage.SeekRange{}, func(k, _ []byte) bool {
+			ic.DAO.DeleteStorageItem(contract.ID, k)
+			return true
+		})
+		markUpdated(ic.DAO, m.ID, hash, nil)
 	}
 
 	if blockBeforeErase {
-		m.Policy.BlockAccountInternal(ic, hash)
-		err = m.Policy.CleanWhitelist(ic, hash)
-		if err != nil {
-			panic(fmt.Errorf("failed to clean whitelist for %s: %w", contract.Hash.StringLE(), err))
-		}
+		m.Policy.BlockAccountInternalDeferrable(ic, hash, func(_ bool) { // no `blockAccount` result handling.
+			err = m.Policy.CleanWhitelist(ic, hash)
+			if err != nil {
+				panic(fmt.Errorf("failed to clean whitelist for %s: %w", contract.Hash.StringLE(), err))
+			}
+			erase()
+			err = m.emitNotification(ic, contractDestroyNotificationName, hash)
+			if err != nil {
+				panic(err)
+			}
+			popArgsPushRes(stackitem.Null{})
+		})
+	} else {
+		erase()
+
+		m.Policy.BlockAccountInternalDeferrable(ic, hash, func(_ bool) { // no `blockAccount` result handling.
+			err = m.Policy.CleanWhitelist(ic, hash)
+			if err != nil {
+				panic(fmt.Errorf("failed to clean whitelist for %s: %w", contract.Hash.StringLE(), err))
+			}
+			err = m.emitNotification(ic, contractDestroyNotificationName, hash)
+			if err != nil {
+				panic(err)
+			}
+			popArgsPushRes(stackitem.Null{})
+		})
 	}
-
-	key := MakeContractKey(hash)
-	ic.DAO.DeleteStorageItem(m.ID, key)
-	key = putHashKey(key, contract.ID)
-	ic.DAO.DeleteStorageItem(m.ID, key)
-	ic.DAO.Seek(contract.ID, storage.SeekRange{}, func(k, _ []byte) bool {
-		ic.DAO.DeleteStorageItem(contract.ID, k)
-		return true
-	})
-	markUpdated(ic.DAO, m.ID, hash, nil)
-
-	if !blockBeforeErase {
-		m.Policy.BlockAccountInternal(ic, hash)
-		err = m.Policy.CleanWhitelist(ic, hash)
-		if err != nil {
-			panic(fmt.Errorf("failed to clean whitelist for %s: %w", contract.Hash.StringLE(), err))
-		}
-	}
-
-	return contract, nil
 }
 
 func (m *Management) getMinimumDeploymentFee(ic *interop.Context, args []stackitem.Item) stackitem.Item {
@@ -589,14 +593,16 @@ func (m *Management) setMinimumDeploymentFee(ic *interop.Context, args []stackit
 	return stackitem.Null{}
 }
 
-func (m *Management) callDeploy(ic *interop.Context, cs *state.Contract, data stackitem.Item, isUpdate bool) {
+func (m *Management) callDeployDeferrable(ic *interop.Context, cs *state.Contract, data stackitem.Item, isUpdate bool, onUnloaded func(v *vm.VM)) {
 	md := cs.Manifest.ABI.GetMethod(manifest.MethodDeploy, 2)
 	if md != nil {
 		err := contract.CallFromNative(ic, m.Hash, cs, manifest.MethodDeploy,
-			[]stackitem.Item{data, stackitem.NewBool(isUpdate)}, false)
+			[]stackitem.Item{data, stackitem.NewBool(isUpdate)}, false, onUnloaded)
 		if err != nil {
 			panic(err)
 		}
+	} else {
+		onUnloaded(ic.VM)
 	}
 }
 

--- a/pkg/core/native/management_test.go
+++ b/pkg/core/native/management_test.go
@@ -41,9 +41,11 @@ func (n neo) ComputeNextBlockValidators(d *dao.Simple) keys.PublicKeys { panic("
 func (n neo) GetCandidates(d *dao.Simple) ([]state.Validator, error)   { panic("TODO") }
 func (n neo) CheckCommittee(ic *interop.Context) bool                  { panic("TODO") }
 func (n neo) CheckAlmostFullCommittee(ic *interop.Context) bool        { panic("TODO") }
-func (n neo) RevokeVotes(ic *interop.Context, h util.Uint160) error    { return nil }
+func (n neo) RevokeVotesDeferrable(ic *interop.Context, h util.Uint160, continuation func()) (bool, error) {
+	return true, nil
+}
 
-func TestDeployGetUpdateDestroyContract(t *testing.T) {
+func TestDeployGetUpdateContract(t *testing.T) {
 	mgmt := NewManagement()
 	p := NewPolicy()
 	p.NEO = neo{}
@@ -101,13 +103,6 @@ func TestDeployGetUpdateDestroyContract(t *testing.T) {
 	refContract.UpdateCounter++
 	require.NoError(t, err)
 	require.Equal(t, refContract, upContract)
-
-	_, err = mgmt.Destroy(ic, h, false)
-	require.NoError(t, err)
-	_, err = GetContract(d, mgmt.ID, h)
-	require.Error(t, err)
-	_, err = GetContractByID(d, mgmt.ID, contract.ID)
-	require.Error(t, err)
 }
 
 func TestManagement_Initialize(t *testing.T) {

--- a/pkg/core/native/native_gas.go
+++ b/pkg/core/native/native_gas.go
@@ -48,7 +48,7 @@ func newGAS(init int64) *GAS {
 	return g
 }
 
-func (g *GAS) increaseBalance(_ *interop.Context, _ util.Uint160, si *state.StorageItem, amount *big.Int, checkBal *big.Int) (func(), error) {
+func (g *GAS) increaseBalance(_ *interop.Context, _ util.Uint160, si *state.StorageItem, amount *big.Int, checkBal *big.Int) (*gasDistribution, error) {
 	acc, err := state.NEP17BalanceFromBytes(*si)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func (g *GAS) Initialize(ic *interop.Context, hf *config.Hardfork, newMD *intero
 	if err != nil {
 		return err
 	}
-	g.Mint(ic, h, big.NewInt(g.initialSupply), false)
+	g.MintDeferrable(ic, h, big.NewInt(g.initialSupply), false, func() { /*no continuation*/ })
 	return nil
 }
 
@@ -127,7 +127,7 @@ func (g *GAS) OnPersist(ic *interop.Context) error {
 			netFee -= (int64(na.NKeys) + 1) * g.Policy.GetAttributeFeeInternal(ic.DAO, transaction.NotaryAssistedT)
 		}
 	}
-	g.Mint(ic, primary, big.NewInt(int64(netFee)), false)
+	g.MintDeferrable(ic, primary, big.NewInt(int64(netFee)), false, func() { /*no continuation*/ })
 	return nil
 }
 

--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -35,7 +35,7 @@ import (
 // NEO represents NEO native contract.
 type NEO struct {
 	nep17TokenNative
-	GAS    IGAS
+	gas    IGAS
 	Policy IPolicy
 
 	// Configuration and standby keys are set in constructor and then
@@ -77,6 +77,12 @@ type NeoCache struct {
 	// It is set in state-modifying methods only and read in `PostPersist`, thus is not protected
 	// by any mutex.
 	gasPerVoteCache map[string]big.Int
+}
+
+// gasDistribution represents a task to distribute GAS to the specified account.
+type gasDistribution struct {
+	To     util.Uint160
+	Amount *big.Int
 }
 
 const (
@@ -166,8 +172,8 @@ func makeValidatorKey(key *keys.PublicKey) []byte {
 }
 
 // NewNEO returns NeoToken native contract.
-func NewNEO(cfg config.ProtocolConfiguration) *NEO {
-	n := &NEO{}
+func NewNEO(cfg config.ProtocolConfiguration, gas IGAS) *NEO {
+	n := &NEO{gas: gas}
 	defer n.BuildHFSpecificMD(n.ActiveIn())
 
 	nep17 := newNEP17Native(nativenames.Neo, nativeids.NeoToken, func(m *manifest.Manifest, hf config.Hardfork) {
@@ -180,6 +186,7 @@ func NewNEO(cfg config.ProtocolConfiguration) *NEO {
 	nep17.factor = 1
 	nep17.incBalance = n.increaseBalance
 	nep17.balFromBytes = n.balanceFromBytes
+	nep17.gasMinter = gas
 
 	n.nep17TokenNative = *nep17
 
@@ -220,10 +227,10 @@ func NewNEO(cfg config.ProtocolConfiguration) *NEO {
 	desc = NewDescriptor("vote", smartcontract.BoolType,
 		manifest.NewParameter("account", smartcontract.Hash160Type),
 		manifest.NewParameter("voteTo", smartcontract.PublicKeyType))
-	md = NewMethodAndPrice(n.vote, 1<<16, callflag.States, config.HFDefault, config.HFEchidna)
+	md = NewMethodAndPriceDeferrable(n.voteDeferrable, 1<<16, callflag.States, config.HFDefault, config.HFEchidna)
 	n.AddMethod(md, desc)
 
-	md = NewMethodAndPrice(n.vote, 1<<16, callflag.States|callflag.AllowNotify, config.HFEchidna)
+	md = NewMethodAndPriceDeferrable(n.voteDeferrable, 1<<16, callflag.States|callflag.AllowNotify, config.HFEchidna)
 	n.AddMethod(md, desc)
 
 	desc = NewDescriptor("getCandidates", smartcontract.ArrayType)
@@ -337,7 +344,7 @@ func (n *NEO) Initialize(ic *interop.Context, hf *config.Hardfork, newMD *intero
 	if err != nil {
 		return err
 	}
-	n.Mint(ic, h, big.NewInt(NEOTotalSupply), false)
+	n.MintDeferrable(ic, h, big.NewInt(NEOTotalSupply), false, func() {}) // no onNEP17Payment call => no source of asynchronous execution.
 
 	var index uint32
 	value := big.NewInt(5 * GASFactor)
@@ -500,7 +507,7 @@ func (n *NEO) PostPersist(ic *interop.Context) error {
 	committeeSize := n.cfg.GetCommitteeSize(ic.Block.Index)
 	index := int(ic.Block.Index) % committeeSize
 	committeeReward := new(big.Int).Mul(gas, bigCommitteeRewardRatio)
-	n.GAS.Mint(ic, pubs[index].GetScriptHash(), committeeReward.Div(committeeReward, big100), false)
+	n.gas.MintDeferrable(ic, pubs[index].GetScriptHash(), committeeReward.Div(committeeReward, big100), false, func() {}) // no onNEP17Payment call => no source of asynchronous execution.
 
 	var isCacheRW bool
 	if n.cfg.ShouldUpdateCommitteeAt(ic.Block.Index) {
@@ -579,9 +586,8 @@ func (n *NEO) getLatestGASPerVote(d *dao.Simple, key []byte) big.Int {
 	return g
 }
 
-func (n *NEO) increaseBalance(ic *interop.Context, h util.Uint160, si *state.StorageItem, amount *big.Int, checkBal *big.Int) (func(), error) {
-	var postF func()
-
+func (n *NEO) increaseBalance(ic *interop.Context, h util.Uint160, si *state.StorageItem, amount *big.Int, checkBal *big.Int) (*gasDistribution, error) {
+	var dist *gasDistribution
 	acc, err := state.NEOBalanceFromBytes(*si)
 	if err != nil {
 		return nil, err
@@ -595,11 +601,14 @@ func (n *NEO) increaseBalance(ic *interop.Context, h util.Uint160, si *state.Sto
 		return nil, err
 	}
 	if newGas != nil { // Can be if it was already distributed in the same block.
-		postF = func() { n.GAS.Mint(ic, h, newGas, true) }
+		dist = &gasDistribution{
+			To:     h,
+			Amount: newGas,
+		}
 	}
 	if amount.Sign() == 0 {
 		*si = acc.Bytes(ic.DAO.GetItemCtx())
-		return postF, nil
+		return dist, nil
 	}
 	if err := n.ModifyAccountVotes(acc, ic.DAO, amount, false); err != nil {
 		return nil, err
@@ -615,7 +624,7 @@ func (n *NEO) increaseBalance(ic *interop.Context, h util.Uint160, si *state.Sto
 	} else {
 		*si = nil
 	}
-	return postF, nil
+	return dist, nil
 }
 
 func (n *NEO) balanceFromBytes(si *state.StorageItem) (*big.Int, error) {
@@ -885,7 +894,7 @@ func (n *NEO) onNEP17Payment(ic *interop.Context, args []stackitem.Item) stackit
 		regPrice = n.getRegisterPriceInternal(ic.DAO)
 	)
 
-	if caller != n.GAS.Metadata().Hash {
+	if caller != n.gas.Metadata().Hash {
 		panic("only GAS is accepted")
 	}
 	if !amount.IsInt64() || amount.Int64() != regPrice {
@@ -895,7 +904,7 @@ func (n *NEO) onNEP17Payment(ic *interop.Context, args []stackitem.Item) stackit
 	if err != nil {
 		panic(err)
 	}
-	n.GAS.Burn(ic, n.Hash, amount)
+	n.gas.Burn(ic, n.Hash, amount)
 	return stackitem.Null{}
 }
 
@@ -984,45 +993,51 @@ func (n *NEO) UnregisterCandidateInternal(ic *interop.Context, pub *keys.PublicK
 	return nil
 }
 
-func (n *NEO) vote(ic *interop.Context, args []stackitem.Item) stackitem.Item {
+func (n *NEO) voteDeferrable(ic *interop.Context, args []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
 	acc := toUint160(args[0])
 	var pub *keys.PublicKey
 	if _, ok := args[1].(stackitem.Null); !ok {
 		pub = toPublicKey(args[1])
 	}
-	err := n.VoteInternal(ic, acc, pub)
-	return stackitem.NewBool(err == nil)
-}
-
-// VoteInternal votes from account h for validarors specified in pubs. This method
-// must not be called outside of VM since it panics on critical errors.
-func (n *NEO) VoteInternal(ic *interop.Context, h util.Uint160, pub *keys.PublicKey) error {
-	ok, err := runtime.CheckHashedWitness(ic, h)
+	ok, err := runtime.CheckHashedWitness(ic, acc)
 	if err != nil {
-		return err
-	} else if !ok {
-		return errors.New("invalid signature")
+		popArgsPushRes(stackitem.NewBool(false))
+		return
 	}
-	return n.voteInternalUnchecked(ic, h, pub)
+	if !ok {
+		popArgsPushRes(stackitem.NewBool(false))
+		return
+	}
+	continuationScheduled, err := n.voteInternalUncheckedDeferrable(ic, acc, pub, func() {
+		// voteInternalUncheckedDeferrable either panics or returns an error or completes successfully.
+		// The first two cases are covered by the code out of continuation. The last case should always push `true` on stack:
+		popArgsPushRes(stackitem.NewBool(true))
+	})
+	if !continuationScheduled {
+		popArgsPushRes(stackitem.NewBool(err == nil))
+		return
+	}
 }
 
-// RevokeVotes implements INEO interface. It revokes votes of account h and
+// RevokeVotesDeferrable implements INEO interface. It revokes votes of account h and
 // doesn't check the h's witness.
-func (n *NEO) RevokeVotes(ic *interop.Context, h util.Uint160) error {
-	return n.voteInternalUnchecked(ic, h, nil)
+func (n *NEO) RevokeVotesDeferrable(ic *interop.Context, h util.Uint160, continuation func()) (bool, error) {
+	return n.voteInternalUncheckedDeferrable(ic, h, nil, continuation)
 }
 
-// VoteInternalUnchecked it's an internal representation of VoteInternal that
+// VoteInternalUnchecked it's an internal representation of VoteInternalDeferrable that
 // votes of the specified account without checking the voter's signature.
-func (n *NEO) voteInternalUnchecked(ic *interop.Context, h util.Uint160, pub *keys.PublicKey) error {
+// It returns a boolean value denoting whether continuation call was scheduled
+// and an error.
+func (n *NEO) voteInternalUncheckedDeferrable(ic *interop.Context, h util.Uint160, pub *keys.PublicKey, continuation func()) (bool, error) {
 	key := makeAccountKey(h)
 	si := ic.DAO.GetStorageItem(n.ID, key)
 	if si == nil {
-		return errors.New("invalid account")
+		return false, errors.New("invalid account")
 	}
 	acc, err := state.NEOBalanceFromBytes(si)
 	if err != nil {
-		return err
+		return false, err
 	}
 	// we should put it in storage anyway as it affects dumps
 	ic.DAO.PutStorageItem(n.ID, key, si)
@@ -1030,13 +1045,13 @@ func (n *NEO) voteInternalUnchecked(ic *interop.Context, h util.Uint160, pub *ke
 		valKey := makeValidatorKey(pub)
 		valSi := ic.DAO.GetStorageItem(n.ID, valKey)
 		if valSi == nil {
-			return errors.New("unknown validator")
+			return false, errors.New("unknown validator")
 		}
 		cd := new(candidate).FromBytes(valSi)
 		// we should put it in storage anyway as it affects dumps
 		ic.DAO.PutStorageItem(n.ID, valKey, valSi)
 		if !cd.Registered {
-			return errors.New("validator must be registered")
+			return false, errors.New("validator must be registered")
 		}
 	}
 
@@ -1046,15 +1061,15 @@ func (n *NEO) voteInternalUnchecked(ic *interop.Context, h util.Uint160, pub *ke
 			val = new(big.Int).Neg(val)
 		}
 		if err := n.modifyVoterTurnout(ic.DAO, val); err != nil {
-			return err
+			return false, err
 		}
 	}
 	newGas, err := n.distributeGas(ic, acc)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if err := n.ModifyAccountVotes(acc, ic.DAO, new(big.Int).Neg(&acc.Balance), false); err != nil {
-		return err
+		return false, err
 	}
 	if pub != nil && pub != acc.VoteTo {
 		acc.LastGasPerVote = n.getLatestGASPerVote(ic.DAO, makeVoterKey(pub.Bytes()))
@@ -1062,7 +1077,7 @@ func (n *NEO) voteInternalUnchecked(ic *interop.Context, h util.Uint160, pub *ke
 	oldVote := acc.VoteTo
 	acc.VoteTo = pub
 	if err := n.ModifyAccountVotes(acc, ic.DAO, &acc.Balance, true); err != nil {
-		return err
+		return false, err
 	}
 	if pub == nil {
 		acc.LastGasPerVote = *big.NewInt(0)
@@ -1081,9 +1096,10 @@ func (n *NEO) voteInternalUnchecked(ic *interop.Context, h util.Uint160, pub *ke
 	}
 
 	if newGas != nil { // Can be if it was already distributed in the same block.
-		n.GAS.Mint(ic, h, newGas, true)
+		n.gas.MintDeferrable(ic, h, newGas, true, continuation)
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
 func keyToStackItem(k *keys.PublicKey) stackitem.Item {

--- a/pkg/core/native/native_nep17.go
+++ b/pkg/core/native/native_nep17.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
@@ -30,11 +31,24 @@ func makeAccountKey(h util.Uint160) []byte {
 // nep17TokenNative represents a NEP-17 token contract.
 type nep17TokenNative struct {
 	interop.ContractMD
+	// gasMinter is something capable of GAS minting (GAS contract in fact).
+	// It's nil for the GAS contract itself and guaranteed not to be invoked for
+	// the GAS contract.
+	gasMinter    IGASMinter
 	symbol       string
 	decimals     int64
 	factor       int64
-	incBalance   func(*interop.Context, util.Uint160, *state.StorageItem, *big.Int, *big.Int) (func(), error)
+	incBalance   func(*interop.Context, util.Uint160, *state.StorageItem, *big.Int, *big.Int) (*gasDistribution, error)
 	balFromBytes func(item *state.StorageItem) (*big.Int, error)
+}
+
+// IGASMinter is an abstraction leak that describes GAS minting functionality.
+type IGASMinter interface {
+	// MintDeferrable mints specified amount of GAS to the receiver address and
+	// optionally calls onNEP17Payment method. It always either runs or schedules
+	// continuation, so the caller must never call the continuation afterwards
+	// by himself.
+	MintDeferrable(ic *interop.Context, to util.Uint160, amount *big.Int, callOnPayment bool, continuation func())
 }
 
 // totalSupplyKey is the key used to store totalSupply value.
@@ -77,7 +91,7 @@ func newNEP17Native(name string, id int32, onManifestConstruction func(m *manife
 	desc = NewDescriptor("transfer", smartcontract.BoolType,
 		append(transferParams, manifest.NewParameter("data", smartcontract.AnyType))...,
 	)
-	md = NewMethodAndPrice(n.Transfer, 1<<17, callflag.States|callflag.AllowCall|callflag.AllowNotify)
+	md = NewMethodAndPriceDeferrable(n.transferDeferrable, 1<<17, callflag.States|callflag.AllowCall|callflag.AllowNotify)
 	md.StorageFee = 50
 	n.AddMethod(md, desc)
 
@@ -117,12 +131,48 @@ func (c *nep17TokenNative) saveTotalSupply(d *dao.Simple, si state.StorageItem, 
 	d.PutBigInt(c.ID, totalSupplyKey, supply)
 }
 
-func (c *nep17TokenNative) Transfer(ic *interop.Context, args []stackitem.Item) stackitem.Item {
+func (c *nep17TokenNative) transferDeferrable(ic *interop.Context, args []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
 	from := toUint160(args[0])
 	to := toUint160(args[1])
 	amount := toBigInt(args[2])
-	err := c.TransferInternal(ic, from, to, amount, args[3])
-	return stackitem.NewBool(err == nil)
+	data := args[3]
+	var dist1, dist2 *gasDistribution
+
+	if amount.Sign() == -1 {
+		panic(errors.New("negative amount"))
+	}
+
+	caller := ic.VM.GetCallingScriptHash()
+	if caller.Equals(util.Uint160{}) || !from.Equals(caller) {
+		ok, err := runtime.CheckHashedWitness(ic, from)
+		if err != nil || !ok {
+			popArgsPushRes(stackitem.NewBool(false))
+			return
+		}
+	}
+	isEmpty := from.Equals(to) || amount.Sign() == 0
+	inc := amount
+	if isEmpty {
+		inc = big.NewInt(0)
+	} else {
+		inc = new(big.Int).Neg(inc)
+	}
+
+	dist1, err := c.updateAccBalance(ic, from, inc, amount)
+	if err != nil {
+		popArgsPushRes(stackitem.NewBool(false))
+		return
+	}
+
+	if !isEmpty {
+		dist2, err = c.updateAccBalance(ic, to, amount, nil)
+		if err != nil {
+			popArgsPushRes(stackitem.NewBool(false))
+			return
+		}
+	}
+
+	c.postTransfer(ic, &from, &to, amount, data, true, popArgsPushRes, dist1, dist2)
 }
 
 func addrToStackItem(u *util.Uint160) stackitem.Item {
@@ -132,29 +182,45 @@ func addrToStackItem(u *util.Uint160) stackitem.Item {
 	return stackitem.NewByteArray(u.BytesBE())
 }
 
+// postTransfer emits Transfer notification, calls onNEP17Payment (if so) and schedules
+// GAS distributions (if so). It always either runs or schedules popArgsPushRes callback
+// execution so the caller must not call it afterward.
 func (c *nep17TokenNative) postTransfer(ic *interop.Context, from, to *util.Uint160, amount *big.Int,
-	data stackitem.Item, callOnPayment bool, postCalls ...func()) {
-	var skipPostCalls bool
-	defer func() {
-		if skipPostCalls {
-			return
-		}
-		for _, f := range postCalls {
-			if f != nil {
-				f()
-			}
-		}
-	}()
+	data stackitem.Item, callOnPayment bool, popArgsPushRes func(stackitem.Item), dists ...*gasDistribution) {
 	err := c.emitTransfer(ic, from, to, amount)
 	if err != nil {
-		skipPostCalls = true
 		panic(err)
 	}
+	continuation := func() {
+		if len(dists) > 2 {
+			// Write more nested continuations and nil distributions filtering if you need to support more than 2 stacked distributions.
+			panic(fmt.Errorf("program bug: too many GAS distributions in postTransfer: max 2, got %d", len(dists)))
+		}
+		if len(dists) > 0 && dists[0] == nil { // filter out possible first nil distribution.
+			dists = dists[1:]
+		}
+		// Execute a part of Mint, enqueue context with onNEP17Payment and return.
+		if len(dists) > 0 && dists[0] != nil {
+			c.gasMinter.MintDeferrable(ic, dists[0].To, dists[0].Amount, callOnPayment, func() {
+				if len(dists) > 1 && dists[1] != nil { // at max two distributions are supported for now.
+					c.gasMinter.MintDeferrable(ic, dists[1].To, dists[1].Amount, callOnPayment, func() {
+						popArgsPushRes(stackitem.NewBool(true)) // the result of `transfer` in fact.
+					})
+				} else {
+					popArgsPushRes(stackitem.NewBool(true)) // the result of `transfer` in fact.
+				}
+			})
+		} else {
+			popArgsPushRes(stackitem.NewBool(true)) // the result of `transfer` in fact.
+		}
+	}
 	if to == nil || !callOnPayment {
+		continuation()
 		return
 	}
 	cs, err := ic.GetContract(*to)
 	if err != nil {
+		continuation()
 		return
 	}
 
@@ -167,8 +233,11 @@ func (c *nep17TokenNative) postTransfer(ic *interop.Context, from, to *util.Uint
 		stackitem.NewBigInteger(amount),
 		data,
 	}
-	if err := contract.CallFromNative(ic, c.Hash, cs, manifest.MethodOnNEP17Payment, args, false); err != nil {
-		skipPostCalls = true
+	err = contract.CallFromNative(ic, c.Hash, cs, manifest.MethodOnNEP17Payment, args, false, func(v *vm.VM) {
+		// onNEP17Payment returns void => no need to pop the result from the parent's stack.
+		continuation()
+	})
+	if err != nil {
 		panic(err)
 	}
 }
@@ -183,7 +252,7 @@ func (c *nep17TokenNative) emitTransfer(ic *interop.Context, from, to *util.Uint
 
 // updateAccBalance adds the specified amount to the acc's balance. If requiredBalance
 // is set and amount is 0, the acc's balance is checked against requiredBalance.
-func (c *nep17TokenNative) updateAccBalance(ic *interop.Context, acc util.Uint160, amount *big.Int, requiredBalance *big.Int) (func(), error) {
+func (c *nep17TokenNative) updateAccBalance(ic *interop.Context, acc util.Uint160, amount *big.Int, requiredBalance *big.Int) (*gasDistribution, error) {
 	key := makeAccountKey(acc)
 	si := ic.DAO.GetStorageItem(c.ID, key)
 	if si == nil {
@@ -200,7 +269,7 @@ func (c *nep17TokenNative) updateAccBalance(ic *interop.Context, acc util.Uint16
 		si = state.StorageItem{}
 	}
 
-	postF, err := c.incBalance(ic, acc, &si, amount, requiredBalance)
+	dist, err := c.incBalance(ic, acc, &si, amount, requiredBalance)
 	if err != nil {
 		if si != nil && amount.Sign() <= 0 {
 			ic.DAO.PutStorageItem(c.ID, key, si)
@@ -212,48 +281,7 @@ func (c *nep17TokenNative) updateAccBalance(ic *interop.Context, acc util.Uint16
 	} else {
 		ic.DAO.PutStorageItem(c.ID, key, si)
 	}
-	return postF, nil
-}
-
-// TransferInternal transfers NEO across accounts.
-func (c *nep17TokenNative) TransferInternal(ic *interop.Context, from, to util.Uint160, amount *big.Int, data stackitem.Item) error {
-	var postF1, postF2 func()
-
-	if amount.Sign() == -1 {
-		panic(errors.New("negative amount"))
-	}
-
-	caller := ic.VM.GetCallingScriptHash()
-	if caller.Equals(util.Uint160{}) || !from.Equals(caller) {
-		ok, err := runtime.CheckHashedWitness(ic, from)
-		if err != nil {
-			return err
-		} else if !ok {
-			return errors.New("invalid signature")
-		}
-	}
-	isEmpty := from.Equals(to) || amount.Sign() == 0
-	inc := amount
-	if isEmpty {
-		inc = big.NewInt(0)
-	} else {
-		inc = new(big.Int).Neg(inc)
-	}
-
-	postF1, err := c.updateAccBalance(ic, from, inc, amount)
-	if err != nil {
-		return err
-	}
-
-	if !isEmpty {
-		postF2, err = c.updateAccBalance(ic, to, amount, nil)
-		if err != nil {
-			return err
-		}
-	}
-
-	c.postTransfer(ic, &from, &to, amount, data, true, postF1, postF2)
-	return nil
+	return dist, nil
 }
 
 func (c *nep17TokenNative) balanceOf(ic *interop.Context, args []stackitem.Item) stackitem.Item {
@@ -274,12 +302,17 @@ func (c *nep17TokenNative) balanceOfInternal(d *dao.Simple, h util.Uint160) *big
 	return balance
 }
 
-func (c *nep17TokenNative) Mint(ic *interop.Context, h util.Uint160, amount *big.Int, callOnPayment bool) {
+func (c *nep17TokenNative) MintDeferrable(ic *interop.Context, h util.Uint160, amount *big.Int, callOnPayment bool, continuation func()) {
 	if amount.Sign() == 0 {
+		continuation()
 		return
 	}
-	postF := c.addTokens(ic, h, amount)
-	c.postTransfer(ic, nil, &h, amount, stackitem.Null{}, callOnPayment, postF)
+	c.addTokens(ic, h, amount)
+	c.postTransfer(ic, nil, &h, amount, stackitem.Null{}, callOnPayment,
+		// postTransfer is primarily designated to work as a `transfer` callback, that's why is always either returns
+		// `true` or panics, but MintDeferrable doesn't return anything, so skip `res` handling and just continue the
+		// caller's execution flow.
+		func(res stackitem.Item) { continuation() })
 }
 
 func (c *nep17TokenNative) Burn(ic *interop.Context, h util.Uint160, amount *big.Int) {
@@ -287,12 +320,12 @@ func (c *nep17TokenNative) Burn(ic *interop.Context, h util.Uint160, amount *big
 		return
 	}
 	amount.Neg(amount)
-	postF := c.addTokens(ic, h, amount)
+	dist := c.addTokens(ic, h, amount)
 	amount.Neg(amount)
-	c.postTransfer(ic, &h, nil, amount, stackitem.Null{}, false, postF)
+	c.postTransfer(ic, &h, nil, amount, stackitem.Null{}, false, func(res stackitem.Item) {}, dist) // no onNEP17Payment call => no source of asynchronous execution.
 }
 
-func (c *nep17TokenNative) addTokens(ic *interop.Context, h util.Uint160, amount *big.Int) func() {
+func (c *nep17TokenNative) addTokens(ic *interop.Context, h util.Uint160, amount *big.Int) *gasDistribution {
 	if amount.Sign() == 0 {
 		return nil
 	}
@@ -302,7 +335,7 @@ func (c *nep17TokenNative) addTokens(ic *interop.Context, h util.Uint160, amount
 	if si == nil {
 		si = state.StorageItem{}
 	}
-	postF, err := c.incBalance(ic, h, &si, amount, nil)
+	dist, err := c.incBalance(ic, h, &si, amount, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -315,7 +348,7 @@ func (c *nep17TokenNative) addTokens(ic *interop.Context, h util.Uint160, amount
 	buf, supply := c.getTotalSupply(ic.DAO)
 	supply.Add(supply, amount)
 	c.saveTotalSupply(ic.DAO, buf, supply)
-	return postF
+	return dist
 }
 
 func NewDescriptor(name string, ret smartcontract.ParamType, ps ...manifest.Parameter) *manifest.Method {
@@ -333,11 +366,22 @@ func NewDescriptor(name string, ret smartcontract.ParamType, ps ...manifest.Para
 // values consequently specified via activations. [config.HFDefault] specified as ActiveFrom is treated
 // as active starting from the genesis block.
 func NewMethodAndPrice(f interop.Method, cpuFee int64, flags callflag.CallFlag, activations ...config.Hardfork) *interop.MethodAndPrice {
+	return newMethodAndPriceInternal(f, nil, cpuFee, flags, activations...)
+}
+
+// NewMethodAndPriceDeferrable works similar to NewMethodAndPrice except that it expects a deferrable
+// method handler that processes the result via callback instead of direct return.
+func NewMethodAndPriceDeferrable(f interop.DeferrableMethod, cpuFee int64, flags callflag.CallFlag, activations ...config.Hardfork) *interop.MethodAndPrice {
+	return newMethodAndPriceInternal(nil, f, cpuFee, flags, activations...)
+}
+
+func newMethodAndPriceInternal(f interop.Method, fDeferrable interop.DeferrableMethod, cpuFee int64, flags callflag.CallFlag, activations ...config.Hardfork) *interop.MethodAndPrice {
 	md := &interop.MethodAndPrice{
 		HFSpecificMethodAndPrice: interop.HFSpecificMethodAndPrice{
-			Func:          f,
-			CPUFee:        cpuFee,
-			RequiredFlags: flags,
+			Func:           f,
+			DeferrableFunc: fDeferrable,
+			CPUFee:         cpuFee,
+			RequiredFlags:  flags,
 		},
 	}
 	if len(activations) > 0 {

--- a/pkg/core/native/notary.go
+++ b/pkg/core/native/notary.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
@@ -100,7 +101,7 @@ func NewNotary() *Notary {
 	desc = NewDescriptor("withdraw", smartcontract.BoolType,
 		manifest.NewParameter("from", smartcontract.Hash160Type),
 		manifest.NewParameter("to", smartcontract.Hash160Type))
-	md = NewMethodAndPrice(n.withdraw, 1<<15, callflag.All)
+	md = NewMethodAndPriceDeferrable(n.withdrawDeferrable, 1<<15, callflag.All)
 	n.AddMethod(md, desc)
 
 	desc = NewDescriptor("balanceOf", smartcontract.IntegerType,
@@ -203,7 +204,7 @@ func (n *Notary) OnPersist(ic *interop.Context) error {
 	feePerKey := n.Policy.GetAttributeFeeInternal(ic.DAO, transaction.NotaryAssistedT)
 	singleReward := calculateNotaryReward(nFees, feePerKey, len(notaries))
 	for _, notary := range notaries {
-		n.GAS.Mint(ic, notary.GetScriptHash(), singleReward, false)
+		n.GAS.MintDeferrable(ic, notary.GetScriptHash(), singleReward, false, func() {}) // no onNEP17Payment call => no source of asynchronous execution.
 	}
 	return nil
 }
@@ -298,15 +299,16 @@ func (n *Notary) lockDepositUntil(ic *interop.Context, args []stackitem.Item) st
 	return stackitem.NewBool(true)
 }
 
-// withdraw sends all deposited GAS for "from" address to "to" address.
-func (n *Notary) withdraw(ic *interop.Context, args []stackitem.Item) stackitem.Item {
+// withdrawDeferrable sends all deposited GAS for "from" address to "to" address.
+func (n *Notary) withdrawDeferrable(ic *interop.Context, args []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
 	from := toUint160(args[0])
 	ok, err := runtime.CheckHashedWitness(ic, from)
 	if err != nil {
 		panic(fmt.Errorf("failed to check witness for %s: %w", from.StringBE(), err))
 	}
 	if !ok {
-		return stackitem.NewBool(false)
+		popArgsPushRes(stackitem.NewBool(false))
+		return
 	}
 	to := from
 	if !args[1].Equals(stackitem.Null{}) {
@@ -314,11 +316,13 @@ func (n *Notary) withdraw(ic *interop.Context, args []stackitem.Item) stackitem.
 	}
 	deposit := n.GetDepositFor(ic.DAO, from)
 	if deposit == nil {
-		return stackitem.NewBool(false)
+		popArgsPushRes(stackitem.NewBool(false))
+		return
 	}
 	// Allow withdrawal only after `till` block was persisted, thus, use ic.BlockHeight().
 	if ic.BlockHeight() < deposit.Till {
-		return stackitem.NewBool(false)
+		popArgsPushRes(stackitem.NewBool(false))
+		return
 	}
 	cs, err := ic.GetContract(n.GAS.Metadata().Hash)
 	if err != nil {
@@ -330,14 +334,15 @@ func (n *Notary) withdraw(ic *interop.Context, args []stackitem.Item) stackitem.
 	n.removeDepositFor(ic.DAO, from)
 
 	transferArgs := []stackitem.Item{stackitem.NewByteArray(n.Hash.BytesBE()), stackitem.NewByteArray(to.BytesBE()), stackitem.NewBigInteger(deposit.Amount), stackitem.Null{}}
-	err = contract.CallFromNative(ic, n.Hash, cs, "transfer", transferArgs, true)
+	err = contract.CallFromNative(ic, n.Hash, cs, "transfer", transferArgs, true, func(v *vm.VM) {
+		if !v.Estack().Pop().Bool() { // pop the result of `transfer` from the parent context's stack.
+			panic("failed to transfer GAS from Notary account: `transfer` returned false")
+		}
+		popArgsPushRes(stackitem.NewBool(true))
+	})
 	if err != nil {
 		panic(fmt.Errorf("failed to transfer GAS from Notary account: %w", err))
 	}
-	if !ic.VM.Estack().Pop().Bool() {
-		panic("failed to transfer GAS from Notary account: `transfer` returned false")
-	}
-	return stackitem.NewBool(true)
 }
 
 // balanceOf returns the deposited GAS amount for the specified address.

--- a/pkg/core/native/oracle.go
+++ b/pkg/core/native/oracle.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
@@ -136,7 +137,7 @@ func newOracle() *Oracle {
 	o.AddMethod(md, desc)
 
 	desc = NewDescriptor("finish", smartcontract.VoidType)
-	md = NewMethodAndPrice(o.finish, 0, callflag.States|callflag.AllowCall|callflag.AllowNotify)
+	md = NewMethodAndPriceDeferrable(o.finishDeferrable, 0, callflag.States|callflag.AllowCall|callflag.AllowNotify)
 	o.AddMethod(md, desc)
 
 	desc = NewDescriptor("verify", smartcontract.BoolType)
@@ -235,7 +236,7 @@ func (o *Oracle) PostPersist(ic *interop.Context) error {
 		}
 	}
 	for i := range reward {
-		o.GAS.Mint(ic, nodes[i].GetScriptHash(), &reward[i], false)
+		o.GAS.MintDeferrable(ic, nodes[i].GetScriptHash(), &reward[i], false, func() {}) // no onNEP17Payment call => no source of asynchronous execution.
 	}
 
 	if len(removedIDs) != 0 {
@@ -301,48 +302,37 @@ func getResponse(tx *transaction.Transaction) *transaction.OracleResponse {
 	return nil
 }
 
-func (o *Oracle) finish(ic *interop.Context, _ []stackitem.Item) stackitem.Item {
-	err := o.FinishInternal(ic)
-	if err != nil {
-		panic(err)
-	}
-	return stackitem.Null{}
-}
-
-// FinishInternal processes an oracle response.
-func (o *Oracle) FinishInternal(ic *interop.Context) error {
+func (o *Oracle) finishDeferrable(ic *interop.Context, _ []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
 	if len(ic.VM.Istack()) != 2 {
-		return errors.New("'Oracle.finish' called from non-entry script")
+		panic(errors.New("'Oracle.finish' called from non-entry script"))
 	}
 	if ic.Invocations[o.Hash] != 1 {
-		return errors.New("'Oracle.finish' called multiple times")
+		panic(errors.New("'Oracle.finish' called multiple times"))
 	}
 	resp := getResponse(ic.Tx)
 	if resp == nil {
-		return ErrResponseNotFound
+		panic(ErrResponseNotFound)
 	}
 	req, err := o.GetRequestInternal(ic.DAO, resp.ID)
 	if err != nil {
-		return ErrRequestNotFound
+		panic(ErrRequestNotFound)
 	}
 	err = ic.AddNotification(o.Hash, "OracleResponse", stackitem.NewArray([]stackitem.Item{
 		stackitem.Make(resp.ID),
 		stackitem.Make(req.OriginalTxID.BytesBE()),
 	}))
 	if err != nil {
-		return err
+		panic(err)
 	}
 
 	origTx, _, err := ic.DAO.GetTransaction(req.OriginalTxID)
 	if err != nil {
-		return ErrRequestNotFound
+		panic(ErrRequestNotFound)
 	}
-	ic.UseSigners(origTx.Signers)
-	defer ic.UseSigners(nil)
 
 	userData, err := stackitem.Deserialize(req.UserData)
 	if err != nil {
-		return err
+		panic(err)
 	}
 	args := []stackitem.Item{
 		stackitem.Make(req.URL),
@@ -352,9 +342,19 @@ func (o *Oracle) FinishInternal(ic *interop.Context) error {
 	}
 	cs, err := ic.GetContract(req.CallbackContract)
 	if err != nil {
-		return err
+		panic(err)
 	}
-	return contract.CallFromNative(ic, o.Hash, cs, req.CallbackMethod, args, false)
+
+	ic.UseSigners(origTx.Signers)
+	err = contract.CallFromNative(ic, o.Hash, cs, req.CallbackMethod, args, false, func(v *vm.VM) {
+		// req.CallbackMethod returns void => no need to pop the result from the parent's stack.
+		ic.UseSigners(nil)
+		popArgsPushRes(stackitem.Null{})
+	})
+	if err != nil {
+		ic.UseSigners(nil)
+		panic(err)
+	}
 }
 
 func (o *Oracle) request(ic *interop.Context, args []stackitem.Item) stackitem.Item {
@@ -406,7 +406,7 @@ func (o *Oracle) RequestInternal(ic *interop.Context, url string, filter *string
 		return fmt.Errorf("%w minting reward for Oracle request", err)
 	}
 	callingHash := ic.VM.GetCallingScriptHash()
-	o.GAS.Mint(ic, o.Hash, gas, false)
+	o.GAS.MintDeferrable(ic, o.Hash, gas, false, func() {}) // no onNEP17Payment call => no source of asynchronous execution.
 	si := ic.DAO.GetStorageItem(o.ID, prefixRequestID)
 	itemID := bigint.FromBytes(si)
 	id := itemID.Uint64()

--- a/pkg/core/native/policy.go
+++ b/pkg/core/native/policy.go
@@ -201,12 +201,12 @@ func NewPolicy() *Policy {
 
 	desc = NewDescriptor("blockAccount", smartcontract.BoolType,
 		manifest.NewParameter("account", smartcontract.Hash160Type))
-	md = NewMethodAndPrice(p.blockAccount, 1<<15, callflag.States, config.HFDefault, config.HFFaun)
+	md = NewMethodAndPriceDeferrable(p.blockAccountDeferrable, 1<<15, callflag.States, config.HFDefault, config.HFFaun)
 	p.AddMethod(md, desc)
 
 	desc = NewDescriptor("blockAccount", smartcontract.BoolType,
 		manifest.NewParameter("account", smartcontract.Hash160Type))
-	md = NewMethodAndPrice(p.blockAccount, 1<<15, callflag.States|callflag.AllowNotify, config.HFFaun)
+	md = NewMethodAndPriceDeferrable(p.blockAccountDeferrable, 1<<15, callflag.States|callflag.AllowNotify, config.HFFaun)
 	p.AddMethod(md, desc)
 
 	desc = NewDescriptor("unblockAccount", smartcontract.BoolType,
@@ -278,7 +278,7 @@ func NewPolicy() *Policy {
 	desc = NewDescriptor("recoverFund", smartcontract.BoolType,
 		manifest.NewParameter("account", smartcontract.Hash160Type),
 		manifest.NewParameter("token", smartcontract.Hash160Type))
-	md = NewMethodAndPrice(p.recoverFund, 1<<15, callflag.All, config.HFFaun)
+	md = NewMethodAndPriceDeferrable(p.recoverFundDeferrable, 1<<15, callflag.All, config.HFFaun)
 	p.AddMethod(md, desc)
 
 	eDesc = NewEventDescriptor("WhitelistFeeChanged",
@@ -650,7 +650,7 @@ func (p *Policy) setFeePerByte(ic *interop.Context, args []stackitem.Item) stack
 
 // blockAccount is a Policy contract method that adds the given account hash to the list
 // of blocked accounts.
-func (p *Policy) blockAccount(ic *interop.Context, args []stackitem.Item) stackitem.Item {
+func (p *Policy) blockAccountDeferrable(ic *interop.Context, args []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
 	if !p.NEO.CheckCommittee(ic) {
 		panic("invalid committee signature")
 	}
@@ -660,31 +660,44 @@ func (p *Policy) blockAccount(ic *interop.Context, args []stackitem.Item) stacki
 			panic("cannot block native contract")
 		}
 	}
-	return stackitem.NewBool(p.BlockAccountInternal(ic, hash))
+	p.BlockAccountInternalDeferrable(ic, hash, func(res bool) {
+		popArgsPushRes(stackitem.NewBool(res))
+	})
 }
 
-func (p *Policy) BlockAccountInternal(ic *interop.Context, hash util.Uint160) bool {
+func (p *Policy) BlockAccountInternalDeferrable(ic *interop.Context, hash util.Uint160, handleRes func(res bool)) {
 	i, blocked := p.isBlockedInternal(ic.DAO.GetROCache(p.ID).(*PolicyCache), hash)
 	if blocked {
-		return false
+		handleRes(false)
+		return
 	}
+
+	continuation := func() {
+		key := makeBlockedAccountKey(hash)
+		if ic.IsHardforkEnabled(config.HFFaun) {
+			ic.DAO.PutBigInt(p.ID, key, new(big.Int).SetUint64(ic.GetTime()))
+		} else {
+			ic.DAO.PutStorageItem(p.ID, key, state.StorageItem{})
+		}
+		cache := ic.DAO.GetRWCache(p.ID).(*PolicyCache)
+		if len(cache.blockedAccounts) == i {
+			cache.blockedAccounts = append(cache.blockedAccounts, hash)
+		} else {
+			cache.blockedAccounts = append(cache.blockedAccounts[:i+1], cache.blockedAccounts[i:]...)
+			cache.blockedAccounts[i] = hash
+		}
+		handleRes(true)
+	}
+
 	if ic.IsHardforkEnabled(config.HFFaun) {
-		var _ = p.NEO.RevokeVotes(ic, hash) // ignore error, as in the reference.
+		var continuationScheduled, _ = p.NEO.RevokeVotesDeferrable(ic, hash, continuation)
+		if !continuationScheduled { // ignore error, as in the reference.
+			continuation()
+		}
+		return
 	}
-	key := makeBlockedAccountKey(hash)
-	if ic.IsHardforkEnabled(config.HFFaun) {
-		ic.DAO.PutBigInt(p.ID, key, new(big.Int).SetUint64(ic.GetTime()))
-	} else {
-		ic.DAO.PutStorageItem(p.ID, key, state.StorageItem{})
-	}
-	cache := ic.DAO.GetRWCache(p.ID).(*PolicyCache)
-	if len(cache.blockedAccounts) == i {
-		cache.blockedAccounts = append(cache.blockedAccounts, hash)
-	} else {
-		cache.blockedAccounts = append(cache.blockedAccounts[:i+1], cache.blockedAccounts[i:]...)
-		cache.blockedAccounts[i] = hash
-	}
-	return true
+
+	continuation()
 }
 
 // unblockAccount is a Policy contract method that removes the given account hash from
@@ -975,7 +988,7 @@ func (p *Policy) getWhitelistFeeContracts(ic *interop.Context, _ []stackitem.Ite
 	return stackitem.NewInterop(&iterator[*state.WhitelistFeeContract]{keys: res})
 }
 
-func (p *Policy) recoverFund(ic *interop.Context, args []stackitem.Item) stackitem.Item {
+func (p *Policy) recoverFundDeferrable(ic *interop.Context, args []stackitem.Item, popArgsPushRes func(res stackitem.Item)) {
 	acc := toUint160(args[0])
 	token := toUint160(args[1])
 
@@ -998,35 +1011,36 @@ func (p *Policy) recoverFund(ic *interop.Context, args []stackitem.Item) stackit
 	if !cs.Manifest.IsStandardSupported("NEP-17") {
 		panic(fmt.Errorf("contract %s does not support NEP-17", token.StringLE()))
 	}
-
-	err = contract.CallFromNative(ic, acc, cs, "balanceOf", []stackitem.Item{stackitem.NewByteArray(acc.BytesBE())}, true)
+	err = contract.CallFromNative(ic, acc, cs, "balanceOf", []stackitem.Item{stackitem.NewByteArray(acc.BytesBE())}, true,
+		func(v *vm.VM) {
+			balance := v.Estack().Pop().BigInt() // pop the result of `balanceOf` from the parent context's stack.
+			if balance.Sign() <= 0 {
+				popArgsPushRes(stackitem.NewBool(false))
+				return
+			}
+			err = contract.CallFromNative(ic, acc, cs, "transfer", []stackitem.Item{
+				stackitem.NewByteArray(acc.BytesBE()),
+				stackitem.NewByteArray(nativehashes.Treasury.BytesBE()),
+				stackitem.NewBigInteger(balance),
+				stackitem.Null{},
+			}, true, func(v *vm.VM) {
+				ok := v.Estack().Pop().Bool() // pop the result of `transfer` from the parent context's stack.
+				if !ok {
+					panic(fmt.Errorf("transfer/%s from %s to %s failed", token.StringLE(), acc.StringLE(), nativehashes.Treasury.StringLE()))
+				}
+				err = ic.AddNotification(p.Hash, "RecoveredFund", stackitem.NewArray([]stackitem.Item{stackitem.NewByteArray(acc.BytesBE())}))
+				if err != nil {
+					panic(err)
+				}
+				popArgsPushRes(stackitem.NewBool(true))
+			})
+			if err != nil {
+				panic(fmt.Errorf("failed to call transfer/%s: %w", token.StringLE(), err))
+			}
+		})
 	if err != nil {
 		panic(fmt.Errorf("failed to call balanceOf/%s: %w", token.StringLE(), err))
 	}
-	balance := ic.VM.Estack().Pop().BigInt()
-	if balance.Sign() <= 0 {
-		return stackitem.NewBool(false)
-	}
-
-	err = contract.CallFromNative(ic, acc, cs, "transfer", []stackitem.Item{
-		stackitem.NewByteArray(acc.BytesBE()),
-		stackitem.NewByteArray(nativehashes.Treasury.BytesBE()),
-		stackitem.NewBigInteger(balance),
-		stackitem.Null{},
-	}, true)
-	if err != nil {
-		panic(fmt.Errorf("failed to call transfer/%s: %w", token.StringLE(), err))
-	}
-	ok := ic.VM.Estack().Pop().Bool()
-	if !ok {
-		panic(fmt.Errorf("transfer/%s from %s to %s failed", token.StringLE(), acc.StringLE(), nativehashes.Treasury.StringLE()))
-	}
-
-	err = ic.AddNotification(p.Hash, "RecoveredFund", stackitem.NewArray([]stackitem.Item{stackitem.NewByteArray(acc.BytesBE())}))
-	if err != nil {
-		panic(err)
-	}
-	return stackitem.NewBool(true)
 }
 
 func makeBlockedAccountKey(acc util.Uint160) []byte {

--- a/pkg/vm/context.go
+++ b/pkg/vm/context.go
@@ -48,9 +48,15 @@ type scriptContext struct {
 	Manifest *manifest.Manifest
 	// invTree is an invocation tree (or a branch of it) for this context.
 	invTree *invocations.Tree
-	// onUnload is a callback that should be called after current context unloading
-	// if no exception occurs.
+	// onUnload is a callback that should be called after the current context
+	// is removed from the VM's invocation stack and after return values are
+	// copied from the unloaded context estack to the parent's context estack.
+	// This method is called even if there's an uncaught VM exception.
 	onUnload ContextUnloadCallback
+	// onUnloaded is a callback that should be called after the current context
+	// is fully unloaded from the VM's invocation stack iff there's no uncaught
+	// VM exception. It's OK for this function to panic.
+	onUnloaded ContextUnloadedCallback
 	// whitelisted denotes whether execution fee charging should be omitted for
 	// the current context.
 	whitelisted bool
@@ -79,8 +85,16 @@ type contextAux struct {
 	Caller string
 }
 
-// ContextUnloadCallback is a callback method used on context unloading from istack.
-type ContextUnloadCallback func(v *VM, ctx *Context, commit bool) error
+type (
+	// ContextUnloadCallback is a callback method used on context unloading from istack.
+	// It is called after the context is removed from the VM's invocation stack but
+	// before return values are copied from the unloaded context estack to the parent's
+	// context estack.
+	ContextUnloadCallback func(v *VM, ctx *Context, commit bool) error
+	// ContextUnloadedCallback is a callback method that is called after the context
+	// is fully unloaded from the VM's invocation stack if no exception occurs.
+	ContextUnloadedCallback func(v *VM)
+)
 
 // ErrMultiRet is returned when caller does not expect multiple return values
 // from callee.

--- a/pkg/vm/debug_test.go
+++ b/pkg/vm/debug_test.go
@@ -56,7 +56,7 @@ func TestContext_BreakPoints(t *testing.T) {
 	require.Equal(t, []int{3, 5}, v.Context().BreakPoints())
 
 	// New context -> clean breakpoints.
-	v.loadScriptWithCallingHash(prog, nil, nil, util.Uint160{}, util.Uint160{}, callflag.All, 1, 3, nil, false)
+	v.loadScriptWithCallingHash(prog, nil, nil, util.Uint160{}, util.Uint160{}, callflag.All, 1, 3, nil, nil, false)
 	require.Nil(t, v.Context().BreakPoints())
 
 	v.AddBreakPoint(3)

--- a/pkg/vm/stack.go
+++ b/pkg/vm/stack.go
@@ -175,8 +175,15 @@ func (s *Stack) InsertAt(e Element, n int) {
 
 // Push pushes the given element on the stack.
 func (s *Stack) Push(e Element) {
-	s.elems = append(s.elems, e)
+	s.pushNoRef(e)
 	s.refs.Add(e.value)
+}
+
+// pushNoRef pushes the given element on the stack without changing the reference
+// counter. Be super-careful when using it and only use it when you understand
+// what you're doing.
+func (s *Stack) pushNoRef(e Element) {
+	s.elems = append(s.elems, e)
 }
 
 // PushItem pushes an Item to the stack.

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -409,14 +409,14 @@ func (v *VM) LoadScript(b []byte) {
 
 // LoadScriptWithFlags loads script and sets call flag to f.
 func (v *VM) LoadScriptWithFlags(b []byte, f callflag.CallFlag) {
-	v.loadScriptWithCallingHash(b, nil, nil, v.GetCurrentScriptHash(), util.Uint160{}, f, -1, 0, nil, false)
+	v.loadScriptWithCallingHash(b, nil, nil, v.GetCurrentScriptHash(), util.Uint160{}, f, -1, 0, nil, nil, false)
 }
 
 // LoadDynamicScript loads the given script with the given flags. This script is
 // considered to be dynamic, it can either return no value at all or return
 // exactly one value.
 func (v *VM) LoadDynamicScript(b []byte, f callflag.CallFlag) {
-	v.loadScriptWithCallingHash(b, nil, nil, v.GetCurrentScriptHash(), util.Uint160{}, f, -1, 0, DynamicOnUnload, false)
+	v.loadScriptWithCallingHash(b, nil, nil, v.GetCurrentScriptHash(), util.Uint160{}, f, -1, 0, DynamicOnUnload, nil, false)
 }
 
 // LoadScriptWithHash is similar to the LoadScriptWithFlags method, but it also loads
@@ -426,19 +426,19 @@ func (v *VM) LoadDynamicScript(b []byte, f callflag.CallFlag) {
 // accordingly). It's up to the user of this function to make sure the script and hash match
 // each other.
 func (v *VM) LoadScriptWithHash(b []byte, hash util.Uint160, f callflag.CallFlag) {
-	v.loadScriptWithCallingHash(b, nil, nil, v.GetCurrentScriptHash(), hash, f, 1, 0, nil, false)
+	v.loadScriptWithCallingHash(b, nil, nil, v.GetCurrentScriptHash(), hash, f, 1, 0, nil, nil, false)
 }
 
 // LoadNEFMethod allows to create a context to execute a method from the NEF
 // file with the specified caller and executing hash, call flags, return value,
 // method and _initialize offsets.
 func (v *VM) LoadNEFMethod(exe *nef.File, manifest *manifest.Manifest, caller util.Uint160, hash util.Uint160, f callflag.CallFlag,
-	hasReturn bool, methodOff int, initOff int, onContextUnload ContextUnloadCallback, whitelisted bool) {
+	hasReturn bool, methodOff int, initOff int, onContextUnload ContextUnloadCallback, onContextUnloaded ContextUnloadedCallback, whitelisted bool) {
 	var rvcount int
 	if hasReturn {
 		rvcount = 1
 	}
-	v.loadScriptWithCallingHash(exe.Script, exe, manifest, caller, hash, f, rvcount, methodOff, onContextUnload, whitelisted)
+	v.loadScriptWithCallingHash(exe.Script, exe, manifest, caller, hash, f, rvcount, methodOff, onContextUnload, onContextUnloaded, whitelisted)
 	if initOff >= 0 {
 		v.Call(initOff)
 	}
@@ -447,7 +447,7 @@ func (v *VM) LoadNEFMethod(exe *nef.File, manifest *manifest.Manifest, caller ut
 // loadScriptWithCallingHash is similar to LoadScriptWithHash but sets calling hash explicitly.
 // It should be used for calling from native contracts.
 func (v *VM) loadScriptWithCallingHash(b []byte, exe *nef.File, manifest *manifest.Manifest, caller util.Uint160,
-	hash util.Uint160, f callflag.CallFlag, rvcount int, offset int, onContextUnload ContextUnloadCallback, whitelisted bool) {
+	hash util.Uint160, f callflag.CallFlag, rvcount int, offset int, onContextUnload ContextUnloadCallback, onContextUnloaded ContextUnloadedCallback, whitelisted bool) {
 	v.checkInvocationStackSize()
 	ctx := NewContextWithParams(b, rvcount, offset)
 	parent := v.Context()
@@ -476,6 +476,7 @@ func (v *VM) loadScriptWithCallingHash(b []byte, exe *nef.File, manifest *manife
 		ctx.sc.invTree = newTree
 	}
 	ctx.sc.onUnload = onContextUnload
+	ctx.sc.onUnloaded = onContextUnloaded
 	v.istack = append(v.istack, ctx)
 }
 
@@ -1658,27 +1659,32 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 	case opcode.RET:
 		oldCtx := v.istack[len(v.istack)-1]
 		v.istack = v.istack[:len(v.istack)-1]
-		oldEstack := v.estack
-
-		v.unloadContext(oldCtx)
-		if len(v.istack) == 0 {
-			v.state = vmstate.Halt
-			break
+		oldEstack := oldCtx.Estack()
+		newEstack := v.estack
+		if len(v.istack) != 0 {
+			newEstack = v.Context().Estack()
 		}
 
-		newEstack := v.Context().sc.estack
-		if oldEstack != newEstack {
+		if len(v.istack) != 0 && oldEstack != newEstack {
 			if oldCtx.retCount >= 0 && oldEstack.Len() != oldCtx.retCount {
 				panic(fmt.Errorf("invalid return values count: expected %d, got %d",
 					oldCtx.retCount, oldEstack.Len()))
 			}
 			rvcount := oldEstack.Len()
 			for i := rvcount; i > 0; i-- {
-				elem := oldEstack.RemoveAt(i - 1)
-				newEstack.Push(elem)
+				// Do not modify the unloaded context's stack since v.unloadContext interacts with it (DynamicOnUnload tracks return values).
+				// Ref. https://github.com/neo-project/neo-vm/blob/ed0eb66359fd1d76ddb5be91cc5a703ddc714a18/src/Neo.VM/JumpTable/JumpTable.Control.cs#L540.
+				elem := oldEstack.Peek(i - 1)
+				// However, these items are already added to VM's refs in the old context, so
+				// there's no need to count them twice.
+				newEstack.pushNoRef(elem)
 			}
 			v.estack = newEstack
 		}
+		if len(v.istack) == 0 {
+			v.state = vmstate.Halt
+		}
+		v.unloadContext(oldCtx)
 
 	case opcode.NEWMAP:
 		v.estack.PushItem(stackitem.NewMap())
@@ -1858,6 +1864,12 @@ func (v *VM) unloadContext(ctx *Context) {
 				}
 				panic(errors.New(errMessage))
 			}
+		}
+		if ctx.sc.onUnloaded != nil {
+			if v.uncaughtException != nil {
+				panic(v.uncaughtException)
+			}
+			ctx.sc.onUnloaded(v)
 		}
 	}
 }


### PR DESCRIPTION
 Closes https://github.com/neo-project/neo/issues/4514 via the following refactoring:

1. Execute asynchronous calls from native contracts in a standard way via pushing new context to invocation stack without immediate nested execution as in ref.: https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/SmartContract/ApplicationEngine.cs#L587
2. Bind continuation of parent's context execution to the spawned child's context: https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/SmartContract/ApplicationEngine.cs#L602
3. Execute parent's continuation on the child's context unloading: https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/SmartContract/ApplicationEngine.cs#L635-L640

Refactor RET handler to make the scheme above work properly and to follow presizely the reference RET behaviour:

1. Firstly, pop unloaded context from istack and copy the return values to the parent's context. Fix NeoGo VM bug where values were POPped from the child's context instead of PEEKing: https://github.com/neo-project/neo-vm/blob/ed0eb66359fd1d76ddb5be91cc5a703ddc714a18/src/Neo.VM/JumpTable/JumpTable.Control.cs#L540
2. After that, execute context unloading callbacks: https://github.com/neo-project/neo-vm/blob/ed0eb66359fd1d76ddb5be91cc5a703ddc714a18/src/Neo.VM/JumpTable/JumpTable.Control.cs#L544