### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/pkg/vm/emit/emit.go
+++ b/pkg/vm/emit/emit.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/bits"
+	"slices"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/interop/interopnames"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/bigint"
@@ -118,8 +119,8 @@ func Array(w *io.BinWriter, es ...any) {
 		Opcodes(w, opcode.NEWARRAY0)
 		return
 	}
-	for i := len(es) - 1; i >= 0; i-- {
-		Any(w, es[i])
+	for _, v := range slices.Backward(es) {
+		Any(w, v)
 	}
 	Int(w, int64(len(es)))
 	Opcodes(w, opcode.PACK)
@@ -235,17 +236,17 @@ func StackItem(w *io.BinWriter, si stackitem.Item) {
 		Array(w, arrAny...)
 	case stackitem.StructT:
 		arr := si.Value().([]stackitem.Item)
-		for i := len(arr) - 1; i >= 0; i-- {
-			StackItem(w, arr[i])
+		for _, v := range slices.Backward(arr) {
+			StackItem(w, v)
 		}
 
 		Int(w, int64(len(arr)))
 		Opcodes(w, opcode.PACKSTRUCT)
 	case stackitem.MapT:
 		arr := si.Value().([]stackitem.MapElement)
-		for i := len(arr) - 1; i >= 0; i-- {
-			StackItem(w, arr[i].Value)
-			StackItem(w, arr[i].Key)
+		for _, v := range slices.Backward(arr) {
+			StackItem(w, v.Value)
+			StackItem(w, v.Key)
 		}
 
 		Int(w, int64(len(arr)))

--- a/pkg/vm/stack.go
+++ b/pkg/vm/stack.go
@@ -269,8 +269,8 @@ func (s *Stack) Dup(n int) Element {
 //		// do something with the element.
 //	})
 func (s *Stack) Iter(f func(Element)) {
-	for i := len(s.elems) - 1; i >= 0; i-- {
-		f(s.elems[i])
+	for _, v := range slices.Backward(s.elems) {
+		f(v)
 	}
 }
 

--- a/pkg/vm/stack_test.go
+++ b/pkg/vm/stack_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"math/big"
+	"slices"
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
@@ -46,8 +47,8 @@ func TestPopElement(t *testing.T) {
 		s.Push(elem)
 	}
 
-	for i := len(elems) - 1; i >= 0; i-- {
-		assert.Equal(t, elems[i], s.Pop())
+	for i, v := range slices.Backward(elems) {
+		assert.Equal(t, v, s.Pop())
 		assert.Equal(t, i, s.Len())
 	}
 }
@@ -60,8 +61,8 @@ func TestPeekElement(t *testing.T) {
 	for _, elem := range elems {
 		s.Push(elem)
 	}
-	for i := len(elems) - 1; i >= 0; i-- {
-		assert.Equal(t, elems[i], s.Peek(len(elems)-i-1))
+	for i, v := range slices.Backward(elems) {
+		assert.Equal(t, v, s.Peek(len(elems)-i-1))
 	}
 }
 


### PR DESCRIPTION
### Problem

There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899


### Solution

...
