### PR TITLE
config: set MaxTransactionsPerBlock to 200 for N3 mainnet

### DIFF
--- a/config/protocol.mainnet.yml
+++ b/config/protocol.mainnet.yml
@@ -2,6 +2,7 @@ ProtocolConfiguration:
   Magic: 860833102
   MaxBlockSystemFee: 2000000000
   MaxTraceableBlocks: 2102400
+  MaxTransactionsPerBlock: 200
   InitialGASSupply: 52000000
   TimePerBlock: 15s
   Genesis:


### PR DESCRIPTION
Ref.
https://neonewstoday.com/governance/neo-council-approves-3-second-block-time-defers-fee-reduction-to-gorgon-hard-fork/, ref. https://github.com/neo-project/neo-node/pull/1029. The default value will not be changed.