### PR TITLE
native: update Management's cache before contract block

### DIFF
--- a/pkg/core/native/management.go
+++ b/pkg/core/native/management.go
@@ -535,8 +535,8 @@ func (m *Management) Destroy(ic *interop.Context, hash util.Uint160) (*state.Con
 		ic.DAO.DeleteStorageItem(contract.ID, k)
 		return true
 	})
-	m.Policy.BlockAccountInternal(ic, hash)
 	markUpdated(ic.DAO, m.ID, hash, nil)
+	m.Policy.BlockAccountInternal(ic, hash)
 	return contract, nil
 }
 

--- a/pkg/core/native/native_test/management_test.go
+++ b/pkg/core/native/native_test/management_test.go
@@ -1273,3 +1273,89 @@ func TestManagement_WhitelistedUpdate(t *testing.T) {
 		}),
 	})
 }
+
+func TestManagement_VotingContractDestroy(t *testing.T) {
+	c := newManagementClient(t)
+	neoCommitteeInvoker := c.CommitteeInvoker(nativehashes.NeoToken)
+	neoValidatorsInvoker := c.ValidatorInvoker(nativehashes.NeoToken)
+
+	// Elect the new committee.
+	candidates := electNewCommittee(t, c.Executor, neoCommitteeInvoker, neoValidatorsInvoker)
+	candidate := candidates[0].(neotest.SingleSigner).Account().PublicKey().Bytes()
+
+	// Create a destroyable contract with onNEP17Payment method.
+	src := `package votingcontract
+	  import (
+          "github.com/nspcc-dev/neo-go/pkg/interop/native/management"
+		  "github.com/nspcc-dev/neo-go/pkg/interop"
+          "github.com/nspcc-dev/neo-go/pkg/interop/runtime"
+	  )
+      func Verify() bool {
+          return true
+      }
+      func Destroy() {
+          management.Destroy()
+      }
+      func OnNEP17Payment(from interop.Hash160, amount int, data any) {
+          token := runtime.GetCallingScriptHash()
+          runtime.Notify("OnNEP17Payment", token, from)
+      }`
+	ctr := neotest.CompileSource(t, c.Validator.ScriptHash(), strings.NewReader(src), &compiler.Options{
+		Name: "votingcontract",
+		ContractEvents: []compiler.HybridEvent{
+			{
+				Name: "OnNEP17Payment",
+				Parameters: []compiler.HybridParameter{
+					{Parameter: manifest.Parameter{Name: "token", Type: smartcontract.Hash160Type}},
+					{Parameter: manifest.Parameter{Name: "from", Type: smartcontract.Hash160Type}},
+				},
+			},
+		},
+		Permissions: []manifest.Permission{{Methods: manifest.WildStrings{Value: []string{"destroy"}}}},
+	})
+	c.DeployContract(t, ctr, nil)
+	ctrInv := c.CommitteeInvoker(ctr.Hash)
+
+	// Transfer some NEO to the contract and vote from the contract account for the candidate.
+	const balance = 1_000_000
+	neoCommitteeContractInvoker := &neotest.ContractInvoker{
+		Executor: c.Executor,
+		Hash:     nativehashes.NeoToken,
+		Signers: []neotest.Signer{c.Committee, neotest.NewContractSigner(ctr.Hash, func(tx *transaction.Transaction) []any {
+			return nil
+		})}}
+	neoCommitteeInvoker.Invoke(t, true, "transfer", c.Committee.ScriptHash(), ctr.Hash, balance, nil)
+	neoCommitteeContractInvoker.Invoke(t, true, "vote", ctr.Hash, candidate)
+
+	// Generate some blocks to earn some GAS for the contract.
+	c.GenerateNewBlocks(t, 5)
+
+	// Destroy contract and trigger unvoting and unclaimed GAS payment with a subsequent call to onNEP17Payment.
+	h := ctrInv.Invoke(t, stackitem.Null{}, "destroy")
+
+	// Check there's no onNEP17Payment notification emitted since the contract is marked as destroyed by this moment.
+	c.CheckTxNotificationEvents(t, h, []state.NotificationEvent{{
+		Name:       "Vote", // revoke votes on block.
+		ScriptHash: nativehashes.NeoToken,
+		Item: stackitem.NewArray([]stackitem.Item{
+			stackitem.Make(ctr.Hash),
+			stackitem.Make(candidate),
+			stackitem.Null{},
+			stackitem.Make(balance),
+		}),
+	}, {
+		Name:       "Transfer", // mint earned GAS.
+		ScriptHash: nativehashes.GasToken,
+		Item: stackitem.NewArray([]stackitem.Item{
+			stackitem.Null{},
+			stackitem.Make(ctr.Hash),
+			stackitem.Make(3_000_000),
+		}),
+	}, {
+		Name:       "Destroy", // destroy contract.
+		ScriptHash: nativehashes.ContractManagement,
+		Item: stackitem.NewArray([]stackitem.Item{
+			stackitem.Make(ctr.Hash),
+		}),
+	}})
+}

--- a/pkg/core/native/native_test/neo_test.go
+++ b/pkg/core/native/native_test/neo_test.go
@@ -130,11 +130,10 @@ func TestNEO_CandidateEvents(t *testing.T) {
 	require.Equal(t, 0, len(aer.Events))
 }
 
-func TestNEO_CommitteeEvents(t *testing.T) {
-	neoCommitteeInvoker := newNeoCommitteeClient(t, 100_0000_0000)
-	neoValidatorsInvoker := neoCommitteeInvoker.WithSigners(neoCommitteeInvoker.Validator)
-	e := neoCommitteeInvoker.Executor
-
+// electNewCommittee registers a set of accounts as candidates and votes for
+// them so that they are elected as the new committee. It returns a set of
+// candidates.
+func electNewCommittee(t *testing.T, e *neotest.Executor, neoCommitteeInvoker, neoValidatorsInvoker *neotest.ContractInvoker) []neotest.Signer {
 	cfg := e.Chain.GetConfig()
 	committeeSize := cfg.GetCommitteeSize(0)
 
@@ -164,6 +163,18 @@ func TestNEO_CommitteeEvents(t *testing.T) {
 	for (block.Index)%uint32(committeeSize) != 0 {
 		block = neoCommitteeInvoker.AddNewBlock(t)
 	}
+
+	return candidates
+}
+
+func TestNEO_CommitteeEvents(t *testing.T) {
+	neoCommitteeInvoker := newNeoCommitteeClient(t, 100_0000_0000)
+	neoValidatorsInvoker := neoCommitteeInvoker.WithSigners(neoCommitteeInvoker.Validator)
+	e := neoCommitteeInvoker.Executor
+
+	cfg := e.Chain.GetConfig()
+	committeeSize := cfg.GetCommitteeSize(0)
+	candidates := electNewCommittee(t, e, neoCommitteeInvoker, neoValidatorsInvoker)
 
 	// Check for CommitteeChanged event in the last persisted block's AER.
 	blockHash := e.Chain.CurrentBlockHash()

--- a/pkg/neotest/basic.go
+++ b/pkg/neotest/basic.go
@@ -258,6 +258,17 @@ func (e *Executor) CheckFault(t testing.TB, h util.Uint256, s string) {
 		"expected: %s, got: %s", s, aer[0].FaultException)
 }
 
+// CheckTxNotificationEvents checks that the specified events were emitted
+// during transaction script execution.
+func (e *Executor) CheckTxNotificationEvents(t testing.TB, h util.Uint256, expected []state.NotificationEvent) {
+	aer, err := e.Chain.GetAppExecResults(h, trigger.Application)
+	require.NoError(t, err)
+	require.Equal(t, len(expected), len(aer[0].Events))
+	for i, ev := range expected {
+		require.Equal(t, ev, aer[0].Events[i], i)
+	}
+}
+
 // CheckTxNotificationEvent checks that the specified event was emitted at the specified position
 // during transaction script execution. Negative index corresponds to backwards enumeration.
 func (e *Executor) CheckTxNotificationEvent(t testing.TB, h util.Uint256, index int, expected state.NotificationEvent) {


### PR DESCRIPTION
Update native Management's cache prior to contract account blocking on contruct destruction. Startign from
https://github.com/neo-project/neo/pull/4347, account blocking implies votes revoking which may lead to a GAS transfer. If the reciever is a contract supporting onNEP17Payment, the order of cache update and account blocking is important.

Follow
https://github.com/neo-project/neo/blob/43e66b82751bbc7f84689a68f4991b274174ddb5/src/Neo/SmartContract/Native/ContractManagement.cs#L300. Should be a part of https://github.com/nspcc-dev/neo-go/pull/4115.