### PR TITLE
fix(native/ledger): return null from `getBlock` for out-of-range index

### DIFF
--- a/pkg/core/native/ledger.go
+++ b/pkg/core/native/ledger.go
@@ -122,7 +122,13 @@ func (l *Ledger) currentIndex(ic *interop.Context, _ []stackitem.Item) stackitem
 
 // getBlock implements getBlock SC method.
 func (l *Ledger) getBlock(ic *interop.Context, params []stackitem.Item) stackitem.Item {
-	hash := getBlockHashFromItem(ic, params[0])
+	hash, ok := tryBlockHashFromItem(ic, params[0])
+	if !ok {
+		// Match C# Neo: a valid integer index that is beyond the
+		// current chain height yields null, not FAULT. See
+		// https://github.com/nspcc-dev/neo-go/issues/4229.
+		return stackitem.Null{}
+	}
 	block, err := ic.GetBlock(hash)
 	if err != nil || !l.isTraceableBlock(ic, block.Index) {
 		return stackitem.Null{}
@@ -194,6 +200,29 @@ func (l *Ledger) isTraceableBlock(ic *interop.Context, index uint32) bool {
 		maxTraceableBlocks = l.Policy.GetMaxTraceableBlocksInternal(ic.DAO)
 	}
 	return index <= height && index+maxTraceableBlocks > height
+}
+
+// tryBlockHashFromItem is like getBlockHashFromItem but signals an
+// out-of-range integer index with ok=false instead of panicking, so
+// callers that want to emulate C# Neo's "return null" semantics (see
+// issue #4229) can do so without catching panics.
+func tryBlockHashFromItem(ic *interop.Context, item stackitem.Item) (util.Uint256, bool) {
+	bigindex, err := item.TryInteger()
+	if err == nil && bigindex.IsUint64() {
+		index := bigindex.Uint64()
+		if index > math.MaxUint32 {
+			panic("bad block index")
+		}
+		if uint32(index) > ic.BlockHeight() {
+			return util.Uint256{}, false
+		}
+		return ic.Chain.GetHeaderHash(uint32(index)), true
+	}
+	hash, err := getUint256FromItem(item)
+	if err != nil {
+		panic(err)
+	}
+	return hash, true
 }
 
 // getBlockHashFromItem converts the given stackitem.Item to a block hash using the given


### PR DESCRIPTION
Closes #4229.

## Problem

`LedgerContract.getBlock` called with an integer index greater than the current chain height panicked (FAULT), while the reference C# node returns `null` and HALTs — reproducible against `rpc10.n3.nspcc.ru` with `{"type":"Integer","value":"10000000"}`:

```
"exception": "at instruction 15 (SYSCALL): no block with index 10000000"
```

vs. C#:

```
"state": "HALT",
"stack": [{"type": "Any"}]
```

The culprit is `getBlockHashFromItem`, whose integer path unconditionally panics with `no block with index N`.

## Fix

Add `tryBlockHashFromItem` — same logic as `getBlockHashFromItem` but returns `(util.Uint256{}, false)` instead of panicking on an out-of-range integer index. `Ledger.getBlock` uses the new helper and short-circuits to `stackitem.Null{}` on the false branch, matching C#.

`getBlockHashFromItem` and its other caller (`getTransactionFromBlock`) are untouched — `getTransactionFromBlock`'s semantics differ (the index is required to refer to a real block, so a panic-on-missing behavior is a fair invariant to keep), so scoping this PR to `getBlock` avoids changing other native-method behaviour.

Malformed hash bytes still panic in both paths — that indicates a genuine caller bug, not a runtime-observable "block does not exist" state.

## Tests

`go build ./pkg/core/native/...` clean; native-package tests still green. Full integration test that hits the RPC endpoint would need a chain, which I can't run locally; happy to add a targeted unit test if there's a preferred spot.