### PR TITLE
core, vm: fix RC diff for FAULT-ed mainnet transactions

### DIFF
--- a/pkg/core/interop/contract/call.go
+++ b/pkg/core/interop/contract/call.go
@@ -53,16 +53,16 @@ func LoadToken(ic *interop.Context, id int32) error {
 // Call calls a contract with flags.
 func Call(ic *interop.Context) error {
 	h := ic.VM.Estack().Pop().Bytes()
+	u, err := util.Uint160DecodeBytesBE(h)
+	if err != nil {
+		return errors.New("invalid contract hash")
+	}
 	method := ic.VM.Estack().Pop().String()
 	fs := callflag.CallFlag(int32(ic.VM.Estack().Pop().BigInt().Int64()))
 	if fs&^callflag.All != 0 {
 		return errors.New("call flags out of range")
 	}
 	args := ic.VM.Estack().Pop().Array()
-	u, err := util.Uint160DecodeBytesBE(h)
-	if err != nil {
-		return errors.New("invalid contract hash")
-	}
 	cs, err := ic.GetContract(u)
 	if err != nil {
 		return fmt.Errorf("called contract %s not found: %w", u.StringLE(), err)

--- a/pkg/core/interop/contract/call_test.go
+++ b/pkg/core/interop/contract/call_test.go
@@ -172,6 +172,17 @@ func TestCall(t *testing.T) {
 		require.Equal(t, big.NewInt(8), ic.VM.Estack().Pop().Value())
 		require.Equal(t, big.NewInt(42), ic.VM.Estack().Pop().Value())
 	})
+
+	t.Run("RC with wrong args", func(t *testing.T) {
+		ic.VM.Reset(trigger.Application)
+		ic.VM.Estack().PushVal("method")
+		ic.VM.Estack().PushVal([]byte{1, 2, 3}) // not a hash.
+		require.ErrorContains(t, contract.Call(ic), "invalid contract hash")
+
+		// Ensure no additional arguments are POP-ed from the stack since it affects the resulting RC.
+		require.Equal(t, 1, ic.VM.Estack().Len())
+		require.Equal(t, stackitem.Make("method"), ic.VM.Estack().Pop().Item())
+	})
 }
 
 func TestSystemContractCall_Permissions(t *testing.T) {

--- a/pkg/core/interop/crypto/ecdsa.go
+++ b/pkg/core/interop/crypto/ecdsa.go
@@ -20,12 +20,12 @@ func ECDSASecp256r1CheckMultisig(ic *interop.Context) error {
 	if err != nil {
 		return fmt.Errorf("wrong key parameters: %w", err)
 	}
-	if err := ic.VM.AddPicoGas(ic.BaseExecFee() * fee.ECDSAVerifyPrice * int64(len(pkeys))); err != nil {
-		return err
-	}
 	sigs, err := ic.VM.Estack().PopSigElements()
 	if err != nil {
 		return fmt.Errorf("wrong signature parameters: %w", err)
+	}
+	if err := ic.VM.AddPicoGas(ic.BaseExecFee() * fee.ECDSAVerifyPrice * int64(len(pkeys))); err != nil {
+		return err
 	}
 	// It's ok to have more keys than there are signatures (it would
 	// just mean that some keys didn't sign), but not the other way around.

--- a/pkg/core/interop/storage/basic.go
+++ b/pkg/core/interop/storage/basic.go
@@ -18,45 +18,45 @@ type Context struct {
 	ReadOnly bool
 }
 
-func deleteWithContext(ic *interop.Context, stc *Context) {
-	key := ic.VM.Estack().Pop().Bytes()
-	ic.DAO.DeleteStorageItem(stc.ID, key)
-}
-
-// storageDelete deletes stored key-value pair.
+// Delete deletes stored key-value pair.
 func Delete(ic *interop.Context) error {
 	stcInterface := ic.VM.Estack().Pop().Value()
 	stc, ok := stcInterface.(*Context)
 	if !ok {
 		return fmt.Errorf("%T is not a storage.Context", stcInterface)
 	}
+	key := ic.VM.Estack().Pop().Bytes()
 	if stc.ReadOnly {
 		return errors.New("storage.Context is read only")
 	}
-	deleteWithContext(ic, stc)
+	ic.DAO.DeleteStorageItem(stc.ID, key)
 	return nil
 }
 
 // LocalDelete is similar to Delete, but does not require storage context.
 func LocalDelete(ic *interop.Context) error {
+	key := ic.VM.Estack().Pop().Bytes()
 	contract, err := ic.GetContract(ic.VM.GetCurrentScriptHash())
 	if err != nil {
 		return fmt.Errorf("storage context can not be retrieved in dynamic scripts: %w", err)
 	}
-	deleteWithContext(ic, &Context{
-		ID: contract.ID,
-	})
+	ic.DAO.DeleteStorageItem(contract.ID, key)
 	return nil
 }
 
-func getWithContext(ic *interop.Context, stc *Context) {
+func get(ic *interop.Context, getID func(ic *interop.Context) (int32, error)) error {
 	key := ic.VM.Estack().Pop().Bytes()
-	si := ic.DAO.GetStorageItem(stc.ID, key)
+	id, err := getID(ic)
+	if err != nil {
+		return err
+	}
+	si := ic.DAO.GetStorageItem(id, key)
 	if si != nil {
 		ic.VM.Estack().PushItem(stackitem.NewByteArray([]byte(si)))
 	} else {
 		ic.VM.Estack().PushItem(stackitem.Null{})
 	}
+	return nil
 }
 
 // Get returns stored key-value pair.
@@ -66,21 +66,20 @@ func Get(ic *interop.Context) error {
 	if !ok {
 		return fmt.Errorf("%T is not a storage.Context", stcInterface)
 	}
-	getWithContext(ic, stc)
-	return nil
+	return get(ic, func(ic *interop.Context) (int32, error) {
+		return stc.ID, nil
+	})
 }
 
 // LocalGet is similar to Get, but does not require storage context.
 func LocalGet(ic *interop.Context) error {
-	contract, err := ic.GetContract(ic.VM.GetCurrentScriptHash())
-	if err != nil {
-		return fmt.Errorf("storage context can not be retrieved in dynamic scripts: %w", err)
-	}
-	getWithContext(ic, &Context{
-		ID:       contract.ID,
-		ReadOnly: true,
+	return get(ic, func(ic *interop.Context) (int32, error) {
+		contract, err := ic.GetContract(ic.VM.GetCurrentScriptHash())
+		if err != nil {
+			return 0, fmt.Errorf("storage context can not be retrieved in dynamic scripts: %w", err)
+		}
+		return contract.ID, nil
 	})
-	return nil
 }
 
 // GetContext returns storage context for the currently executing contract.
@@ -150,12 +149,12 @@ func Put(ic *interop.Context) error {
 
 // LocalPut is similar to Put, but does not require storage context.
 func LocalPut(ic *interop.Context) error {
+	key := ic.VM.Estack().Pop().Bytes()
+	value := ic.VM.Estack().Pop().Bytes()
 	contract, err := ic.GetContract(ic.VM.GetCurrentScriptHash())
 	if err != nil {
 		return fmt.Errorf("storage context can not be retrieved in dynamic scripts: %w", err)
 	}
-	key := ic.VM.Estack().Pop().Bytes()
-	value := ic.VM.Estack().Pop().Bytes()
 	return putWithContext(ic, &Context{
 		ID: contract.ID,
 	}, key, value)

--- a/pkg/core/interop/storage/find.go
+++ b/pkg/core/interop/storage/find.go
@@ -90,9 +90,16 @@ func (s *Iterator) Value() stackitem.Item {
 	})
 }
 
-func findWithContext(ic *interop.Context, stc *Context) error {
+func findWithContext(ic *interop.Context, stc *Context, getID ...func(ic *interop.Context) (int32, error)) error {
 	prefix := ic.VM.Estack().Pop().Bytes()
 	opts := ic.VM.Estack().Pop().BigInt().Int64()
+	if len(getID) > 0 {
+		var err error
+		stc.ID, err = getID[0](ic)
+		if err != nil {
+			return err
+		}
+	}
 	if opts&^FindAll != 0 {
 		return fmt.Errorf("%w: unknown flag", errFindInvalidOptions)
 	}
@@ -139,12 +146,12 @@ func Find(ic *interop.Context) error {
 
 // LocalFind is similar to Find, but does not require storage context.
 func LocalFind(ic *interop.Context) error {
-	contract, err := ic.GetContract(ic.VM.GetCurrentScriptHash())
-	if err != nil {
-		return fmt.Errorf("storage context can not be retrieved in dynamic scripts: %w", err)
-	}
-	return findWithContext(ic, &Context{
-		ID:       contract.ID,
-		ReadOnly: true,
+	return findWithContext(ic, &Context{ReadOnly: true}, func(ic *interop.Context) (int32, error) {
+		contract, err := ic.GetContract(ic.VM.GetCurrentScriptHash())
+		if err != nil {
+			return 0, fmt.Errorf("storage context can not be retrieved in dynamic scripts: %w", err)
+		}
+
+		return contract.ID, nil
 	})
 }

--- a/pkg/core/interop/storage/storage_test.go
+++ b/pkg/core/interop/storage/storage_test.go
@@ -384,9 +384,20 @@ func TestStorage_LocalInteropAPI(t *testing.T) {
 	ctrInvoker.Invoke(t, stackitem.Make(false), "localFind")
 }
 
-func TestStorage_LocalErrors(t *testing.T) {
-	_, ic, _ := createVM(t)
-	for _, f := range []func(*interop.Context) error{istorage.LocalDelete, istorage.LocalFind, istorage.LocalGet, istorage.LocalPut} {
-		require.Contains(t, f(ic).Error(), "storage context can not be retrieved in dynamic scripts")
-	}
+func TestLocal_Errors(t *testing.T) {
+	v, ic, _ := createVM(t)
+
+	v.Estack().PushVal([]byte{1})
+	require.ErrorContains(t, istorage.LocalDelete(ic), "storage context can not be retrieved in dynamic scripts")
+
+	v.Estack().PushVal([]byte{1})
+	require.ErrorContains(t, istorage.LocalGet(ic), "storage context can not be retrieved in dynamic scripts")
+
+	v.Estack().PushVal([]byte{1})
+	v.Estack().PushVal([]byte{2})
+	require.ErrorContains(t, istorage.LocalPut(ic), "storage context can not be retrieved in dynamic scripts")
+
+	v.Estack().PushVal([]byte{1})
+	v.Estack().PushVal(1)
+	require.ErrorContains(t, istorage.LocalFind(ic), "storage context can not be retrieved in dynamic scripts")
 }

--- a/pkg/vm/slot.go
+++ b/pkg/vm/slot.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
@@ -32,19 +33,16 @@ func (s *Slot) initFromStack(n int, t *Stack) {
 	}
 }
 
-// set sets i-th storage slot.
-func (s Slot) set(i int, item stackitem.Item, refs *refCounter) {
-	if s[i] == item {
-		return
+// store stores the top element from the stack into the i-th slot. It modifies
+// the reference counter accordingly.
+func (s Slot) store(stack *Stack, i int, refs *refCounter) {
+	if s == nil {
+		panic("slot is not initialized")
 	}
-	s.setNoRef(i, item, refs)
-	refs.Add(item)
-}
-
-// setNoRef sets i-th storage slot, but doesn't add it to the reference counter.
-// Notice that the old item is deleted anyway, hence refs passed. Be
-// super-careful when using it.
-func (s Slot) setNoRef(i int, item stackitem.Item, refs *refCounter) {
+	if i < 0 || i >= len(s) {
+		panic(fmt.Errorf("slot index is out of range: %d with length %d", i, len(s)))
+	}
+	item := stack.popNoRef().Item()
 	refs.Remove(s[i])
 	s[i] = item
 }

--- a/pkg/vm/slot_test.go
+++ b/pkg/vm/slot_test.go
@@ -21,7 +21,9 @@ func TestSlot_Get(t *testing.T) {
 	item := s.Get(2)
 	require.Equal(t, stackitem.Null{}, item)
 
-	s.set(1, stackitem.NewBigInteger(big.NewInt(42)), rc)
+	stack := newStack("estack", rc)
+	stack.PushVal(stackitem.NewBigInteger(big.NewInt(42)))
+	s.store(stack, 1, rc)
 	require.Equal(t, stackitem.NewBigInteger(big.NewInt(42)), s.Get(1))
 	require.Equal(t, 3, int(*rc))
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -786,12 +786,10 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 		v.estack.PushItem(item)
 
 	case opcode.STSFLD0, opcode.STSFLD1, opcode.STSFLD2, opcode.STSFLD3, opcode.STSFLD4, opcode.STSFLD5, opcode.STSFLD6:
-		item := v.estack.popNoRef().Item()
-		ctx.sc.static.setNoRef(int(op-opcode.STSFLD0), item, &v.refs)
+		ctx.sc.static.store(v.estack, int(op-opcode.STSFLD0), &v.refs)
 
 	case opcode.STSFLD:
-		item := v.estack.popNoRef().Item()
-		ctx.sc.static.setNoRef(int(parameter[0]), item, &v.refs)
+		ctx.sc.static.store(v.estack, int(parameter[0]), &v.refs)
 
 	case opcode.LDLOC0, opcode.LDLOC1, opcode.LDLOC2, opcode.LDLOC3, opcode.LDLOC4, opcode.LDLOC5, opcode.LDLOC6:
 		item := ctx.local.Get(int(op - opcode.LDLOC0))
@@ -802,12 +800,10 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 		v.estack.PushItem(item)
 
 	case opcode.STLOC0, opcode.STLOC1, opcode.STLOC2, opcode.STLOC3, opcode.STLOC4, opcode.STLOC5, opcode.STLOC6:
-		item := v.estack.popNoRef().Item()
-		ctx.local.setNoRef(int(op-opcode.STLOC0), item, &v.refs)
+		ctx.local.store(v.estack, int(op-opcode.STLOC0), &v.refs)
 
 	case opcode.STLOC:
-		item := v.estack.popNoRef().Item()
-		ctx.local.setNoRef(int(parameter[0]), item, &v.refs)
+		ctx.local.store(v.estack, int(parameter[0]), &v.refs)
 
 	case opcode.LDARG0, opcode.LDARG1, opcode.LDARG2, opcode.LDARG3, opcode.LDARG4, opcode.LDARG5, opcode.LDARG6:
 		item := ctx.arguments.Get(int(op - opcode.LDARG0))
@@ -818,12 +814,10 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 		v.estack.PushItem(item)
 
 	case opcode.STARG0, opcode.STARG1, opcode.STARG2, opcode.STARG3, opcode.STARG4, opcode.STARG5, opcode.STARG6:
-		item := v.estack.popNoRef().Item()
-		ctx.arguments.setNoRef(int(op-opcode.STARG0), item, &v.refs)
+		ctx.arguments.store(v.estack, int(op-opcode.STARG0), &v.refs)
 
 	case opcode.STARG:
-		item := v.estack.popNoRef().Item()
-		ctx.arguments.setNoRef(int(parameter[0]), item, &v.refs)
+		ctx.arguments.store(v.estack, int(parameter[0]), &v.refs)
 
 	case opcode.NEWBUFFER:
 		n := toInt(v.estack.Pop().BigInt())


### PR DESCRIPTION
### Problem

41 FAULT-ed mainnet transactions causing RC diff (comparing to the C# node). Required for https://github.com/nspcc-dev/neo-go/pull/4219.

### Solution

Merge.
