### PR TITLE
cli: make `contract [test]invokefunction` accept native contract name

### DIFF
--- a/cli/smartcontract/contract_test.go
+++ b/cli/smartcontract/contract_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nspcc-dev/neo-go/internal/versionutil"
 	"github.com/nspcc-dev/neo-go/pkg/config"
 	"github.com/nspcc-dev/neo-go/pkg/core/interop/storage"
+	"github.com/nspcc-dev/neo-go/pkg/core/native/nativenames"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
@@ -1008,11 +1009,22 @@ func TestComlileAndInvokeFunction(t *testing.T) {
 
 	cmd := []string{"neo-go", "contract", "testinvokefunction",
 		"--rpc-endpoint", "http://" + e.RPC.Addresses()[0]}
+	checkGetValueOut := func(expected any) {
+		res := new(result.Invoke)
+		require.NoError(t, json.Unmarshal(e.Out.Bytes(), res))
+		require.Equal(t, vmstate.Halt.String(), res.State, res.FaultException)
+		require.Len(t, res.Stack, 1)
+		require.Equal(t, expected, res.Stack[0].Value())
+	}
 	t.Run("missing hash", func(t *testing.T) {
 		e.RunWithError(t, cmd...)
 	})
 	t.Run("invalid hash", func(t *testing.T) {
 		e.RunWithError(t, append(cmd, "notahash")...)
+	})
+	t.Run("native hash", func(t *testing.T) {
+		e.Run(t, append(cmd, nativenames.Policy, "getFeePerByte")...)
+		checkGetValueOut(big.NewInt(1000))
 	})
 
 	cmd = append(cmd, h.StringLE())
@@ -1033,15 +1045,7 @@ func TestComlileAndInvokeFunction(t *testing.T) {
 	})
 
 	e.Run(t, cmd...)
-
-	checkGetValueOut := func(str string) {
-		res := new(result.Invoke)
-		require.NoError(t, json.Unmarshal(e.Out.Bytes(), res))
-		require.Equal(t, vmstate.Halt.String(), res.State, res.FaultException)
-		require.Len(t, res.Stack, 1)
-		require.Equal(t, []byte(str), res.Stack[0].Value())
-	}
-	checkGetValueOut("on create|sub create")
+	checkGetValueOut([]byte("on create|sub create"))
 
 	// deploy verification contract
 	hVerify := deployVerifyContract(t, e)
@@ -1266,7 +1270,7 @@ func TestComlileAndInvokeFunction(t *testing.T) {
 		e.Run(t, "neo-go", "contract", "testinvokefunction",
 			"--rpc-endpoint", "http://"+e.RPC.Addresses()[0],
 			h.StringLE(), "getValue")
-		checkGetValueOut("on update|sub update")
+		checkGetValueOut([]byte("on update|sub update"))
 	})
 	t.Run("historic", func(t *testing.T) {
 		t.Run("bad ref", func(t *testing.T) {
@@ -1286,14 +1290,14 @@ func TestComlileAndInvokeFunction(t *testing.T) {
 					"--historic", ref,
 					h.StringLE(), "getValue")
 			})
-			checkGetValueOut("on create|sub create")
+			checkGetValueOut([]byte("on create|sub create"))
 		}
 		t.Run("updated historic", func(t *testing.T) {
 			e.Run(t, "neo-go", "contract", "testinvokefunction",
 				"--rpc-endpoint", "http://"+e.RPC.Addresses()[0],
 				"--historic", strconv.FormatUint(uint64(indexAfterUpdate), 10),
 				h.StringLE(), "getValue")
-			checkGetValueOut("on update|sub update")
+			checkGetValueOut([]byte("on update|sub update"))
 		})
 	})
 }

--- a/cli/smartcontract/smart_contract.go
+++ b/cli/smartcontract/smart_contract.go
@@ -14,6 +14,8 @@ import (
 	"github.com/nspcc-dev/neo-go/cli/options"
 	"github.com/nspcc-dev/neo-go/cli/txctx"
 	"github.com/nspcc-dev/neo-go/pkg/compiler"
+	"github.com/nspcc-dev/neo-go/pkg/core/native/nativehashes"
+	"github.com/nspcc-dev/neo-go/pkg/core/native/nativenames"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/neorpc/result"
@@ -267,7 +269,8 @@ func NewCommands() []*cli.Command {
 				Name:      "invokefunction",
 				Usage:     "Invoke deployed contract on the blockchain",
 				UsageText: "neo-go contract invokefunction -r endpoint -w wallet [-a address] [-g gas] [-e sysgas] [--out file] [--force] [--await] scripthash [method] [arguments...] [--] [signers...]",
-				Description: `Executes given (as a script hash) deployed script with the given method,
+				Description: `Executes given (as a script hash or case-insensitive full or shortened native
+   contract name, e.g. NeoToken, NEO, Neo, neo) deployed script with the given method,
    arguments and signers. Sender is included in the list of signers by default
    with None witness scope. If you'd like to change default sender's scope, 
    specify it via signers parameter. See testinvokefunction documentation for 
@@ -282,7 +285,8 @@ func NewCommands() []*cli.Command {
 				Name:      "testinvokefunction",
 				Usage:     "Invoke deployed contract on the blockchain (test mode)",
 				UsageText: "neo-go contract testinvokefunction -r endpoint [--historic index/hash] scripthash [method] [arguments...] [--] [signers...]",
-				Description: `Executes given (as a script hash) deployed script with the given method,
+				Description: `Executes given (as a script hash or case-insensitive full or shortened native
+   contract name, e.g. NeoToken, NEO, Neo, neo) deployed script with the given method,
    arguments and signers (sender is not included by default). If no method is given
    "" is passed to the script, if no arguments are given, an empty array is 
    passed, if no signers are given no array is passed. If signers are specified,
@@ -603,9 +607,13 @@ func invokeInternal(ctx *cli.Context, signAndPush bool) error {
 		return cli.Exit(errNoScriptHash, 1)
 	}
 	argsSlice := args.Slice()
-	script, err := flags.ParseAddress(argsSlice[0])
+	hashOrName := argsSlice[0]
+	script, err := flags.ParseAddress(hashOrName)
 	if err != nil {
-		return cli.Exit(fmt.Errorf("incorrect script hash: %w", err), 1)
+		script, err = nativeHash(hashOrName)
+		if err != nil {
+			return cli.Exit(fmt.Errorf("incorrect script hash or invalid native contract name: %w", err), 1)
+		}
 	}
 	if len(argsSlice) <= 1 {
 		return cli.Exit(errNoMethod, 1)
@@ -990,4 +998,33 @@ func cloneFlag(p *cli.StringFlag, required bool) *cli.StringFlag {
 	f := *p
 	f.Required = required
 	return &f
+}
+
+func nativeHash(name string) (util.Uint160, error) {
+	switch strings.ToLower(name) {
+	case strings.ToLower(nativenames.Management), "management":
+		return nativehashes.ContractManagement, nil
+	case strings.ToLower(nativenames.Ledger), "ledger":
+		return nativehashes.LedgerContract, nil
+	case strings.ToLower(nativenames.Neo), "neo":
+		return nativehashes.NeoToken, nil
+	case strings.ToLower(nativenames.Gas), "gas":
+		return nativehashes.GasToken, nil
+	case strings.ToLower(nativenames.Policy), "policy":
+		return nativehashes.PolicyContract, nil
+	case strings.ToLower(nativenames.Oracle), "oracle":
+		return nativehashes.OracleContract, nil
+	case strings.ToLower(nativenames.Designation), "designation":
+		return nativehashes.RoleManagement, nil
+	case strings.ToLower(nativenames.Notary):
+		return nativehashes.Notary, nil
+	case strings.ToLower(nativenames.CryptoLib), "crypto":
+		return nativehashes.CryptoLib, nil
+	case strings.ToLower(nativenames.StdLib), "std":
+		return nativehashes.StdLib, nil
+	case strings.ToLower(nativenames.Treasury):
+		return nativehashes.Treasury, nil
+	default:
+		return util.Uint160{}, fmt.Errorf("unknown native contract: %s", name)
+	}
 }

--- a/cli/smartcontract/smart_contract_test.go
+++ b/cli/smartcontract/smart_contract_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/internal/random"
+	"github.com/nspcc-dev/neo-go/pkg/core/native/nativehashes"
+	"github.com/nspcc-dev/neo-go/pkg/core/native/nativenames"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
@@ -135,4 +138,29 @@ func TestPermissionUnmarshalInvalid(t *testing.T) {
 			require.Error(t, yaml.Unmarshal([]byte(tc), new(permission)))
 		})
 	}
+}
+
+func TestNativeHash(t *testing.T) {
+	t.Run("all", func(t *testing.T) {
+		for _, n := range nativenames.All {
+			_, err := nativeHash(n)
+			require.NoError(t, err)
+		}
+	})
+	t.Run("shortened", func(t *testing.T) {
+		for name, hash := range map[string]util.Uint160{
+			"management":  nativehashes.ContractManagement,
+			"ledger":      nativehashes.LedgerContract,
+			"neo":         nativehashes.NeoToken,
+			"gas":         nativehashes.GasToken,
+			"policy":      nativehashes.PolicyContract,
+			"std":         nativehashes.StdLib,
+			"crypto":      nativehashes.CryptoLib,
+			"designation": nativehashes.RoleManagement,
+		} {
+			h, err := nativeHash(name)
+			require.NoError(t, err)
+			require.Equal(t, hash, h)
+		}
+	})
 }


### PR DESCRIPTION
Native names are well-known and easy-to-remember:
```
anna@kiwi:~/Documents/GitProjects/nspcc-dev/neo-go$ ./bin/neo-go contract testinvokefunction -r http://seed1.neo.org:10332 PolicyContract getMillisecondsPerBlock
{
  "state": "HALT",
  "gasconsumed": "65570",
  "script": "wh8MF2dldE1pbGxpc2Vjb25kc1BlckJsb2NrDBR7xoHAofcdVDRXtou6jV+f3U5ezEFifVtS",
  "stack": [
    {
      "type": "Integer",
      "value": "3000"
    }
  ],
  "exception": null,
  "notifications": []
}
```