### PR TITLE
Fix incorrect comment for decodeHashableFields method

### DIFF
--- a/pkg/network/payload/notary_request.go
+++ b/pkg/network/payload/notary_request.go
@@ -65,7 +65,7 @@ func (r *P2PNotaryRequest) createHash() error {
 	return nil
 }
 
-// DecodeBinaryUnsigned reads payload from the w excluding signature.
+// decodeHashableFields reads payload from the br excluding signature.
 func (r *P2PNotaryRequest) decodeHashableFields(br *io.BinReader) {
 	r.MainTransaction = &transaction.Transaction{}
 	r.FallbackTransaction = &transaction.Transaction{}


### PR DESCRIPTION
### Problem

The comment incorrectly referenced the old function name "DecodeBinaryUnsigned"  and wrong parameter name "w" instead of the actual function name  "decodeHashableFields" and parameter "br". 




### Solution

Updated the comment to match the actual function signature.

