### PR TITLE
mempool: optimize "same fee" scenario for tx addition

### DIFF
--- a/pkg/core/mempool/mem_pool.go
+++ b/pkg/core/mempool/mem_pool.go
@@ -240,9 +240,16 @@ func (mp *Pool) Add(t *transaction.Transaction, fee Feer, data ...any) error {
 	// prioritized than our new item because we do expect a lot of
 	// transactions with the same priority and appending to the end of the
 	// slice is always more efficient.
-	n := sort.Search(len(mp.verifiedTxes), func(n int) bool {
-		return pItem.Compare(mp.verifiedTxes[n]) > 0
-	})
+	var n int
+	if len(mp.verifiedTxes) > 0 {
+		if pItem.Compare(mp.verifiedTxes[len(mp.verifiedTxes)-1]) == 0 {
+			n = len(mp.verifiedTxes)
+		} else {
+			n = sort.Search(len(mp.verifiedTxes), func(n int) bool {
+				return pItem.Compare(mp.verifiedTxes[n]) > 0
+			})
+		}
+	}
 	// Changing sort.Search to slices.BinarySearchFunc() like
 	//	n, _ := slices.BinarySearchFunc(mp.verifiedTxes, pItem, func (e, t item) int {
 	//		if t.Compare(e) > 0 {


### PR DESCRIPTION
It's very typical in real life, no one wants to pay much, so people pay the minimal amount possible and we always append elements to the list. If that's the case we shortcut up to 16 comparisons, if not, then the overhead is just a single comparison (added to the same "up to 16").
```
goarch: amd64
pkg: github.com/nspcc-dev/neo-go/pkg/core/mempool
cpu: AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics
                       │     old     │              last-fee               │
                       │   sec/op    │   sec/op     vs base                │
Pool/one,_same_fee-16    1.970m ± 1%   1.501m ± 3%  -23.79% (p=0.002 n=10)
Pool/one,_incr_fee-16    13.50m ± 1%   13.42m ± 1%        ~ (p=0.105 n=10)
Pool/many,_same_fee-16   2.717m ± 5%   2.256m ± 1%  -16.97% (p=0.000 n=10)
Pool/many,_incr_fee-16   14.60m ± 1%   14.50m ± 1%   -0.68% (p=0.019 n=10)
geomean                  5.699m        5.067m       -11.09%

                       │      old      │               last-fee               │
                       │     B/op      │     B/op      vs base                │
Pool/one,_same_fee-16    7.269Ki ±  8%   5.542Ki ± 1%  -23.75% (p=0.001 n=10)
Pool/one,_incr_fee-16    17.52Ki ± 10%   17.62Ki ± 7%        ~ (p=0.627 n=10)
Pool/many,_same_fee-16   404.5Ki ±  0%   404.4Ki ± 0%        ~ (p=0.955 n=10)
Pool/many,_incr_fee-16   452.1Ki ±  1%   452.5Ki ± 1%        ~ (p=0.897 n=10)
geomean                  69.46Ki         65.02Ki        -6.40%
```