### PR TITLE
Optimize NEWARRAY(T), NEWSTRUCT

### DIFF
--- a/pkg/vm/bench_test.go
+++ b/pkg/vm/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/stretchr/testify/require"
 )
 
@@ -194,6 +195,23 @@ func BenchmarkScriptValuesArray(t *testing.B) {
 		byte(opcode.STSFLD0),
 		byte(opcode.LDSFLD0),
 		byte(opcode.JMPIF), 0xfb,
+	}
+	benchScript(t, script)
+}
+
+func BenchmarkScriptNewArrayT(t *testing.B) {
+	var script = []byte{
+		byte(opcode.INITSSLOT), 1,
+		byte(opcode.PUSHINT16), 0, 2,
+		byte(opcode.STSFLD0),
+		byte(opcode.PUSHINT16), 0, 7,
+		byte(opcode.NEWARRAYT), byte(stackitem.ByteArrayT),
+		byte(opcode.DROP),
+		byte(opcode.LDSFLD0),
+		byte(opcode.DEC),
+		byte(opcode.STSFLD0),
+		byte(opcode.LDSFLD0),
+		byte(opcode.JMPIF), 0xf6,
 	}
 	benchScript(t, script)
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -2121,18 +2121,21 @@ func makeArrayOfType(n int, typ stackitem.Type) []stackitem.Item {
 	if !typ.IsValid() {
 		panic(fmt.Sprintf("invalid stack item type: %d", typ))
 	}
-	items := make([]stackitem.Item, n)
-	for i := range items {
-		switch typ {
-		case stackitem.BooleanT:
-			items[i] = stackitem.NewBool(false)
-		case stackitem.IntegerT:
-			items[i] = stackitem.NewBigInteger(big.NewInt(0))
-		case stackitem.ByteArrayT:
-			items[i] = stackitem.NewByteArray([]byte{})
-		default:
-			items[i] = stackitem.Null{}
-		}
+	items := make([]stackitem.Item, 0, n)
+	var item stackitem.Item
+	switch typ {
+	case stackitem.BooleanT:
+		item = stackitem.NewBool(false)
+	case stackitem.IntegerT:
+		item = stackitem.NewBigInteger(big.NewInt(0))
+	case stackitem.ByteArrayT:
+		item = stackitem.NewByteArray([]byte{})
+	default:
+		item = stackitem.Null{}
+	}
+	// Use one immutable item to initialize the entire array.
+	for range n {
+		items = append(items, item)
 	}
 	return items
 }


### PR DESCRIPTION
`NEWARRAYT` creates an array of different immutable elements, this is redundant. Look at https://github.com/neo-project/neo-vm/blob/8b9cb5c0055280945e2dd1d33834e0e94d73ebc4/src/Neo.VM/JumpTable/JumpTable.Compound.cs#L158-L190.