### PR TITLE
core: validate method's return value type on call

### DIFF
--- a/pkg/core/interop/contract/call.go
+++ b/pkg/core/interop/contract/call.go
@@ -144,6 +144,9 @@ func callExFromNative(ic *interop.Context, caller util.Uint160, cs *state.Contra
 	if len(args) != len(md.Parameters) {
 		return fmt.Errorf("invalid argument count: %d (expected %d)", len(args), len(md.Parameters))
 	}
+	if hasReturn != (md.ReturnType != smartcontract.VoidType) {
+		return fmt.Errorf("method '%s' return type mismatch: got %s, expected to be void: %t", name, md.ReturnType, !hasReturn)
+	}
 
 	methodOff := md.Offset
 	initOff := -1

--- a/pkg/core/native/native_test/management_test.go
+++ b/pkg/core/native/native_test/management_test.go
@@ -831,6 +831,29 @@ func TestManagement_ContractDeploy(t *testing.T) {
 			managementInvoker.Invoke(t, stackitem.Null{}, "getContract", h.BytesBE())
 		})
 	})
+	t.Run("invalid _deploy signature", func(t *testing.T) {
+		// https://github.com/nspcc-dev/neo-go/pull/4253.
+		deployScript := []byte{byte(opcode.RET)}
+		m := manifest.NewManifest("TestDeploy")
+		m.ABI.Methods = []manifest.Method{
+			{
+				Name:   manifest.MethodDeploy,
+				Offset: 0,
+				Parameters: []manifest.Parameter{
+					manifest.NewParameter("data", smartcontract.AnyType),
+					manifest.NewParameter("isUpdate", smartcontract.BoolType),
+				},
+				ReturnType: smartcontract.ArrayType,
+			},
+		}
+		nefD, err := nef.NewFile(deployScript)
+		require.NoError(t, err)
+		nefDb, err := nefD.Bytes()
+		require.NoError(t, err)
+		manifD, err := json.Marshal(m)
+		require.NoError(t, err)
+		managementInvoker.InvokeFail(t, "at instruction 1 (SYSCALL): method '_deploy' return type mismatch: got Array, expected to be void: true", "deploy", nefDb, manifD)
+	})
 	t.Run("bad _deploy", func(t *testing.T) { // invalid _deploy signature
 		deployScript := []byte{byte(opcode.RET)}
 		m := manifest.NewManifest("TestBadDeploy")
@@ -842,7 +865,7 @@ func TestManagement_ContractDeploy(t *testing.T) {
 					manifest.NewParameter("data", smartcontract.AnyType),
 					manifest.NewParameter("isUpdate", smartcontract.BoolType),
 				},
-				ReturnType: smartcontract.ArrayType,
+				ReturnType: smartcontract.VoidType,
 			},
 		}
 		nefD, err := nef.NewFile(deployScript)


### PR DESCRIPTION
Transaction
0xb9ae94f4bc82155d870e9c30803d2381baf72d05156c0e9d156f512b96f7b093 of testnet at block 612422 is FAULTed.
Go node exception:
```
at instruction 1 (SYSCALL): failed native call: at instruction 64 (RET): invalid return values count: expected 0, got 1
```
C# node exception:
```
The return value type does not match.
```

The follwing set of opcodes is executed by Go node:
```
[NEWARRAY0  1] [PUSH15  2] [PUSHDATA1 66696E697368 3] [PUSHDATA1 588717117E0AA81072AFAB71D2DD89FE7C4B92FE 4] [SYSCALL 627D5B52 0] [PUSH0  1] [SYSCALL 1AF77B67 4] [INITSLOT 0004 4] [NEWSTRUCT0  5] [DUP  6] [LDARG2  7] [APPEND  6] [DUP  7] [LDARG0  8] [APPEND  7] [DUP  8] [LDARG1  9] [APPEND  8] [DUP  9] [LDARG3  10] [APPEND  9] [JMP 02 9] [RET  9]
```
By C# node:
```
[NEWARRAY0  1] [PUSH15  2] [PUSHDATA1 66696E697368 3] [PUSHDATA1 588717117E0AA81072AFAB71D2DD89FE7C4B92FE 4] [SYSCALL 627D5B52 0] [PUSH0  1] [SYSCALL 1AF77B67 0]
```
The transaction is an Oracle response, it calls native Oracle's 'finish' method which itself calls the method of some contract that has non-void return type. It's expected to be void (it's explicitly marked by native Oracle's finish handler), co C# node FAULTs the execution immediately during System.Contract.CallNative processing:
https://github.com/neo-project/neo/blob/c612597a742b67f7e342ce7a1d3faf2f658712c0/src/Neo/SmartContract/Native/OracleContract.cs#L108 https://github.com/neo-project/neo/blob/c612597a742b67f7e342ce7a1d3faf2f658712c0/src/Neo/SmartContract/ApplicationEngine.cs#L587 https://github.com/neo-project/neo/blob/c612597a742b67f7e342ce7a1d3faf2f658712c0/src/Neo/SmartContract/ApplicationEngine.cs#L565

Go node doesn't have this check, so it continues execution until return from this method (where the number of return values doesn't match the expected count).

The problem itself is slightly similar to the one fixed in https://github.com/nspcc-dev/neo-go/pull/4165.