### PR TITLE
Optimize DUP in primitive type branch

### DIFF
--- a/pkg/vm/emit/emit_test.go
+++ b/pkg/vm/emit/emit_test.go
@@ -573,9 +573,6 @@ func (StrangeStackItem) Type() stackitem.Type {
 func (StrangeStackItem) String() string {
 	panic("TODO")
 }
-func (StrangeStackItem) Dup() stackitem.Item {
-	panic("TODO")
-}
 func (StrangeStackItem) TryBool() (bool, error) {
 	panic("TODO")
 }

--- a/pkg/vm/exception.go
+++ b/pkg/vm/exception.go
@@ -49,11 +49,6 @@ func (c *exceptionHandlingContext) Value() any {
 	return c
 }
 
-// Dup implements the stackitem.Item interface.
-func (c *exceptionHandlingContext) Dup() stackitem.Item {
-	return c
-}
-
 // TryBool implements the stackitem.Item interface.
 func (c *exceptionHandlingContext) TryBool() (bool, error) {
 	panic("can't convert exceptionHandlingContext to Bool")

--- a/pkg/vm/stack.go
+++ b/pkg/vm/stack.go
@@ -259,16 +259,6 @@ func (s *Stack) RemoveAt(n int) Element {
 	return e
 }
 
-// Dup duplicates and returns the element at position n.
-// Dup is used for copying elements on the top of its own stack.
-//
-//	s.Push(s.Peek(0)) // will result in unexpected behavior.
-//	s.Push(s.Dup(0)) // is the correct approach.
-func (s *Stack) Dup(n int) Element {
-	e := s.Peek(n)
-	return Element{e.value.Dup()}
-}
-
 // Iter iterates over all elements int the stack, starting from the top
 // of the stack.
 //

--- a/pkg/vm/stack_test.go
+++ b/pkg/vm/stack_test.go
@@ -100,17 +100,6 @@ func TestPushFromOtherStack(t *testing.T) {
 	assert.Equal(t, 1, s2.Len())
 }
 
-func TestDupElement(t *testing.T) {
-	s := NewStack("test")
-	elemA := NewElement(101)
-	s.Push(elemA)
-
-	dupped := s.Dup(0)
-	s.Push(dupped)
-	assert.Equal(t, 2, s.Len())
-	assert.Equal(t, dupped, s.Peek(0))
-}
-
 func TestBack(t *testing.T) {
 	var (
 		s     = NewStack("test")
@@ -336,7 +325,7 @@ func TestInsertAt(t *testing.T) {
 	s.PushVal(4)
 	s.PushVal(5)
 
-	e := s.Dup(1) // it's `4`
+	e := s.Peek(1) // it's `4`
 	s.InsertAt(e, 3)
 
 	assert.Equal(t, int64(5), s.Peek(0).BigInt().Int64())

--- a/pkg/vm/stackitem/item.go
+++ b/pkg/vm/stackitem/item.go
@@ -37,8 +37,6 @@ const (
 type Item interface {
 	fmt.Stringer
 	Value() any
-	// Dup duplicates current Item.
-	Dup() Item
 	// TryBool converts Item to a boolean value.
 	TryBool() (bool, error)
 	// TryBytes converts Item to a byte slice. If the underlying type is a
@@ -270,12 +268,6 @@ func (i *Struct) String() string {
 	return "Struct"
 }
 
-// Dup implements the Item interface.
-func (i *Struct) Dup() Item {
-	// it's a reference type, so no copying here.
-	return i
-}
-
 // TryBool implements the Item interface.
 func (i *Struct) TryBool() (bool, error) { return true, nil }
 
@@ -397,13 +389,6 @@ func (i Null) Value() any {
 	return nil
 }
 
-// Dup implements the Item interface.
-// There is no need to perform a real copy here
-// since Null has no internal state.
-func (i Null) Dup() Item {
-	return i
-}
-
 // TryBool implements the Item interface.
 func (i Null) TryBool() (bool, error) { return false, nil }
 
@@ -510,11 +495,6 @@ func (i *BigInteger) String() string {
 	return "BigInteger"
 }
 
-// Dup implements the Item interface.
-func (i *BigInteger) Dup() Item {
-	return i
-}
-
 // Type implements the Item interface.
 func (i *BigInteger) Type() Type { return IntegerT }
 
@@ -548,11 +528,6 @@ func (i Bool) MarshalJSON() ([]byte, error) {
 
 func (i Bool) String() string {
 	return "Boolean"
-}
-
-// Dup implements the Item interface.
-func (i Bool) Dup() Item {
-	return i
 }
 
 // TryBool implements the Item interface.
@@ -684,11 +659,6 @@ func (i *ByteArray) equalsLimited(s Item, limit *int) bool {
 	return bytes.Equal(*i, *val)
 }
 
-// Dup implements the Item interface.
-func (i *ByteArray) Dup() Item {
-	return i
-}
-
 // Type implements the Item interface.
 func (i *ByteArray) Type() Type { return ByteArrayT }
 
@@ -771,12 +741,6 @@ func (i *Array) TryInteger() (*big.Int, error) {
 // Equals implements the Item interface.
 func (i *Array) Equals(s Item) bool {
 	return i == s
-}
-
-// Dup implements the Item interface.
-func (i *Array) Dup() Item {
-	// reference type
-	return i
 }
 
 // Type implements the Item interface.
@@ -890,12 +854,6 @@ func (i *Map) Has(key Item) bool {
 	return ok
 }
 
-// Dup implements the Item interface.
-func (i *Map) Dup() Item {
-	// reference type
-	return i
-}
-
 // Type implements the Item interface.
 func (i *Map) Type() Type { return MapT }
 
@@ -998,12 +956,6 @@ func (i *Interop) String() string {
 	return "InteropInterface"
 }
 
-// Dup implements the Item interface.
-func (i *Interop) Dup() Item {
-	// reference type
-	return i
-}
-
 // TryBool implements the Item interface.
 func (i *Interop) TryBool() (bool, error) { return true, nil }
 
@@ -1089,15 +1041,6 @@ func (p *Pointer) String() string {
 // Value implements the Item interface.
 func (p *Pointer) Value() any {
 	return p.pos
-}
-
-// Dup implements the Item interface.
-func (p *Pointer) Dup() Item {
-	return &Pointer{
-		pos:    p.pos,
-		script: p.script,
-		hash:   p.hash,
-	}
 }
 
 // TryBool implements the Item interface.
@@ -1187,11 +1130,6 @@ func (i *Buffer) TryInteger() (*big.Int, error) {
 // Equals implements the Item interface.
 func (i *Buffer) Equals(s Item) bool {
 	return i == s
-}
-
-// Dup implements the Item interface.
-func (i *Buffer) Dup() Item {
-	return i
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/pkg/vm/stackitem/item.go
+++ b/pkg/vm/stackitem/item.go
@@ -512,8 +512,7 @@ func (i *BigInteger) String() string {
 
 // Dup implements the Item interface.
 func (i *BigInteger) Dup() Item {
-	n := new(big.Int)
-	return (*BigInteger)(n.Set(i.Big()))
+	return i
 }
 
 // Type implements the Item interface.
@@ -687,8 +686,7 @@ func (i *ByteArray) equalsLimited(s Item, limit *int) bool {
 
 // Dup implements the Item interface.
 func (i *ByteArray) Dup() Item {
-	ba := bytes.Clone(*i)
-	return (*ByteArray)(&ba)
+	return i
 }
 
 // Type implements the Item interface.

--- a/pkg/vm/stackitem/serialization_test.go
+++ b/pkg/vm/stackitem/serialization_test.go
@@ -13,7 +13,7 @@ func TestSerializationMaxErr(t *testing.T) {
 	item := Make(base)
 
 	// Pointer is unserializable, but we specifically want to catch ErrTooBig.
-	arr := []Item{item, item.Dup(), NewPointer(0, []byte{})}
+	arr := []Item{item, Make(item.Value()), NewPointer(0, []byte{})}
 	aitem := Make(arr)
 
 	_, err := Serialize(item)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -932,13 +932,13 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 		v.estack.Clear()
 
 	case opcode.DUP:
-		v.estack.Push(v.estack.Dup(0))
+		v.estack.Push(v.estack.Peek(0))
 
 	case opcode.OVER:
 		if v.estack.Len() < 2 {
 			panic("no second element found")
 		}
-		a := v.estack.Dup(1)
+		a := v.estack.Peek(1)
 		v.estack.Push(a)
 
 	case opcode.PICK:
@@ -949,14 +949,14 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 		if v.estack.Len() < n+1 {
 			panic("no nth element found")
 		}
-		a := v.estack.Dup(n)
+		a := v.estack.Peek(n)
 		v.estack.Push(a)
 
 	case opcode.TUCK:
 		if v.estack.Len() < 2 {
 			panic("too short stack to TUCK")
 		}
-		a := v.estack.Dup(0)
+		a := v.estack.Peek(0)
 		v.estack.InsertAt(a, 2)
 
 	case opcode.SWAP:
@@ -1387,15 +1387,14 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 				v.throw(stackitem.NewByteArray([]byte(msg)))
 				return
 			}
-			item := arr[index].Dup()
-			v.estack.PushItem(item)
+			v.estack.PushItem(arr[index])
 		case *stackitem.Map:
 			index := t.Index(key.Item())
 			if index < 0 {
 				v.throw(stackitem.NewByteArray([]byte("Key not found in Map")))
 				return
 			}
-			v.estack.PushItem(t.Value().([]stackitem.MapElement)[index].Value.Dup())
+			v.estack.PushItem(t.Value().([]stackitem.MapElement)[index].Value)
 		default:
 			index := toInt(key.BigInt())
 			arr := obj.Bytes()
@@ -1702,7 +1701,7 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 
 		arr := make([]stackitem.Item, 0, m.Len())
 		for k := range m.Value().([]stackitem.MapElement) {
-			arr = append(arr, m.Value().([]stackitem.MapElement)[k].Key.Dup())
+			arr = append(arr, m.Value().([]stackitem.MapElement)[k].Key)
 		}
 		var res = stackitem.NewArray(arr)
 		res.IncRC()


### PR DESCRIPTION
I checked if we have opcodes that change primitive types, but I didn't see any. I took a closer look at CONVERT, primitive types (and more) are copied there by value, so DUP does not need unnecessary duplication, it significantly slows down the script.