### PR TITLE
Revert "core: remove Echidna compatibility code from registerCandidate"

### DIFF
--- a/pkg/core/native/native_neo.go
+++ b/pkg/core/native/native_neo.go
@@ -868,6 +868,14 @@ func (n *NEO) CalculateNEOHolderReward(d *dao.Simple, value *big.Int, start, end
 
 func (n *NEO) registerCandidate(ic *interop.Context, args []stackitem.Item) stackitem.Item {
 	pub := toPublicKey(args[0])
+	if !ic.IsHardforkEnabled(config.HFEchidna) { // doesn't affect N3 states but affects execution result, so need to be kept, ref. #4262.
+		ok, err := runtime.CheckKeyedWitness(ic, pub)
+		if err != nil {
+			panic(err)
+		} else if !ok {
+			return stackitem.NewBool(false)
+		}
+	}
 	if err := ic.VM.AddDatoshi(n.getRegisterPriceInternal(ic.DAO)); err != nil {
 		panic(fmt.Errorf("%w executing %s/registerCandidate", err, n.Hash.StringLE()))
 	}


### PR DESCRIPTION
This reverts commit a0c3d776c64ccb986eef0c8ef409c238c64451e5 since it affects execution results. Close #4262.