### PR TITLE
scripts: add script for ApplicationLogs comparison

### DIFF
--- a/scripts/compare-applogs/compare-applogs.go
+++ b/scripts/compare-applogs/compare-applogs.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/nspcc-dev/neo-go/scripts/rpcutil"
+	"github.com/urfave/cli/v2"
+)
+
+func cliMain(c *cli.Context) error {
+	const reportInterval = 500_000
+
+	a := c.Args().Get(0)
+	b := c.Args().Get(1)
+	if a == "" || b == "" {
+		return errors.New("usage: compare-applogs RPC_A RPC_B [-s start] [-e end]")
+	}
+
+	ca, ha, err := rpcutil.InitClient(a, "A")
+	if err != nil {
+		return err
+	}
+	cb, hb, err := rpcutil.InitClient(b, "B")
+	if err != nil {
+		return err
+	}
+	refHeight, err := rpcutil.CheckHeights(ha, hb, c.Bool(rpcutil.IgnoreHeightFlag.Name))
+	if err != nil {
+		return err
+	}
+
+	if err := rpcutil.CompareNetwork(ca, cb); err != nil {
+		return err
+	}
+
+	end := uint32(c.Uint("end"))
+	if end == 0 {
+		end = refHeight
+	} else if end > refHeight {
+		return fmt.Errorf("end %d exceeds chain height: A has %d blocks, B has %d blocks", end, ha, hb)
+	}
+
+	start := uint32(c.Uint("start"))
+	if start >= end {
+		return fmt.Errorf("invalid block range: [%d, %d)", start, end)
+	}
+
+	for i := start; i < end; i++ {
+		if (i-start)%reportInterval == 0 {
+			fmt.Printf("Processing blocks %d-%d\n", i, min(i+reportInterval, end))
+		}
+		blk, err := ca.GetBlockByIndex(i)
+		if err != nil {
+			return fmt.Errorf("can't get block %d from A: %w", i, err)
+		}
+		for _, tx := range blk.Transactions {
+			da, err := rpcutil.GetApplicationLog(ca, tx.Hash())
+			if err != nil {
+				return fmt.Errorf("can't get ApplicationLog bytes for tx %s at height %d from A: %w", tx.Hash().StringLE(), i, err)
+			}
+			db, err := rpcutil.GetApplicationLog(cb, tx.Hash())
+			if err != nil {
+				return fmt.Errorf("can't get ApplicationLog bytes for tx %s at height %d from B: %w", tx.Hash().StringLE(), i, err)
+			}
+			if !bytes.Equal(da, db) {
+				fmt.Printf("applogs differ at %d, block %s, tx %s\n", i, blk.Hash().StringLE(), tx.Hash().StringLE())
+				rpcutil.DumpApplicationLogDiff(a, b, da, db)
+				return errors.New("application log mismatch found")
+			}
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	ctl := cli.NewApp()
+	ctl.Name = "compare-applogs"
+	ctl.Version = "1.0"
+	ctl.Usage = "compare-applogs [--ignore-height] RPC_A RPC_B [-s start] [-e end]"
+	ctl.Action = cliMain
+	ctl.Flags = []cli.Flag{
+		&cli.UintFlag{
+			Name:    "start",
+			Aliases: []string{"s"},
+			Usage:   "Block number to start from (inclusive)",
+		},
+		&cli.UintFlag{
+			Name:    "end",
+			Aliases: []string{"e"},
+			Usage:   "Block number to end at (exclusive)",
+		},
+		rpcutil.IgnoreHeightFlag,
+	}
+
+	if err := ctl.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/scripts/compare-states/compare-states.go
+++ b/scripts/compare-states/compare-states.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/scripts/rpcutil"
-	"github.com/pmezard/go-difflib/difflib"
 	"github.com/urfave/cli/v2"
 )
 
@@ -114,26 +112,15 @@ func dumpApplogDiff(isBlock bool, container util.Uint256, a string, b string, ca
 	} else {
 		fmt.Printf("transaction %s:\n", container.StringLE())
 	}
-	la, err := ca.GetApplicationLog(container, nil)
+	da, err := rpcutil.GetApplicationLog(ca, container)
 	if err != nil {
 		return err
 	}
-	lb, err := cb.GetApplicationLog(container, nil)
+	db, err := rpcutil.GetApplicationLog(cb, container)
 	if err != nil {
 		return err
 	}
-	da := spew.Sdump(la)
-	db := spew.Sdump(lb)
-	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-		A:        difflib.SplitLines(da),
-		B:        difflib.SplitLines(db),
-		FromFile: a,
-		FromDate: "",
-		ToFile:   b,
-		ToDate:   "",
-		Context:  1,
-	})
-	fmt.Println(diff)
+	rpcutil.DumpApplicationLogDiff(a, b, da, db)
 	return nil
 }
 

--- a/scripts/compare-states/compare-states.go
+++ b/scripts/compare-states/compare-states.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -9,27 +8,12 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/scripts/rpcutil"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/urfave/cli/v2"
 )
 
 var errStateMatches = errors.New("state matches")
-
-func initClient(addr string, name string) (*rpcclient.Client, uint32, error) {
-	c, err := rpcclient.New(context.Background(), addr, rpcclient.Options{})
-	if err != nil {
-		return nil, 0, fmt.Errorf("RPC %s: %w", name, err)
-	}
-	err = c.Init()
-	if err != nil {
-		return nil, 0, fmt.Errorf("RPC %s init: %w", name, err)
-	}
-	h, err := c.GetBlockCount()
-	if err != nil {
-		return nil, 0, fmt.Errorf("RPC %s block count: %w", name, err)
-	}
-	return c, h, nil
-}
 
 func getRoots(ca *rpcclient.Client, cb *rpcclient.Client, h uint32) (util.Uint256, util.Uint256, error) {
 	ra, err := ca.GetStateRootByHeight(h)
@@ -87,24 +71,17 @@ func cliMain(c *cli.Context) error {
 	if b == "" {
 		return errors.New("missing second argument")
 	}
-	ca, ha, err := initClient(a, "A")
+	ca, ha, err := rpcutil.InitClient(a, "A")
 	if err != nil {
 		return err
 	}
-	cb, hb, err := initClient(b, "B")
+	cb, hb, err := rpcutil.InitClient(b, "B")
 	if err != nil {
 		return err
 	}
-	var refHeight = ha
-	if ha != hb {
-		var diff = hb - ha
-		if ha > hb {
-			refHeight = hb
-			diff = ha - hb
-		}
-		if diff > 10 && !c.Bool("ignore-height") { // Allow some height drift.
-			return fmt.Errorf("chains have different heights: %d vs %d", ha, hb)
-		}
+	refHeight, err := rpcutil.CheckHeights(ha, hb, c.Bool(rpcutil.IgnoreHeightFlag.Name))
+	if err != nil {
+		return err
 	}
 	h, err := bisectState(ca, cb, refHeight-1)
 	if err != nil {
@@ -164,15 +141,9 @@ func main() {
 	ctl := cli.NewApp()
 	ctl.Name = "compare-states"
 	ctl.Version = "1.0"
-	ctl.Usage = "compare-states RPC_A RPC_B"
+	ctl.Usage = "compare-states [--ignore-height] RPC_A RPC_B"
 	ctl.Action = cliMain
-	ctl.Flags = []cli.Flag{
-		&cli.BoolFlag{
-			Name:    "ignore-height",
-			Aliases: []string{"g"},
-			Usage:   "Ignore height difference",
-		},
-	}
+	ctl.Flags = []cli.Flag{rpcutil.IgnoreHeightFlag}
 
 	if err := ctl.Run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/scripts/rpcutil/rpcutil.go
+++ b/scripts/rpcutil/rpcutil.go
@@ -1,0 +1,92 @@
+package rpcutil
+
+import (
+	"context"
+	"fmt"
+
+	ojson "github.com/nspcc-dev/go-ordered-json"
+	"github.com/nspcc-dev/neo-go/pkg/rpcclient"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/urfave/cli/v2"
+)
+
+// IgnoreHeightFlag ignores blockchain height difference.
+var IgnoreHeightFlag = &cli.BoolFlag{
+	Name:    "ignore-height",
+	Aliases: []string{"g"},
+	Usage:   "Ignore height difference",
+}
+
+// InitClient initializes an RPC client and returns the current blockchain height.
+func InitClient(addr string, name string) (*rpcclient.Client, uint32, error) {
+	c, err := rpcclient.New(context.Background(), addr, rpcclient.Options{})
+	if err != nil {
+		return nil, 0, fmt.Errorf("RPC %s: %w", name, err)
+	}
+	if err = c.Init(); err != nil {
+		return nil, 0, fmt.Errorf("RPC %s init: %w", name, err)
+	}
+	h, err := c.GetBlockCount()
+	if err != nil {
+		return nil, 0, fmt.Errorf("RPC %s block count: %w", name, err)
+	}
+	return c, h, nil
+}
+
+// CompareNetwork verifies that both RPC nodes belong to the same network.
+func CompareNetwork(ca, cb *rpcclient.Client) error {
+	na := ca.Network()
+	nb := cb.Network()
+	if na != nb {
+		return fmt.Errorf("different network magic: A=%d (0x%X), B=%d (0x%X)", na, uint32(na), nb, uint32(nb))
+	}
+	return nil
+}
+
+// GetApplicationLog returns a normalized JSON representation of an application log.
+func GetApplicationLog(c *rpcclient.Client, h util.Uint256) ([]byte, error) {
+	l, err := c.GetApplicationLog(h, nil)
+	if err != nil {
+		return nil, fmt.Errorf("can't get ApplicationLog for %s: %w", h.StringLE(), err)
+	}
+	// Ignore FaultException and Invocations because its message may differ between implementations.
+	for i := range l.Executions {
+		l.Executions[i].FaultException = ""
+		l.Executions[i].Invocations = nil
+	}
+	d, err := ojson.MarshalIndent(l, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ApplicationLog for %s: %w", h.StringLE(), err)
+	}
+	return d, nil
+}
+
+// DumpApplicationLogDiff prints a unified diff for two application logs.
+func DumpApplicationLogDiff(a string, b string, da []byte, db []byte) {
+	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(da)),
+		B:        difflib.SplitLines(string(db)),
+		FromFile: a,
+		ToFile:   b,
+		Context:  1,
+	})
+	fmt.Println(diff)
+}
+
+// CheckHeights checks chain height difference and returns the minimum height.
+func CheckHeights(ha, hb uint32, ignore bool) (uint32, error) {
+	const maxHeightDrift = 10
+
+	refHeight := ha
+	diff := hb - ha
+	if ha > hb {
+		refHeight = hb
+		diff = ha - hb
+	}
+
+	if diff > maxHeightDrift && !ignore {
+		return 0, fmt.Errorf("chains have different heights: %d vs %d", ha, hb)
+	}
+	return refHeight, nil
+}


### PR DESCRIPTION
To implement https://github.com/nspcc-dev/neo-go/pull/4087, first need to make sure that values of consumed GAS are consistent for each transaction. This script can also be useful in other similar cases.

Close #4216 .