### PR TITLE
neorpc: ensure SignerWithWitness deserialization limits

### DIFF
--- a/pkg/neorpc/types.go
+++ b/pkg/neorpc/types.go
@@ -160,6 +160,13 @@ func (s *SignerWithWitness) UnmarshalJSON(data []byte) error {
 		AllowedGroups:    aux.AllowedGroups,
 		Rules:            aux.Rules,
 	}
+
+	if len(aux.InvocationScript) > transaction.MaxInvocationScript {
+		return fmt.Errorf("invalid invocation script length: got %d, allowed %d at max", len(aux.InvocationScript), transaction.MaxInvocationScript)
+	}
+	if len(aux.VerificationScript) > transaction.MaxVerificationScript {
+		return fmt.Errorf("invalid verification script length: got %d, allowed %d at max", len(aux.VerificationScript), transaction.MaxVerificationScript)
+	}
 	s.Witness = transaction.Witness{
 		InvocationScript:   aux.InvocationScript,
 		VerificationScript: aux.VerificationScript,

--- a/pkg/neorpc/types_test.go
+++ b/pkg/neorpc/types_test.go
@@ -40,14 +40,17 @@ func TestSignerWithWitnessMarshalUnmarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, string(actual))
 
+	checkErr := func(t *testing.T, bad any, errText string) {
+		data, err := json.Marshal(bad)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &SignerWithWitness{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errText)
+	}
 	t.Run("subitems overflow", func(t *testing.T) {
 		checkSubitems := func(t *testing.T, bad any) {
-			data, err := json.Marshal(bad)
-			require.NoError(t, err)
-			err = json.Unmarshal(data, &SignerWithWitness{})
-
-			require.Error(t, err)
-			require.Contains(t, err.Error(), fmt.Sprintf("got %d, allowed %d at max", transaction.MaxAttributes+1, transaction.MaxAttributes))
+			checkErr(t, bad, fmt.Sprintf("got %d, allowed %d at max", transaction.MaxAttributes+1, transaction.MaxAttributes))
 		}
 
 		t.Run("groups", func(t *testing.T) {
@@ -87,6 +90,28 @@ func TestSignerWithWitnessMarshalUnmarshalJSON(t *testing.T) {
 			}
 
 			checkSubitems(t, bad)
+		})
+	})
+	t.Run("witnesses overflow", func(t *testing.T) {
+		t.Run("invocation", func(t *testing.T) {
+			bad := &SignerWithWitness{
+				Witness: transaction.Witness{
+					InvocationScript:   make([]byte, transaction.MaxInvocationScript+1),
+					VerificationScript: nil,
+				},
+			}
+
+			checkErr(t, bad, "invalid invocation script length")
+		})
+		t.Run("verification", func(t *testing.T) {
+			bad := &SignerWithWitness{
+				Witness: transaction.Witness{
+					InvocationScript:   nil,
+					VerificationScript: make([]byte, transaction.MaxVerificationScript+1),
+				},
+			}
+
+			checkErr(t, bad, "invalid verification script length")
 		})
 	})
 }


### PR DESCRIPTION
Close #4293.

The check against MaxTransactionSize for siners or witnesses is excessive because the number of signers and the number of witnesses is restricted at the upper deserialization level:
https://github.com/nspcc-dev/neo-go/blob/76fc43a8bb78301d7a81076402abd2377d5a3b60/pkg/services/rpcsrv/params/param.go#L426.

The number and the size of Signer's subitems is also restricted by Signer deserialization code:
https://github.com/nspcc-dev/neo-go/blob/76fc43a8bb78301d7a81076402abd2377d5a3b60/pkg/neorpc/types.go#L118.

So the only check that should be ported is witness scripts length check.