### PR TITLE
vm: avoid primitive items double-counting in CLEARITEMS

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1568,34 +1568,36 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 			if t.IsReadOnly() {
 				panic(stackitem.ErrReadOnly)
 			}
+			elems := t.Value().([]stackitem.Item)
+			t.Clear()
 			if t.IsReferenced() {
-				for _, item := range t.Value().([]stackitem.Item) {
+				for _, item := range elems {
 					v.refs.Remove(item)
 				}
 			}
-			t.Clear()
 		case *stackitem.Struct:
 			if t.IsReadOnly() {
 				panic(stackitem.ErrReadOnly)
 			}
+			elems := t.Value().([]stackitem.Item)
+			t.Clear()
 			if t.IsReferenced() {
-				for _, item := range t.Value().([]stackitem.Item) {
+				for _, item := range elems {
 					v.refs.Remove(item)
 				}
 			}
-			t.Clear()
 		case *stackitem.Map:
 			if t.IsReadOnly() {
 				panic(stackitem.ErrReadOnly)
 			}
+			elems := t.Value().([]stackitem.MapElement)
+			t.Clear()
 			if t.IsReferenced() {
-				elems := t.Value().([]stackitem.MapElement)
 				for i := range elems {
 					v.refs.Remove(elems[i].Key)
 					v.refs.Remove(elems[i].Value)
 				}
 			}
-			t.Clear()
 		default:
 			panic("CLEARITEMS: invalid type")
 		}

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -106,25 +106,90 @@ func TestVM_SetPriceGetter(t *testing.T) {
 // (which may be misused to break the MaxStackSize limit).
 // Ref. https://github.com/neo-project/neo-vm/issues/580.
 func TestNegativeRC(t *testing.T) {
-	v := newTestVM()
-	prog := []byte{byte(opcode.INITSLOT), 0x01, 0x00,
-		byte(opcode.PUSH16), byte(opcode.INC), byte(opcode.STLOC0),
-		byte(opcode.NEWARRAY0), // first jump target.
-		byte(opcode.DUP),
-		byte(opcode.DUP),
-		byte(opcode.APPEND),
-		byte(opcode.CLEARITEMS),
-		byte(opcode.LDLOC0), byte(opcode.DEC), byte(opcode.DUP),
-		byte(opcode.STLOC0), byte(opcode.PUSH0),
-		byte(opcode.JMPGT), 0xf6,
-		byte(opcode.PUSH16), byte(opcode.PUSH7), byte(opcode.SHL), byte(opcode.PUSH14), byte(opcode.ADD), byte(opcode.STLOC0), // 2048+14
-		byte(opcode.PUSH0), // second jump target.
-		byte(opcode.LDLOC0), byte(opcode.DEC), byte(opcode.DUP),
-		byte(opcode.STLOC0), byte(opcode.PUSH0),
-		byte(opcode.JMPGT), 0xfa,
-	}
-	v.Load(prog)
-	checkVMFailedWithError(t, v, "at instruction 27 (DUP): stack is too big: 2049 vs 2048")
+	t.Run("CLEARITEMS: circular array", func(t *testing.T) {
+		v := newTestVM()
+		prog := []byte{
+			byte(opcode.NEWARRAY0),
+			byte(opcode.DUP),
+			byte(opcode.DUP),
+			byte(opcode.APPEND),
+			byte(opcode.CLEARITEMS),
+		}
+		v.Load(prog)
+		runVM(t, v)
+		require.Equal(t, 0, int(v.refs))
+	})
+	t.Run("CLEARITEMS: circular array with other elements", func(t *testing.T) {
+		v := newTestVM()
+		prog := []byte{
+			byte(opcode.NEWARRAY0),
+			byte(opcode.DUP),
+			byte(opcode.PUSH1),
+			byte(opcode.APPEND),
+			byte(opcode.DUP),
+			byte(opcode.DUP),
+			byte(opcode.APPEND),
+			byte(opcode.CLEARITEMS),
+		}
+		v.Load(prog)
+		runVM(t, v)
+		require.Equal(t, 0, int(v.refs))
+	})
+	t.Run("SETITEM: circular array with other elements", func(t *testing.T) {
+		v := newTestVM()
+		prog := []byte{
+			byte(opcode.NEWARRAY0), // arr {1, arr}
+			byte(opcode.DUP),
+			byte(opcode.PUSH1),
+			byte(opcode.APPEND),
+			byte(opcode.DUP),
+			byte(opcode.DUP),
+			byte(opcode.APPEND),
+			byte(opcode.PUSH1), // arr[1] = 2
+			byte(opcode.PUSH2),
+			byte(opcode.SETITEM),
+		}
+		v.Load(prog)
+		runVM(t, v)
+		require.Equal(t, 0, v.estack.Len())
+		require.Equal(t, 1, int(v.refs))
+	})
+	t.Run("CLEARITEMS: circular map", func(t *testing.T) {
+		v := newTestVM()
+		prog := []byte{
+			byte(opcode.NEWMAP),
+			byte(opcode.DUP),
+			byte(opcode.DUP),
+			byte(opcode.PUSH1),
+			byte(opcode.SWAP),
+			byte(opcode.SETITEM),
+			byte(opcode.CLEARITEMS),
+		}
+		v.Load(prog)
+		runVM(t, v)
+		require.Equal(t, 0, int(v.refs))
+	})
+	t.Run("exceed MaxStackSize limit", func(t *testing.T) {
+		v := newTestVM()
+		prog := []byte{byte(opcode.INITSLOT), 0x01, 0x00,
+			byte(opcode.PUSH16), byte(opcode.INC), byte(opcode.STLOC0),
+			byte(opcode.NEWARRAY0), // first jump target.
+			byte(opcode.DUP),
+			byte(opcode.DUP),
+			byte(opcode.APPEND),
+			byte(opcode.CLEARITEMS),
+			byte(opcode.LDLOC0), byte(opcode.DEC), byte(opcode.DUP),
+			byte(opcode.STLOC0), byte(opcode.PUSH0),
+			byte(opcode.JMPGT), 0xf6,
+			byte(opcode.PUSH16), byte(opcode.PUSH7), byte(opcode.SHL), byte(opcode.PUSH14), byte(opcode.ADD), byte(opcode.STLOC0), // 2048+14
+			byte(opcode.PUSH0), // second jump target.
+			byte(opcode.LDLOC0), byte(opcode.DEC), byte(opcode.DUP),
+			byte(opcode.STLOC0), byte(opcode.PUSH0),
+			byte(opcode.JMPGT), 0xfa,
+		}
+		v.Load(prog)
+		checkVMFailedWithError(t, v, "at instruction 27 (DUP): stack is too big: 2049 vs 2048")
+	})
 }
 
 func TestAddGas(t *testing.T) {


### PR DESCRIPTION
Related to https://github.com/nspcc-dev/neo-go/pull/4312 and https://github.com/neo-project/neo-vm/issues/580.