### PR TITLE
rpcclient: expose cached network magic

### DIFF
--- a/pkg/rpcclient/client.go
+++ b/pkg/rpcclient/client.go
@@ -250,3 +250,12 @@ func (c *Client) Context() context.Context {
 func (c *Client) Endpoint() string {
 	return c.endpoint.String()
 }
+
+// Network returns the network magic of the RPC node the Client is bound to. It
+// uses cache. Calling this method on an uninitialized Client will return 0.
+func (c *Client) Network() netmode.Magic {
+	c.cacheLock.RLock()
+	defer c.cacheLock.RUnlock()
+
+	return c.cache.network
+}

--- a/pkg/rpcclient/local_test.go
+++ b/pkg/rpcclient/local_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/internal/testcli"
 	"github.com/nspcc-dev/neo-go/pkg/config"
+	"github.com/nspcc-dev/neo-go/pkg/config/netmode"
 	"github.com/nspcc-dev/neo-go/pkg/neorpc"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient"
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,11 @@ func TestInternalClientCancel(t *testing.T) {
 	})
 	icl, err := rpcclient.NewInternal(ctx, rpcSrv.RegisterLocal)
 	require.NoError(t, err)
+
+	// Check Network API.
+	require.NoError(t, icl.Init())
+	require.Equal(t, netmode.UnitTestNet, icl.Network())
+
 	cancel()
 	icl.Close()
 	require.NoError(t, icl.GetError())

--- a/pkg/rpcclient/rpc_test.go
+++ b/pkg/rpcclient/rpc_test.go
@@ -2303,3 +2303,21 @@ func newTestNEF(script []byte) nef.File {
 func getTestRequestID() uint64 {
 	return 1
 }
+
+func TestNetwork(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r := params.NewRequest()
+		err := r.DecodeData(req.Body)
+		require.NoErrorf(t, err, "Cannot decode request body: %s", req.Body)
+		// request handler already have `getversion` response wrapper
+		requestHandler(t, r.In, w, "")
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := New(context.TODO(), srv.URL, Options{})
+	require.NoError(t, err)
+	c.getNextRequestID = getTestRequestID
+
+	require.NoError(t, c.Init())
+	require.Equal(t, netmode.UnitTestNet, c.Network())
+}


### PR DESCRIPTION
Network API may be useful for cases like #4287.