### PR TITLE
scripts: log RPC server nonce and user-agent on client init

### DIFF
--- a/scripts/compare-applogs/compare-applogs.go
+++ b/scripts/compare-applogs/compare-applogs.go
@@ -23,7 +23,15 @@ func cliMain(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	err = rpcutil.PrintRPCInfo(ca, "A")
+	if err != nil {
+		return err
+	}
 	cb, hb, err := rpcutil.InitClient(b, "B")
+	if err != nil {
+		return err
+	}
+	err = rpcutil.PrintRPCInfo(cb, "B")
 	if err != nil {
 		return err
 	}

--- a/scripts/compare-states/compare-states.go
+++ b/scripts/compare-states/compare-states.go
@@ -73,7 +73,15 @@ func cliMain(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	err = rpcutil.PrintRPCInfo(ca, "A")
+	if err != nil {
+		return err
+	}
 	cb, hb, err := rpcutil.InitClient(b, "B")
+	if err != nil {
+		return err
+	}
+	err = rpcutil.PrintRPCInfo(cb, "B")
 	if err != nil {
 		return err
 	}

--- a/scripts/rpcutil/rpcutil.go
+++ b/scripts/rpcutil/rpcutil.go
@@ -34,6 +34,16 @@ func InitClient(addr string, name string) (*rpcclient.Client, uint32, error) {
 	return c, h, nil
 }
 
+// PrintRPCInfo prints RPC server user-agent and nonce.
+func PrintRPCInfo(c *rpcclient.Client, name string) error {
+	v, err := c.GetVersion()
+	if err != nil {
+		return fmt.Errorf("RPC %s version: %w", name, err)
+	}
+	fmt.Printf("RPC %s:\n\tuser-agent: %s\n\tnonce: %d\n", name, v.UserAgent, v.Nonce)
+	return nil
+}
+
 // CompareNetwork verifies that both RPC nodes belong to the same network.
 func CompareNetwork(ca, cb *rpcclient.Client) error {
 	na := ca.Network()


### PR DESCRIPTION
Required to make the output more determenistic and ensure the target RPC server has proper version.