### PR TITLE
compiler: detect errors in imported packages

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -216,10 +216,23 @@ func getBuildInfo(name string, src any) (*buildInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, p := range prog {
-		if len(p.Errors) != 0 {
-			return nil, p.Errors[0]
+	// packages.Load never returns per-package errors via err: they sit in each
+	// Package's own Errors field, including transitive imports, so the whole
+	// graph must be walked to find them. Check in pre, not post, to stop
+	// descending as soon as an erroneous package is found.
+	var firstErr error
+	packages.Visit(prog, func(p *packages.Package) bool {
+		if firstErr != nil {
+			return false
 		}
+		if len(p.Errors) != 0 {
+			firstErr = p.Errors[0]
+			return false
+		}
+		return true
+	}, nil)
+	if firstErr != nil {
+		return nil, firstErr
 	}
 	return &buildInfo{
 		config:  conf,

--- a/pkg/compiler/import_test.go
+++ b/pkg/compiler/import_test.go
@@ -89,3 +89,13 @@ func TestImportCycleIndirect(t *testing.T) {
 	_, _, err := compiler.CompileWithOptions("some.go", strings.NewReader(src), nil)
 	require.Error(t, err)
 }
+
+func TestImportPackageError(t *testing.T) {
+	src := `package foo
+		import "github.com/nspcc-dev/neo-go/pkg/compiler/testdata/importerr"
+		func Main() []importerr.Ballot {
+			return importerr.GetBallots()
+		}`
+	_, err := compiler.Compile("foo.go", strings.NewReader(src))
+	require.ErrorContains(t, err, "data (variable of type []byte) is not an interface")
+}

--- a/pkg/compiler/testdata/importerr/importerr.go
+++ b/pkg/compiler/testdata/importerr/importerr.go
@@ -1,0 +1,22 @@
+package importerr
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/interop/native/std"
+	"github.com/nspcc-dev/neo-go/pkg/interop/storage"
+)
+
+type Ballot struct {
+	X int
+}
+
+// GetBallots contains an invalid type assertion: storage.LocalGet already
+// returns []byte, so data.([]byte) doesn't type-check (data is not an
+// interface). This must be reported as a normal compile error, not silently
+// ignored because the error is in an imported package.
+func GetBallots() []Ballot {
+	data := storage.LocalGet([]byte("votekey"))
+	if data != nil {
+		return std.Deserialize(data.([]byte)).([]Ballot)
+	}
+	return []Ballot{}
+}


### PR DESCRIPTION
`getBuildInfo` only checked errors on root packages, ignoring errors in imported packages. Walk the whole import graph with `packages.Visit`.

Close #4354.