### PR TITLE
neotest: always compute the hash in CompileFile

### DIFF
--- a/pkg/neotest/compile.go
+++ b/pkg/neotest/compile.go
@@ -52,11 +52,14 @@ func CompileSource(t testing.TB, sender util.Uint160, src io.Reader, opts *compi
 }
 
 // CompileFile compiles a contract from the file and returns its NEF, manifest and hash.
-// It uses contracts cashes.
+// It uses contracts cache (keyed by source and config path) for NEF/manifest/debug
+// info (hash is sender-dependent, so always recalculated according to parameter).
 func CompileFile(t testing.TB, sender util.Uint160, srcPath string, configPath string) *Contract {
 	cacheKey := srcPath + "|" + configPath
 	if c, ok := contracts[cacheKey]; ok {
-		return c
+		var cc = *c
+		cc.Hash = state.CreateContractHash(sender, c.NEF.Checksum, c.Manifest.Name)
+		return &cc
 	}
 
 	// nef.NewFile() cares about version a lot.


### PR DESCRIPTION
Tests can deploy contracts using different senders depending on scenarios. Most of the time committee invoker is being used (as the most convenient), but some contracts can be deployed multiple times in a single test (that's routine for alphabet NeoFS contract) or can be deployed into different chains (single/multi) to test various aspects of their behavior. In this case caching leads to deployment error like this for the second attempt:

    basic.go:282:
                Error Trace:    /home/rik/go/pkg/mod/github.com/nspcc-dev/neo-go@v0.121.0/pkg/neotest/basic.go:282
                                                        /home/rik/go/pkg/mod/github.com/nspcc-dev/neo-go@v0.121.0/pkg/neotest/basic.go:171
                                                        /home/rik/go/pkg/mod/github.com/nspcc-dev/neo-go@v0.121.0/pkg/neotest/basic.go:157
                                                        /home/rik/dev/neofs-contract/tests/nns_test.go:56
                                                        /home/rik/dev/neofs-contract/tests/container_test.go:114
                                                        /home/rik/dev/neofs-contract/tests/proxy_test.go:45
                Error:          Not equal:
                                expected: state.NotificationEvent{ScriptHash:util.Uint160{0xfd, 0xa3, 0xfa, 0x43, 0x46, 0xea, 0x53, 0x2a, 0x25, 0x8f, 0xc4, 0x97, 0xdd, 0xad, 0xdb, 0x64, 0x37, 0xc9, 0xfd, 0xff}, Name:"Deploy", Item:(*stackitem.Array)(0x35f6bd9b6b70)}
                                actual  : state.NotificationEvent{ScriptHash:util.Uint160{0xfd, 0xa3, 0xfa, 0x43, 0x46, 0xea, 0x53, 0x2a, 0x25, 0x8f, 0xc4, 0x97, 0xdd, 0xad, 0xdb, 0x64, 0x37, 0xc9, 0xfd, 0xff}, Name:"Deploy", Item:(*stackitem.Array)(0x35f6bd71ad80)}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -9,4 +9,4 @@
                                    (*stackitem.ByteArray)((len=20) {
                                -    00000000  98 2e 07 51 7a 85 ad 68  c3 f2 a9 40 6c 98 f7 9d  |...Qz..h...@l...|
                                -    00000010  fc 21 b9 78                                       |.!.x|
                                +    00000000  33 ae f4 e9 99 d2 83 2d  db e2 94 7a 19 b4 2e f6  |3......-...z....|
                                +    00000010  c5 76 46 ed                                       |.vF.|
                                    })
                Test:           TestProxyVerifyWithNoneScopeAlphabetSigner

Solve this using proper hashes for particular deployments.
