### PR TITLE
compiler: make asserted byte-slice fields mutable

### DIFF
--- a/pkg/compiler/codegen.go
+++ b/pkg/compiler/codegen.go
@@ -273,6 +273,27 @@ func (c *codegen) emitStoreIndexExpr(n *ast.IndexExpr) {
 	emit.Opcodes(c.prog.BinWriter, opcode.ROT, opcode.SETITEM)
 }
 
+// emitConvertStructFields converts mutable fields after a structure type assertion.
+// It leaves the asserted structure on the stack.
+func (c *codegen) emitConvertStructFields(typ types.Type) {
+	strct, ok := getStruct(typ)
+	if !ok {
+		return
+	}
+	for i := range strct.NumFields() {
+		fieldTyp := strct.Field(i).Type()
+		slice, ok := fieldTyp.Underlying().(*types.Slice)
+		if ok && isByte(slice.Elem()) {
+			emit.Opcodes(c.prog.BinWriter, opcode.DUP, opcode.DUP)
+			emit.Int(c.prog.BinWriter, int64(i))
+			emit.Opcodes(c.prog.BinWriter, opcode.PICKITEM)
+			c.emitConvert(stackitem.BufferT)
+			emit.Opcodes(c.prog.BinWriter, opcode.SWAP)
+			c.emitStoreStructField(i)
+		}
+	}
+}
+
 // getVarIndex returns variable type and position in the corresponding slot,
 // according to the current scope.
 func (c *codegen) getVarIndex(pkg string, name string) *varInfo {
@@ -1600,6 +1621,9 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 		if canConvert(goTyp.String()) {
 			typ := toNeoType(goTyp)
 			c.emitConvert(typ)
+			if typ == stackitem.StructT {
+				c.emitConvertStructFields(goTyp)
+			}
 		}
 		return nil
 	}

--- a/pkg/compiler/convert_test.go
+++ b/pkg/compiler/convert_test.go
@@ -196,6 +196,38 @@ func TestTypeAssertion(t *testing.T) {
 		_, _, err := compiler.CompileWithOptions("foo.go", strings.NewReader(src), nil)
 		require.Error(t, err)
 	})
+	t.Run("converts mutable struct fields", func(t *testing.T) {
+		src := `package foo
+			type value struct {
+				data []byte
+			}
+			func Main(data []byte) []byte {
+				var item any = value{data: data}
+				return item.(value).data
+			}`
+
+		v := vmAndCompile(t, src)
+		v.Estack().PushItem(stackitem.NewByteArray([]byte{42}))
+
+		require.NoError(t, v.Run())
+		require.Equal(t, 1, v.Estack().Len())
+		require.Equal(t, stackitem.BufferT, v.Estack().Peek(0).Item().Type())
+		assertResult(t, v, []byte{42})
+	})
+	t.Run("allows mutable struct field assignment", func(t *testing.T) {
+		src := `package foo
+			type value struct {
+				data []byte
+			}
+			func Main() int {
+				var item any = value{data: []byte{42}}
+				v := item.(value)
+				v.data[0]++
+				return int(v.data[0])
+			}`
+
+		eval(t, src, big.NewInt(43))
+	})
 }
 
 func TestTypeAssertionWithOK(t *testing.T) {

--- a/pkg/compiler/interop_test.go
+++ b/pkg/compiler/interop_test.go
@@ -800,6 +800,39 @@ func Main() int {
 	c.Invoke(t, big.NewInt(3), "main")
 }
 
+// TestStorageIterator_ValueMutableFields checks that byte-slice fields of a
+// type-asserted storage key-value pair can be mutated.
+func TestStorageIterator_ValueMutableFields(t *testing.T) {
+	bc, acc := chain.NewSingle(t)
+	e := neotest.NewExecutor(t, bc, acc, acc)
+
+	src := `package foo
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/interop/iterator"
+	"github.com/nspcc-dev/neo-go/pkg/interop/storage"
+)
+
+func Main() int {
+	ctx := storage.GetContext()
+	storage.Put(ctx, []byte{1}, []byte{1})
+
+	it := storage.Find(ctx, []byte{}, storage.None)
+	if !iterator.Next(it) {
+		return -1
+	}
+	kv := iterator.Value(it).(storage.KeyValue)
+	kv.Value[0]++
+	return int(kv.Value[0])
+}
+`
+	ctr := neotest.CompileSource(t, e.CommitteeHash, strings.NewReader(src), &compiler.Options{Name: "MutableKVIter"})
+	e.DeployContract(t, ctr, nil)
+	c := e.CommitteeInvoker(ctr.Hash)
+
+	c.Invoke(t, big.NewInt(2), "main")
+}
+
 func TestStdLib_DeserializeToPtrToStructure(t *testing.T) {
 	a := "NQRLhCpAru9BjGsMwk67vdMwmzKMRgsnnN"
 	bc, acc := chain.NewSingle(t)
@@ -844,8 +877,8 @@ func PutUserKey(idKey []byte, addr interop.Hash160, data []byte, role int) {
 	require.NoError(t, err)
 	c.Invoke(t, nil, "putUserKey", []byte("user-key"), h.BytesBE(), []byte("user-data"), 42)
 	c.Invoke(t, stackitem.NewStruct([]stackitem.Item{
-		stackitem.Make(h),
-		stackitem.Make([]byte("user-data")),
+		stackitem.NewBuffer(h.BytesBE()),
+		stackitem.NewBuffer([]byte("user-data")),
 		stackitem.Make(42),
 	}), "getUserKey", []byte("user-key"))
 	c.Invoke(t, nil, "getUserKey", []byte("unknown-key"))

--- a/pkg/core/native/native_test/policy_test.go
+++ b/pkg/core/native/native_test/policy_test.go
@@ -733,13 +733,13 @@ func TestPolicy_WhitelistContractsInteropAPI(t *testing.T) {
 	ctrInvoker.Invoke(t, stackitem.Null{}, "setWhitelistFeeContract", nativehashes.StdLib, "hexDecode", 1, 0)
 	ctrInvoker.Invoke(t, stackitem.Make([]stackitem.Item{
 		stackitem.NewStruct([]stackitem.Item{
-			stackitem.Make(nativehashes.StdLib),
+			stackitem.NewBuffer(nativehashes.StdLib.BytesBE()),
 			stackitem.Make("hexDecode"),
 			stackitem.Make(1),
 			stackitem.Make(0),
 		}),
 		stackitem.NewStruct([]stackitem.Item{
-			stackitem.Make(nativehashes.StdLib),
+			stackitem.NewBuffer(nativehashes.StdLib.BytesBE()),
 			stackitem.Make("hexEncode"),
 			stackitem.Make(1),
 			stackitem.Make(0),
@@ -748,7 +748,7 @@ func TestPolicy_WhitelistContractsInteropAPI(t *testing.T) {
 	ctrInvoker.Invoke(t, stackitem.Null{}, "removeWhitelistFeeContract", nativehashes.StdLib, "hexEncode", 1)
 	ctrInvoker.Invoke(t, stackitem.Make([]stackitem.Item{
 		stackitem.NewStruct([]stackitem.Item{
-			stackitem.Make(nativehashes.StdLib),
+			stackitem.NewBuffer(nativehashes.StdLib.BytesBE()),
 			stackitem.Make("hexDecode"),
 			stackitem.Make(1),
 			stackitem.Make(0),


### PR DESCRIPTION
### Problem

Byte-slice fields loaded from a struct assertion can still be represented as a VM `ByteString`. Assigning through an index such as `value.Key[0] = x` then faults at `SETITEM`, even though the Go field type is `[]byte`.

Fixes #3610.

### Solution

Convert `[]byte` fields to mutable VM `Buffer` values when the containing value is asserted to a struct type. This performs the type guarantee at the assertion/conversion seam, rather than adding work to every indexed store. Other field types and ordinary stores keep their existing code generation.

Regression coverage uses the real `storage.Find` / `iterator.Value` path from #3610: it type-asserts the returned `any` to `storage.KeyValue` and mutates a `[]byte` field. The existing deserialize-to-struct test also pins the resulting mutable field representation.

### Validation

- `go test ./pkg/compiler -count=1`
- `go vet ./pkg/compiler`
- `gofmt` and `git diff --check`

### AI assistance

OpenAI Codex was used to investigate the issue, implement the fix, and add tests. The resulting diff was checked with the validation listed above.