### PR TITLE
Fix a pair of C# VM diffs

### DIFF
--- a/pkg/vm/stack_test.go
+++ b/pkg/vm/stack_test.go
@@ -280,6 +280,8 @@ func TestSwapElemValues(t *testing.T) {
 func TestRoll(t *testing.T) {
 	s := NewStack("test")
 
+	assert.ErrorContains(t, s.Roll(0), "too big index")
+
 	s.PushVal(1)
 	s.PushVal(2)
 	s.PushVal(3)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -779,7 +779,11 @@ func (v *VM) execute(ctx *Context, op opcode.Opcode, parameter []byte) (err erro
 
 	case opcode.ISTYPE:
 		res := v.estack.Pop().Item()
-		v.estack.PushItem(stackitem.Bool(res.Type() == stackitem.Type(parameter[0])))
+		typ := stackitem.Type(parameter[0])
+		if typ == stackitem.AnyT || !typ.IsValid() {
+			panic(fmt.Sprintf("invalid type: %d", parameter[0]))
+		}
+		v.estack.PushItem(stackitem.Bool(res.Type() == typ))
 
 	case opcode.CONVERT:
 		typ := stackitem.Type(parameter[0])

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -327,6 +327,16 @@ func testISTYPE(t *testing.T, result bool, typ stackitem.Type, item stackitem.It
 }
 
 func TestISTYPE(t *testing.T) {
+	t.Run("Any", func(t *testing.T) {
+		v := load([]byte{byte(opcode.ISTYPE), 0})
+		v.estack.PushVal(1)
+		checkVMFailed(t, v)
+	})
+	t.Run("Invalid", func(t *testing.T) {
+		v := load([]byte{byte(opcode.ISTYPE), 0xff})
+		v.estack.PushVal(1)
+		checkVMFailed(t, v)
+	})
 	t.Run("Integer", func(t *testing.T) {
 		testISTYPE(t, true, stackitem.IntegerT, stackitem.NewBigInteger(big.NewInt(42)))
 		testISTYPE(t, false, stackitem.IntegerT, stackitem.NewByteArray([]byte{}))


### PR DESCRIPTION
Edge cases in ISTYPE and ROLL handlers, one of them can lead to state difference.