### PR TITLE
core: fix StdLib's deserializeJSON

### DIFF
--- a/pkg/core/native/native_test/std_test.go
+++ b/pkg/core/native/native_test/std_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/neotest"
 	"github.com/nspcc-dev/neo-go/pkg/neotest/chain"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStd_HexEncodeDecodeCompat(t *testing.T) {
@@ -73,4 +74,39 @@ func TestStd_Itoa_Culture(t *testing.T) {
 	p := e.CommitteeInvoker(nativehashes.StdLib)
 
 	p.Invoke(t, stackitem.NewByteArray([]byte("-1")), "itoa", big.NewInt(-1))
+}
+
+// Data taken from https://github.com/nspcc-dev/neo-go/issues/4381.
+func TestStd_JSONDeserializeCompat(t *testing.T) {
+	bc, acc := chain.NewSingleWithCustomConfig(t, func(c *config.Blockchain) {
+		c.Hardforks = map[string]uint32{
+			config.HFBasilisk.String(): 0, // enable explicitly to test post-Basilisk behaviour.
+		}
+	})
+	e := neotest.NewExecutor(t, bc, acc, acc)
+	std := e.CommitteeInvoker(nativehashes.StdLib)
+
+	std.InvokeAndCheck(t, func(t testing.TB, stack []stackitem.Item) {
+		require.Equal(t, "43893649166666670000000000000000000", stack[0].Value().(*big.Int).String())
+	}, "jsonDeserialize", stackitem.Make("4.389364916666667e+34"))
+
+	std.InvokeAndCheck(t, func(t testing.TB, stack []stackitem.Item) {
+		require.Equal(t, "2221811666666666600000", stack[0].Value().(*big.Int).String())
+	}, "jsonDeserialize", stackitem.Make("2.2218116666666666e+21"))
+
+	std.InvokeAndCheck(t, func(t testing.TB, stack []stackitem.Item) {
+		require.Equal(t, "11039175000000000000", stack[0].Value().(*big.Int).String())
+	}, "jsonDeserialize", stackitem.Make("11039175000000000000"))
+
+	std.InvokeAndCheck(t, func(t testing.TB, stack []stackitem.Item) {
+		require.Equal(t, "90719925474099300000000000000000000", stack[0].Value().(*big.Int).String())
+	}, "jsonDeserialize", stackitem.Make("9.07199254740993e+34"))
+
+	std.InvokeAndCheck(t, func(t testing.TB, stack []stackitem.Item) {
+		require.Equal(t, "90071992547409940000000000000000000", stack[0].Value().(*big.Int).String())
+	}, "jsonDeserialize", stackitem.Make("9.007199254740993e+34"))
+
+	std.InvokeAndCheck(t, func(t testing.TB, stack []stackitem.Item) {
+		require.Equal(t, "90071992547409930000000000000000000000000000000000", stack[0].Value().(*big.Int).String())
+	}, "jsonDeserialize", stackitem.Make("9007199254740993e+34"))
 }

--- a/pkg/core/native/std.go
+++ b/pkg/core/native/std.go
@@ -230,7 +230,7 @@ func (s *Std) jsonDeserialize(ic *interop.Context, args []stackitem.Item) stacki
 		panic(err)
 	}
 
-	item, err := stackitem.FromJSON(data, stackitem.MaxDeserialized, false)
+	item, err := stackitem.FromJSON(data, stackitem.MaxDeserialized, ic.IsHardforkEnabled(config.HFBasilisk))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/vm/stackitem/json.go
+++ b/pkg/vm/stackitem/json.go
@@ -234,10 +234,12 @@ func (d *decoder) decode() (Item, error) {
 		return NewByteArray([]byte(t)), nil
 	case json.Number:
 		ts := t.String()
-		var (
-			num  *big.Int
-			prec uint = CompatIntegerPrec
-		)
+		var num *big.Int
+		f, _, err := big.ParseFloat(ts, 10, CompatIntegerPrec, big.ToNearestEven)
+		if err != nil {
+			return nil, fmt.Errorf("%w (malformed exp value for int)", ErrInvalidValue)
+		}
+
 		// Int.SetString() is more efficient, but there are special
 		// cases requiring additional care for C# compatibility, that's
 		// why we're going through float first:
@@ -245,11 +247,10 @@ func (d *decoder) decode() (Item, error) {
 		//  * integers with fp notation, like 123.000
 		//  * numbers requiring more than 53 bits of mantissa
 		if d.bestIntPrecision {
-			prec = MaxIntegerPrec
-		}
-		f, _, err := big.ParseFloat(ts, 10, prec, big.ToNearestEven)
-		if err != nil {
-			return nil, fmt.Errorf("%w (malformed exp value for int)", ErrInvalidValue)
+			f, _, err = big.ParseFloat(f.Text('e', -1), 10, MaxIntegerPrec, big.ToNearestEven)
+			if err != nil {
+				return nil, fmt.Errorf("%w (malformed exp value for int)", ErrInvalidValue)
+			}
 		}
 		num = new(big.Int)
 		_, acc := f.Int(num)

--- a/pkg/vm/stackitem/json_test.go
+++ b/pkg/vm/stackitem/json_test.go
@@ -51,9 +51,10 @@ func TestFromToJSON(t *testing.T) {
 		t.Run("Precision 53", func(t *testing.T) {
 			js := `9007199254740993`
 
+			// Both best/compat converters should cut the ending digit to match C# behaviour.
 			itm, err := FromJSON([]byte(js), 1, true)
 			require.NoError(t, err)
-			require.Equal(t, Make(9007199254740993), itm)
+			require.Equal(t, Make(9007199254740992), itm)
 
 			itm, err = FromJSON([]byte(js), 1, false)
 			require.NoError(t, err)


### PR DESCRIPTION
Close #4381.

Draft because I need to verify states and move tests to a suitable place (currently UTs are failing because Basilisk is disabled by default).