### PR TITLE
core: fix deadlock on DB persist

### DIFF
--- a/cli/wallet/candidate_test.go
+++ b/cli/wallet/candidate_test.go
@@ -10,6 +10,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// We don't create a new account here, because chain will
+// stop working after validator will change.
+func TestCreateExecutor(t *testing.T) {
+	var _ = testcli.NewExecutorWithConfig(t, true, false, func(cfg *config.Config) {
+		cfg.ProtocolConfiguration.Hardforks = map[string]uint32{
+			config.HFEchidna.String(): 0,
+		}
+	})
+}
+
 // Register standby validator and vote for it.
 // We don't create a new account here, because chain will
 // stop working after validator will change.

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -1962,9 +1962,20 @@ func (bc *Blockchain) GetStateSyncModule() *statesync.Module {
 // transactions with all appropriate side-effects and updates Blockchain state.
 // This is the only way to change Blockchain state.
 func (bc *Blockchain) storeBlock(block *block.Block, txpool *mempool.Pool) error {
+	fmt.Printf("\nstoreBlock #%d:\n", block.Index)
+	fmt.Println("storeBlock: allocating cache")
 	var (
-		cache          = bc.dao.GetPrivate()
-		aerCache       = bc.dao.GetPrivate()
+		cache = bc.dao.GetPrivate(true)
+	)
+	fmt.Println("storeBlock: allocating AER cache")
+	var (
+		aerCache = bc.dao.GetPrivate(true)
+	)
+	fmt.Printf("storeBlock #%d: start processing\n", block.Index)
+	defer func() {
+		fmt.Printf("storeBlock #%d: end processing\n\n", block.Index)
+	}()
+	var (
 		appExecResults = make([]*state.AppExecResult, 0, 2+len(block.Transactions))
 		aerchan        = make(chan *state.AppExecResult, len(block.Transactions)/8) // Tested 8 and 4 with no practical difference, but feel free to test more and tune.
 		aerdone        = make(chan error)
@@ -2085,6 +2096,10 @@ func (bc *Blockchain) storeBlock(block *block.Block, txpool *mempool.Pool) error
 	appExecResults = append(appExecResults, aer)
 	aerchan <- aer
 	close(aerchan)
+
+	cache.Store.Finalize()
+	aerCache.Store.Finalize()
+
 	b := mpt.MapToMPTBatch(cache.Store.GetStorageChanges())
 	mpt, sr, err := bc.stateRoot.AddMPTBatch(block.Index, b, cache.Store)
 	if err != nil {

--- a/pkg/core/blockchain.go
+++ b/pkg/core/blockchain.go
@@ -2502,19 +2502,19 @@ func (bc *Blockchain) persist() (time.Duration, error) {
 
 	persisted, err = bc.dao.Persist()
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to persist dao: %w", err)
 	}
 	if persisted > 0 {
 		bHeight, err := bc.persistent.GetCurrentBlockHeight()
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("failed to get current block height: %w", err)
 		}
 		oldHeight := atomic.SwapUint32(&bc.persistedHeight, bHeight)
 		diff := bHeight - oldHeight
 
 		storedHeaderHeight, _, err := bc.persistent.GetCurrentHeaderHeight()
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("failed to get current header height: %w", err)
 		}
 		duration = time.Since(start)
 		// Low number of keys is not representative and duration _can_

--- a/pkg/core/dao/dao.go
+++ b/pkg/core/dao/dao.go
@@ -102,14 +102,14 @@ func (dao *Simple) GetWrapped() *Simple {
 
 // GetPrivate returns a new DAO instance with another layer of private
 // MemCachedStore around the current DAO Store.
-func (dao *Simple) GetPrivate() *Simple {
+func (dao *Simple) GetPrivate(openReadTx ...bool) *Simple {
 	d := &Simple{
 		Version: dao.Version,
 		keyBuf:  dao.keyBuf,
 		dataBuf: dao.dataBuf,
 		serCtx:  dao.serCtx,
 	} // Inherit everything...
-	d.Store = storage.NewPrivateMemCachedStore(dao.Store) // except storage, wrap another layer.
+	d.Store = storage.NewPrivateMemCachedStore(dao.Store, openReadTx...) // except storage, wrap another layer.
 	d.private = true
 	d.nativeCachePS = dao
 	// Do not inherit cache from nativeCachePS; instead should create clear map:

--- a/pkg/core/interop/context.go
+++ b/pkg/core/interop/context.go
@@ -101,8 +101,9 @@ func NewContext(trigger trigger.Type, bc Ledger, d *dao.Simple, baseExecFee, bas
 	getContract func(*dao.Simple, util.Uint160) (*state.Contract, error), natives []Contract,
 	loadTokenFunc func(ic *Context, id int32) error,
 	block *block.Block, tx *transaction.Transaction, log *zap.Logger) *Context {
+	var startRO = d.Store.View == nil
 	var (
-		dao = d.GetPrivate()
+		dao = d.GetPrivate(startRO)
 		cfg = bc.GetConfig()
 		pch PolicyChecker
 	)

--- a/pkg/core/interop/context.go
+++ b/pkg/core/interop/context.go
@@ -572,6 +572,7 @@ func (ic *Context) Finalize() {
 		f()
 	}
 	ic.cancelFuncs = nil
+	_ = ic.DAO.Store.Finalize() // TODO: need a workaround to avoid finalization error.
 }
 
 // Exec executes loaded VM script and calls registered finalizers to release the occupied resources.

--- a/pkg/core/mpt/trie_store.go
+++ b/pkg/core/mpt/trie_store.go
@@ -34,9 +34,21 @@ func NewTrieStore(root util.Uint256, mode TrieMode, backed storage.Store) *TrieS
 	}
 }
 
-// Get implements the Store interface. It can return [errors.ErrUnsupported]
-// for unsupported operations.
-func (m *TrieStore) Get(key []byte) ([]byte, error) {
+// Seek offers seek functionality over the underlying DB.
+func (m *TrieStore) Seek(rng storage.SeekRange, f func(k, v []byte) bool) {
+	m.SeekWithView(nil, rng, f) // TrieStore itself doesn't hold any iew, it's the lower's Store responsibility.
+}
+
+// BeginView implements the Store interface.
+func (m *TrieStore) BeginView() (storage.IView, error) {
+	// TrieStore is never used as a persistent store, so this code must not be called.
+	panic("bug: not supported")
+}
+
+// GetWithView implements the Store interface. It can return [errors.ErrUnsupported]
+// for unsupported operations. It is not designated for the external usage. Use
+// Get instead.
+func (m *TrieStore) GetWithView(_ storage.IView, key []byte) ([]byte, error) {
 	if len(key) == 0 {
 		return nil, fmt.Errorf("%w: Get is supported only for contract storage items", errors.ErrUnsupported)
 	}
@@ -61,8 +73,8 @@ func (m *TrieStore) PutChangeSet(puts map[string][]byte, stor map[string][]byte)
 	return fmt.Errorf("%w: PutChangeSet is not supported", errors.ErrUnsupported)
 }
 
-// Seek implements the Store interface.
-func (m *TrieStore) Seek(rng storage.SeekRange, f func(k, v []byte) bool) {
+// SeekWithView implements the Store interface.
+func (m *TrieStore) SeekWithView(_ storage.IView, rng storage.SeekRange, f func(k, v []byte) bool) {
 	prefix := storage.KeyPrefix(rng.Prefix[0])
 	if prefix != storage.STStorage && prefix != storage.STTempStorage { // Prefix is always non-empty.
 		panic(fmt.Errorf("%w: Seek is supported only for contract storage items", errors.ErrUnsupported))

--- a/pkg/core/storage/boltdb_store.go
+++ b/pkg/core/storage/boltdb_store.go
@@ -90,14 +90,11 @@ func NewBoltDBStoreFromBucket(db *bbolt.DB, bucket []byte) (*BoltDBStore, error)
 	return &BoltDBStore{db: db, bkt: bucket}, nil
 }
 
-// Get implements the Store interface.
-func (s *BoltDBStore) Get(key []byte) (val []byte, err error) {
-	err = s.db.View(func(tx *bbolt.Tx) error {
-		b := tx.Bucket(s.bkt)
-		// Value from Get is only valid for the lifetime of transaction, #1482
-		val = bytes.Clone(b.Get(key))
-		return nil
-	})
+// GetWithView implements the Store interface.
+func (s *BoltDBStore) GetWithView(tx IView, key []byte) (val []byte, err error) {
+	b := tx.(boltViewAdapter).Bucket(s.bkt)
+	// Value from Get is only valid for the lifetime of transaction, #1482
+	val = bytes.Clone(b.Get(key))
 	if val == nil {
 		err = ErrKeyNotFound
 	}
@@ -139,9 +136,30 @@ func (s *BoltDBStore) SeekGC(rng SeekRange, keepCont func(k, v []byte) (bool, bo
 	})
 }
 
-// Seek implements the Store interface.
-func (s *BoltDBStore) Seek(rng SeekRange, f func(k, v []byte) bool) {
-	err := boltSeek(s.db.View, s.bkt, rng, func(_ *bbolt.Cursor, k, v []byte) (bool, error) {
+// viewAdapter is a wrapper around bbolt transaction implementing IView interface.
+type boltViewAdapter struct {
+	*bbolt.Tx
+}
+
+// Close implements IView interface.
+func (v boltViewAdapter) Close() error {
+	return v.Rollback()
+}
+
+// BeginView implements the Store interface.
+func (s *BoltDBStore) BeginView() (IView, error) {
+	tx, err := s.db.Begin(false)
+	if err != nil {
+		return nil, err
+	}
+	return boltViewAdapter{tx}, nil
+}
+
+// SeekWithView implements the Store interface.
+func (s *BoltDBStore) SeekWithView(view IView, rng SeekRange, f func(k, v []byte) bool) {
+	err := boltSeek(func(f func(*bbolt.Tx) error) error {
+		return f(view.(boltViewAdapter).Tx)
+	}, s.bkt, rng, func(_ *bbolt.Cursor, k, v []byte) (bool, error) {
 		return f(k, v), nil
 	})
 	if err != nil {

--- a/pkg/core/storage/leveldb_store.go
+++ b/pkg/core/storage/leveldb_store.go
@@ -38,9 +38,29 @@ func NewLevelDBStore(cfg dbconfig.LevelDBOptions) (*LevelDBStore, error) {
 	}, nil
 }
 
-// Get implements the Store interface.
-func (s *LevelDBStore) Get(key []byte) ([]byte, error) {
-	value, err := s.db.Get(key, nil)
+// viewAdapter is a wrapper around leveldb transaction implementing IView interface.
+type levelViewAdapter struct {
+	*leveldb.Snapshot
+}
+
+// Close implements IView interface.
+func (v levelViewAdapter) Close() error {
+	v.Snapshot.Release()
+	return nil
+}
+
+// BeginView implements the Store interface.
+func (s *LevelDBStore) BeginView() (IView, error) {
+	sh, err := s.db.GetSnapshot()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get snapshot: %w", err)
+	}
+	return levelViewAdapter{sh}, nil
+}
+
+// GetWithView implements the Store interface.
+func (s *LevelDBStore) GetWithView(view IView, key []byte) ([]byte, error) {
+	value, err := view.(levelViewAdapter).Get(key, nil)
 	if errors.Is(err, leveldb.ErrNotFound) {
 		err = ErrKeyNotFound
 	}
@@ -69,9 +89,9 @@ func (s *LevelDBStore) PutChangeSet(puts map[string][]byte, stores map[string][]
 	return tx.Commit()
 }
 
-// Seek implements the Store interface.
-func (s *LevelDBStore) Seek(rng SeekRange, f func(k, v []byte) bool) {
-	iter := s.db.NewIterator(seekRangeToPrefixes(rng), nil)
+// SeekWithView implements the Store interface.
+func (s *LevelDBStore) SeekWithView(view IView, rng SeekRange, f func(k, v []byte) bool) {
+	iter := view.(levelViewAdapter).NewIterator(seekRangeToPrefixes(rng), nil)
 	s.seek(iter, rng.Backwards, f)
 }
 

--- a/pkg/core/storage/memcached_store.go
+++ b/pkg/core/storage/memcached_store.go
@@ -25,7 +25,8 @@ type MemCachedStore struct {
 	// case if the current instance of MemCachedStore is private. View is opened
 	// during private MemCachedStore construction and is closed once
 	// MemCachedStore is released via
-	View IView
+	View    IView
+	closeTx bool
 }
 
 type (
@@ -61,18 +62,18 @@ func NewMemCachedStore(lower Store) *MemCachedStore {
 // Finalize releases RO DB view occupied by the current private instance of
 // MemCachedStore and, recursively, by its parents (if so).
 func (s *MemCachedStore) Finalize() error {
-	if s.private {
-		if lower, ok := s.ps.(*MemCachedStore); ok && lower.View != nil {
+	if s.private && s.closeTx {
+		/*if lower, ok := s.ps.(*MemCachedStore); ok && lower.View != nil {
 			err := lower.Finalize()
 			if err != nil {
 				return fmt.Errorf("failed to finalize parent's store: %w", err)
 			}
-		} else {
-			err := s.View.Close()
-			if err != nil {
-				return fmt.Errorf("failed to close DB view: %w", err)
-			}
+		} else {*/
+		err := s.View.Close()
+		if err != nil {
+			return fmt.Errorf("failed to close DB view: %w", err)
 		}
+		//}
 		s.View = nil
 	}
 
@@ -81,23 +82,33 @@ func (s *MemCachedStore) Finalize() error {
 
 // NewPrivateMemCachedStore creates a new private (unlocked) MemCachedStore object.
 // Private cached stores are closed after Persist.
-func NewPrivateMemCachedStore(lower Store) *MemCachedStore {
-	var view IView
+func NewPrivateMemCachedStore(lower Store, openReadTx ...bool) *MemCachedStore {
+	var (
+		view    IView
+		closeTx bool
+	)
 	if cache, ok := lower.(*MemCachedStore); ok && cache.View != nil {
 		view = cache.View
-	} else {
+	}
+	if len(openReadTx) > 0 && openReadTx[0] {
 		var err error
+		fmt.Println("BeginView: NewPrivateMemCachedStore")
 		view, err = lower.BeginView()
 		if err != nil {
-			panic(fmt.Errorf("failed to initialize read transaction: %w", err))
+			panic(fmt.Errorf("failed to initialize read transaction to lower persistent storage: %w", err))
 		}
-	}
-
+		closeTx = true
+	} /*
+		if view == nil {
+			panic("bug: nil view")
+		}
+	*/
 	return &MemCachedStore{
 		MemoryStore: *NewMemoryStore(),
 		private:     true,
 		ps:          lower,
 		View:        view,
+		closeTx:     closeTx,
 	}
 }
 
@@ -131,6 +142,7 @@ func (s *MemCachedStore) runlock() {
 
 // BeginView implements the Store interface.
 func (s *MemCachedStore) BeginView() (IView, error) {
+	fmt.Println("BeginView: (s *MemCachedStore) BeginView()")
 	return s.ps.BeginView()
 }
 
@@ -141,6 +153,7 @@ func (s *MemCachedStore) Get(key []byte) ([]byte, error) {
 		err  error
 	)
 	if !s.private {
+		fmt.Println("BeginView: (s *MemCachedStore) Get")
 		view, err = s.ps.BeginView()
 		if err != nil {
 			return nil, err
@@ -191,6 +204,7 @@ func (s *MemCachedStore) GetBatch() *MemBatch {
 		err  error
 	)
 	if !s.private {
+		fmt.Println("BeginView: (s *MemCachedStore) GetBatch()")
 		view, err = s.ps.BeginView()
 		if err != nil {
 			panic(err)
@@ -230,6 +244,7 @@ func (s *MemCachedStore) Seek(rng SeekRange, cont func(k, v []byte) bool) {
 		err  error
 	)
 	if !s.private {
+		fmt.Println("BeginView: (s *MemCachedStore) Seek")
 		view, err = s.ps.BeginView()
 		if err != nil {
 			panic(err)
@@ -266,6 +281,7 @@ func (s *MemCachedStore) SeekAsync(ctx context.Context, rng SeekRange, cutPrefix
 		err  error
 	)
 	if !s.private {
+		fmt.Println("BeginView: (s *MemCachedStore) SeekAsync")
 		view, err = s.ps.BeginView()
 		if err != nil {
 			panic(err)

--- a/pkg/core/storage/memcached_store.go
+++ b/pkg/core/storage/memcached_store.go
@@ -21,6 +21,11 @@ type MemCachedStore struct {
 	plock sync.Mutex
 	// Persistent Store.
 	ps Store
+	// View holds an opened read-only transaction to the persistent Store in
+	// case if the current instance of MemCachedStore is private. View is opened
+	// during private MemCachedStore construction and is closed once
+	// MemCachedStore is released via
+	View IView
 }
 
 type (
@@ -53,13 +58,46 @@ func NewMemCachedStore(lower Store) *MemCachedStore {
 	}
 }
 
+// Finalize releases RO DB view occupied by the current private instance of
+// MemCachedStore and, recursively, by its parents (if so).
+func (s *MemCachedStore) Finalize() error {
+	if s.private {
+		if lower, ok := s.ps.(*MemCachedStore); ok && lower.View != nil {
+			err := lower.Finalize()
+			if err != nil {
+				return fmt.Errorf("failed to finalize parent's store: %w", err)
+			}
+		} else {
+			err := s.View.Close()
+			if err != nil {
+				return fmt.Errorf("failed to close DB view: %w", err)
+			}
+		}
+		s.View = nil
+	}
+
+	return nil
+}
+
 // NewPrivateMemCachedStore creates a new private (unlocked) MemCachedStore object.
 // Private cached stores are closed after Persist.
 func NewPrivateMemCachedStore(lower Store) *MemCachedStore {
+	var view IView
+	if cache, ok := lower.(*MemCachedStore); ok && cache.View != nil {
+		view = cache.View
+	} else {
+		var err error
+		view, err = lower.BeginView()
+		if err != nil {
+			panic(fmt.Errorf("failed to initialize read transaction: %w", err))
+		}
+	}
+
 	return &MemCachedStore{
 		MemoryStore: *NewMemoryStore(),
 		private:     true,
 		ps:          lower,
+		View:        view,
 	}
 }
 
@@ -91,8 +129,30 @@ func (s *MemCachedStore) runlock() {
 	}
 }
 
-// Get implements the Store interface.
+// BeginView implements the Store interface.
+func (s *MemCachedStore) BeginView() (IView, error) {
+	return s.ps.BeginView()
+}
+
+// Get offers get functionality over underlying DB.
 func (s *MemCachedStore) Get(key []byte) ([]byte, error) {
+	var (
+		view = s.View
+		err  error
+	)
+	if !s.private {
+		view, err = s.ps.BeginView()
+		if err != nil {
+			return nil, err
+		}
+		defer view.Close()
+	}
+	return s.GetWithView(view, key)
+}
+
+// GetWithView implements the Store interface. It is not designated for the
+// external usage. Use Get instead.
+func (s *MemCachedStore) GetWithView(view IView, key []byte) ([]byte, error) {
 	s.rlock()
 	defer s.runlock()
 	m := s.chooseMap(key)
@@ -102,7 +162,7 @@ func (s *MemCachedStore) Get(key []byte) ([]byte, error) {
 		}
 		return val, nil
 	}
-	return s.ps.Get(key)
+	return s.ps.GetWithView(view, key)
 }
 
 // Put puts new KV pair into the store.
@@ -126,6 +186,17 @@ func (s *MemCachedStore) Delete(key []byte) {
 func (s *MemCachedStore) GetBatch() *MemBatch {
 	s.rlock()
 	defer s.runlock()
+	var (
+		view = s.View
+		err  error
+	)
+	if !s.private {
+		view, err = s.ps.BeginView()
+		if err != nil {
+			panic(err)
+		}
+		defer view.Close()
+	}
 	var b MemBatch
 
 	b.Put = make([]KeyValueExists, 0, len(s.mem)+len(s.stor))
@@ -133,7 +204,7 @@ func (s *MemCachedStore) GetBatch() *MemBatch {
 	for _, m := range []map[string][]byte{s.mem, s.stor} {
 		for k, v := range m {
 			key := []byte(k)
-			_, err := s.ps.Get(key)
+			_, err := s.ps.GetWithView(view, key)
 			if v == nil {
 				b.Deleted = append(b.Deleted, KeyValueExists{KeyValue: KeyValue{Key: key}, Exists: err == nil})
 			} else {
@@ -152,10 +223,27 @@ func (s *MemCachedStore) PutChangeSet(puts map[string][]byte, stores map[string]
 	return nil
 }
 
-// Seek implements the Store interface.
+// Seek offers the DB seek functionality. See Store comments for behaviour details.
 func (s *MemCachedStore) Seek(rng SeekRange, cont func(k, v []byte) bool) {
+	var (
+		view = s.View
+		err  error
+	)
+	if !s.private {
+		view, err = s.ps.BeginView()
+		if err != nil {
+			panic(err)
+		}
+		defer view.Close()
+	}
+	s.SeekWithView(view, rng, cont)
+}
+
+// SeekWithView implements the Store interface. It is not designated for the
+// external usage. Use Seek instead.
+func (s *MemCachedStore) SeekWithView(view IView, rng SeekRange, cont func(k, v []byte) bool) {
 	ps, memRes := s.prepareSeekMemSnapshot(rng)
-	performSeek(context.Background(), ps, memRes, rng, false, cont)
+	performSeek(context.Background(), view, ps, memRes, rng, false, cont)
 }
 
 // GetStorageChanges returns all current storage changes. It can only be done for private
@@ -173,8 +261,21 @@ func (s *MemCachedStore) GetStorageChanges() map[string][]byte {
 func (s *MemCachedStore) SeekAsync(ctx context.Context, rng SeekRange, cutPrefix bool) chan KeyValue {
 	res := make(chan KeyValue)
 	ps, memRes := s.prepareSeekMemSnapshot(rng)
+	var (
+		view = s.View
+		err  error
+	)
+	if !s.private {
+		view, err = s.ps.BeginView()
+		if err != nil {
+			panic(err)
+		}
+	}
 	go func() {
-		performSeek(ctx, ps, memRes, rng, cutPrefix, func(k, v []byte) bool {
+		if !s.private {
+			defer view.Close()
+		}
+		performSeek(ctx, view, ps, memRes, rng, cutPrefix, func(k, v []byte) bool {
 			select {
 			case <-ctx.Done():
 				return false
@@ -231,7 +332,7 @@ func (s *MemCachedStore) prepareSeekMemSnapshot(rng SeekRange) (Store, []KeyValu
 // `cutPrefix` denotes whether provided key needs to be cut off the resulting keys.
 // `rng` specifies prefix items must match and point to start seeking from. Backwards
 // seeking from some point is supported with corresponding `rng` field set.
-func performSeek(ctx context.Context, ps Store, memRes []KeyValueExists, rng SeekRange, cutPrefix bool, cont func(k, v []byte) bool) {
+func performSeek(ctx context.Context, view IView, ps Store, memRes []KeyValueExists, rng SeekRange, cutPrefix bool, cont func(k, v []byte) bool) {
 	lPrefix := len(string(rng.Prefix))
 	var cmpFunc = getCmpFunc(rng.Backwards)
 
@@ -304,7 +405,7 @@ func performSeek(ctx context.Context, ps Store, memRes []KeyValueExists, rng See
 		if rng.SearchDepth > 1 {
 			rng.SearchDepth--
 		}
-		ps.Seek(rng, mergeFunc)
+		ps.SeekWithView(view, rng, mergeFunc)
 	}
 
 	if !done && haveMem {

--- a/pkg/core/storage/memory_store.go
+++ b/pkg/core/storage/memory_store.go
@@ -25,8 +25,13 @@ func NewMemoryStore() *MemoryStore {
 	}
 }
 
-// Get implements the Store interface.
-func (s *MemoryStore) Get(key []byte) ([]byte, error) {
+// BeginView implements the Store interface.
+func (s *MemoryStore) BeginView() (IView, error) {
+	panic("bug: not supported")
+}
+
+// GetWithView implements the Store interface.
+func (s *MemoryStore) GetWithView(view IView, key []byte) ([]byte, error) {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
 	m := s.chooseMap(key)
@@ -71,8 +76,8 @@ func (s *MemoryStore) Len() int {
 	return len(s.mem) + len(s.stor)
 }
 
-// Seek implements the Store interface.
-func (s *MemoryStore) Seek(rng SeekRange, f func(k, v []byte) bool) {
+// SeekWithView implements the Store interface.
+func (s *MemoryStore) SeekWithView(view IView, rng SeekRange, f func(k, v []byte) bool) {
 	s.seek(rng, f, s.mut.RLock, s.mut.RUnlock)
 }
 

--- a/pkg/core/storage/memory_store.go
+++ b/pkg/core/storage/memory_store.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"cmp"
+	"fmt"
 	"maps"
 	"slices"
 	"strings"
@@ -25,15 +26,38 @@ func NewMemoryStore() *MemoryStore {
 	}
 }
 
+// memoryViewAdapter is a wrapper around MemoryStore mutex emulating read
+// transactions to MemoryStore (if used as a persistent storage) and
+// implementing IView interface.
+type memoryViewAdapter struct {
+	finalize func()
+}
+
+// Close implements IView interface.
+func (m memoryViewAdapter) Close() error {
+	fmt.Println("CLOSING VIEW")
+	m.finalize()
+	fmt.Println("VIEW CLOSED")
+	return nil
+}
+
 // BeginView implements the Store interface.
 func (s *MemoryStore) BeginView() (IView, error) {
-	panic("bug: not supported")
+	fmt.Println("BEGIN VIEW")
+	s.mut.RLock()
+	return memoryViewAdapter{
+		finalize: func() {
+			s.mut.RUnlock()
+		},
+	}, nil
 }
 
 // GetWithView implements the Store interface.
 func (s *MemoryStore) GetWithView(view IView, key []byte) ([]byte, error) {
-	s.mut.RLock()
-	defer s.mut.RUnlock()
+	if view == nil {
+		s.mut.RLock()
+		defer s.mut.RUnlock()
+	}
 	m := s.chooseMap(key)
 	if val, ok := m[string(key)]; ok && val != nil {
 		return val, nil
@@ -78,7 +102,15 @@ func (s *MemoryStore) Len() int {
 
 // SeekWithView implements the Store interface.
 func (s *MemoryStore) SeekWithView(view IView, rng SeekRange, f func(k, v []byte) bool) {
-	s.seek(rng, f, s.mut.RLock, s.mut.RUnlock)
+	s.seek(rng, f, func() {
+		if view == nil {
+			s.mut.RLock()
+		}
+	}, func() {
+		if view == nil {
+			s.mut.RUnlock()
+		}
+	})
 }
 
 // SeekGC implements the Store interface.

--- a/pkg/core/storage/store.go
+++ b/pkg/core/storage/store.go
@@ -80,19 +80,30 @@ type SeekRange struct {
 // when a certain key is not found.
 var ErrKeyNotFound = errors.New("key not found")
 
+// IView represents a read-only transaction to the underlying DB.
+type IView interface {
+	// Close closes the transaction.
+	Close() error
+}
+
 type (
 	// Store is the underlying KV backend for the blockchain data, it's
 	// not intended to be used directly, you wrap it with some memory cache
 	// layer most of the time.
 	Store interface {
-		Get([]byte) ([]byte, error)
+		// BeginView opens a read-only transaction to the underlying DB. It
+		// holds read lock on the DB for the transaction lifetime. It's the
+		// caller's responsibility to close the view once done via IView.Close.
+		BeginView() (IView, error)
+		GetWithView(view IView, k []byte) ([]byte, error)
 		// PutChangeSet allows to push prepared changeset to the Store.
 		PutChangeSet(puts map[string][]byte, stor map[string][]byte) error
-		// Seek can guarantee that provided key (k) and value (v) are the only valid until the next call to f.
-		// Seek continues iteration until false is returned from f.
-		// Key and value slices should not be modified.
-		// Seek can guarantee that key-value items are sorted by key in ascending way.
-		Seek(rng SeekRange, f func(k, v []byte) bool)
+		// SeekWithView can guarantee that provided key (k) and value (v) are
+		// the only valid until the next call to f. Seek continues iteration
+		// until false is returned from f. Key and value slices should not be
+		// modified. Seek can guarantee that key-value items are sorted by key
+		// in an ascending way.
+		SeekWithView(view IView, rng SeekRange, f func(k, v []byte) bool)
 		// SeekGC is similar to Seek, but the function should return true if current
 		// KV pair should be kept and false if it's to be deleted; the second return
 		// value denotes whether to continue iteration. SeekGC only works with the


### PR DESCRIPTION
Close #4397.

Doesn't work yet. TODO:

- [x] Fix the design to avoid `2026-08-28T13:13:00.983Z	ERROR	failed to persist blockchain	{"error": "failed to get current block height: key not found"}` problem.
- [ ] Support MemoryStore read transactions. 
- [X] Implement view functionality over MPT storage.
- [ ] Test.
- [ ] Benchmark.