### PR TITLE
network: use explicit nanosecond sleeps in rebroadcast test

### DIFF
--- a/pkg/network/extpool/pool_test.go
+++ b/pkg/network/extpool/pool_test.go
@@ -179,7 +179,7 @@ func TestRebroadcast(t *testing.T) {
 				check(t)
 
 				// Wait 1ns more, timer should fire.
-				time.Sleep(1) //nolint:staticcheck
+				time.Sleep(time.Nanosecond)
 				synctest.Wait()
 				expected = append(expected, ep1.Hash())
 				check(t)
@@ -192,7 +192,7 @@ func TestRebroadcast(t *testing.T) {
 			ep2 := &payload.Extensible{ValidBlockEnd: 101, Category: payload.ConsensusCategory}
 			p.testAdd(t, true, nil, ep2)
 			// Sleeping the rest of 1ns won't trigger the timer since it was reset.
-			time.Sleep(1) //nolint:staticcheck
+			time.Sleep(time.Nanosecond)
 			synctest.Wait()
 			check(t)
 


### PR DESCRIPTION
### Problem

TestRebroadcast passes the untyped literal 1 to time.Sleep and suppresses staticcheck even though the test specifically advances simulated time by one nanosecond.

### Solution

Use time.Nanosecond at both boundaries. This documents the intended duration and removes the lint suppressions without changing timing behavior.